### PR TITLE
Limit PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - master
     tags:
       - v*
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
@@ -17,7 +17,8 @@ jobs:
       FAUCET_K: ${{ secrets.FAUCET_K }}
 
     name: build-prod
-
+    if: "github.ref == 'refs/heads/master' || contains( github.event.pull_request.labels.*.name, 'ready-to-test')"
+    
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -49,8 +50,10 @@ jobs:
           path: dist/production/opera.crx
 
   release-firefox-nightly:
+    if: "github.ref == 'refs/heads/master' || contains( github.event.pull_request.labels.*.name, 'ready-to-test')"
     runs-on: ubuntu-latest
     needs: build
+    
     env:
       FILE: 'firefox.xpi'
       AWS_REGION: 'eu-central-1'
@@ -71,6 +74,7 @@ jobs:
           args: --acl public-read --content-type application/x-xpinstall
 
   release-chrome-nightly:
+    if: "github.ref == 'refs/heads/master' || contains( github.event.pull_request.labels.*.name, 'ready-to-test')"
     runs-on: ubuntu-latest
     needs: build
     env:
@@ -93,6 +97,7 @@ jobs:
           args: --acl public-read
 
   release-opera-nightly:
+    if: "github.ref == 'refs/heads/master' || contains( github.event.pull_request.labels.*.name, 'ready-to-test')"
     runs-on: ubuntu-latest
     needs: build
     env:
@@ -115,10 +120,10 @@ jobs:
           args: --acl public-read
 
   comment-build-links:
+    if: "contains( github.event.pull_request.labels.*.name, 'ready-to-test')"
     runs-on: ubuntu-latest
     needs: [build, release-firefox-nightly, release-chrome-nightly, release-opera-nightly]
     name: comment-release-links
-    if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - name: Find Comment


### PR DESCRIPTION
This runs the builds on master branches and if the PR has a certain label.
PR runs now also get access to the secrets and full repo access (event: pull_request_target).
To limit this use we now require PRs to have a certain label (which can only be added from maintainers)