### PR TITLE
set default memo for invoice

### DIFF
--- a/src/extension/background-script/actions/ln/makeInvoice.js
+++ b/src/extension/background-script/actions/ln/makeInvoice.js
@@ -2,6 +2,9 @@ import PubSub from "pubsub-js";
 import state from "../../state";
 
 const makeInvoice = async (message, sender) => {
+  if (message.args.memo === undefined) {
+    message.args.memo = "Alby invoice memo";
+  }
   PubSub.publish(`ln.makeInvoice.start`, message);
 
   const connector = state.getState().getConnector();


### PR DESCRIPTION
This PR fixes an error when a service creates an invoice with no memo field, for instance via WebLN: `var payreq = await webln.makeInvoice(parseInt(amount));`.
As per WebLN spec, memo field is optional but backends like lnbits require a memo.