### PR TITLE
[Proposal] Use messaging to get lightning data

### DIFF
--- a/src/app/screens/Home/index.jsx
+++ b/src/app/screens/Home/index.jsx
@@ -38,7 +38,9 @@ class Home extends React.Component {
       browser.tabs
         .sendMessage(tabs[0].id, { type: "lightningData" })
         .then((data) => {
-          this.setState({ lnData: data });
+          if (data) {
+            this.setState({ lnData: data });
+          }
         });
     });
   }

--- a/src/app/screens/Home/index.jsx
+++ b/src/app/screens/Home/index.jsx
@@ -34,21 +34,11 @@ class Home extends React.Component {
 
   loadLightningDataFromCurrentWebsite() {
     // Enhancement data is loaded asynchronously (for example because we need to fetch additional data).
-    // Sadly we can not get return values from async code through executeScript()
-    // To work around this we write the enhancement data into a variable in the content script and access that variable here.
-    // Due to the async execution the variable could potentially not yet be loaded
     browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
-      const [currentTab] = tabs;
       browser.tabs
-        .executeScript(currentTab.id, {
-          code: "window.LBE_LIGHTNING_DATA;",
-        })
+        .sendMessage(tabs[0].id, { type: "lightningData" })
         .then((data) => {
-          // data is an array, see: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript#return_value
-          // we execute it only in the current Tab. Thus the array has only one entry
-          if (data[0]) {
-            this.setState({ lnData: data[0] });
-          }
+          this.setState({ lnData: data });
         });
     });
   }

--- a/src/extension/background-script/actions/allowances/enable.js
+++ b/src/extension/background-script/actions/allowances/enable.js
@@ -1,6 +1,6 @@
-import state from "../../state";
 import db from "../../db";
 import utils from "../../../../common/lib/utils";
+import setIcon from "../setup/setIcon";
 
 const enable = async (message, sender) => {
   const host = message.origin.host || message.args.host;
@@ -10,13 +10,17 @@ const enable = async (message, sender) => {
     .first();
 
   if (allowance && allowance.enabled) {
+    setIcon({ args: { icon: "active" } }, sender); // highlight the icon when enabled
     return {
       data: { enabled: true },
     };
   } else {
     try {
       const response = await utils.openPrompt(message);
-      // if the response should be saved/rememberd we update the allowance for the domain
+      if (response.data.enabled) {
+        setIcon({ args: { icon: "active" } }, sender); // highlight the icon when enabled
+      }
+      // if the response should be saved/remembered we update the allowance for the domain
       // as this returns a promise we must wait until it resolves
       if (response.data.enabled && response.data.remember) {
         if (allowance) {

--- a/src/extension/background-script/actions/setup/setIcon.js
+++ b/src/extension/background-script/actions/setup/setIcon.js
@@ -1,3 +1,5 @@
+import browser from "webextension-polyfill";
+
 const setIcon = async (message, sender) => {
   // TODO: refactor names / rename files?
   const names = {

--- a/src/extension/background-script/index.js
+++ b/src/extension/background-script/index.js
@@ -102,6 +102,15 @@ async function init() {
 
   // TODO: make optional
   browser.tabs.onUpdated.addListener(updateIcon); // update Icon when there is an allowance
+
+  // Notify the content script that the tab has been updated.
+  browser.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+    if (changeInfo.status === "complete") {
+      browser.tabs.sendMessage(tabId, {
+        type: "tabUpdated",
+      });
+    }
+  });
 }
 
 // The onInstalled event is fired directly after the code is loaded.

--- a/src/extension/background-script/index.js
+++ b/src/extension/background-script/index.js
@@ -14,15 +14,6 @@ setInterval(() => {
 }, 5000);
 */
 
-const extractLightningDataFromPage = async (tabId, changeInfo, tabInfo) => {
-  if (changeInfo.status !== "complete" || !tabInfo.url?.startsWith("http")) {
-    return;
-  }
-  browser.tabs.executeScript(tabId, {
-    code: "if ((document.location.protocol === 'https:' || document.location.protocol === 'http:') && window.LBE_EXTRACT_LIGHTNING_DATA) { LBE_EXTRACT_LIGHTNING_DATA(); };",
-  });
-};
-
 const updateIcon = async (tabId, changeInfo, tabInfo) => {
   if (changeInfo.status !== "complete" || !tabInfo.url?.startsWith("http")) {
     return;
@@ -110,8 +101,6 @@ async function init() {
   browser.runtime.onMessage.addListener(routeCalls);
 
   // TODO: make optional
-  browser.tabs.onUpdated.addListener(extractLightningDataFromPage); // extract LN data from websites
-
   browser.tabs.onUpdated.addListener(updateIcon); // update Icon when there is an allowance
 }
 

--- a/src/extension/background-script/index.js
+++ b/src/extension/background-script/index.js
@@ -14,6 +14,14 @@ setInterval(() => {
 }, 5000);
 */
 
+const notifyContentScript = (tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete" && tab.url?.startsWith("http")) {
+    browser.tabs.sendMessage(tabId, {
+      type: "tabUpdated",
+    });
+  }
+};
+
 const updateIcon = async (tabId, changeInfo, tabInfo) => {
   if (changeInfo.status !== "complete" || !tabInfo.url?.startsWith("http")) {
     return;
@@ -104,13 +112,7 @@ async function init() {
   browser.tabs.onUpdated.addListener(updateIcon); // update Icon when there is an allowance
 
   // Notify the content script that the tab has been updated.
-  browser.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-    if (changeInfo.status === "complete") {
-      browser.tabs.sendMessage(tabId, {
-        type: "tabUpdated",
-      });
-    }
-  });
+  browser.tabs.onUpdated.addListener(notifyContentScript);
 }
 
 // The onInstalled event is fired directly after the code is loaded.

--- a/src/extension/background-script/index.js
+++ b/src/extension/background-script/index.js
@@ -14,10 +14,10 @@ setInterval(() => {
 }, 5000);
 */
 
-const notifyContentScript = (tabId, changeInfo, tab) => {
+const extractLightningData = (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url?.startsWith("http")) {
     browser.tabs.sendMessage(tabId, {
-      type: "tabUpdated",
+      type: "extractLightningData",
     });
   }
 };
@@ -112,7 +112,7 @@ async function init() {
   browser.tabs.onUpdated.addListener(updateIcon); // update Icon when there is an allowance
 
   // Notify the content script that the tab has been updated.
-  browser.tabs.onUpdated.addListener(notifyContentScript);
+  browser.tabs.onUpdated.addListener(extractLightningData);
 }
 
 // The onInstalled event is fired directly after the code is loaded.

--- a/src/extension/content-script/batteries/Monetization.ts
+++ b/src/extension/content-script/batteries/Monetization.ts
@@ -1,19 +1,19 @@
 import getOriginData from "../originData";
-import { Battery } from "../../../types";
+import setLightningData from "../setLightningData";
 
 const urlMatcher = /^https?:\/\/.*/i;
 
-const battery = (): Promise<[Battery] | void> => {
+const battery = (): void => {
   const monetizationTag = document.querySelector<HTMLMetaElement>(
-    'head > meta[name="lightning"][content^="lnurlp:" i]'
+    'head > meta[name="lightning"]'
   );
   if (!monetizationTag) {
-    return Promise.resolve();
+    return;
   }
   const recipient = monetizationTag.content.replace(/lnurlp:/i, "");
   const metaData = getOriginData();
 
-  return Promise.resolve([
+  setLightningData([
     {
       method: "lnurlp",
       recipient: recipient,

--- a/src/extension/content-script/batteries/Twitter.ts
+++ b/src/extension/content-script/batteries/Twitter.ts
@@ -1,5 +1,11 @@
 import getOriginData from "../originData";
-import { Battery } from "../../../types";
+import setLightningData from "../setLightningData";
+
+declare global {
+  interface Window {
+    LBE_TWITTER_MUTATION_OBSERVER: MutationObserver;
+  }
+}
 
 const urlMatcher = /^https:\/\/twitter\.com\/(\w+).*/;
 
@@ -61,86 +67,78 @@ function getUserData(username: string) {
   return null;
 }
 
-function battery(): Promise<[Battery] | void> {
+function battery(): void {
   // Twitter loads everything async...so we observe DOM changes to check if data finished loading.
-  let timer: NodeJS.Timeout;
-  const timeout = 1500; // Observing should auto-stop after timeout (when nothing found).
+  function twitterDOMChanged(_: MutationRecord[], observer: MutationObserver) {
+    const username = getUsername();
+    let userData;
+    if ((userData = getUserData(username))) {
+      observer.disconnect();
+      console.log({ userData });
 
-  return new Promise((resolve, reject) => {
-    function twitterDOMChanged(
-      _: MutationRecord[],
-      observer: MutationObserver
-    ) {
-      const username = getUsername();
-      let userData;
-      if ((userData = getUserData(username))) {
-        observer.disconnect();
-        clearTimeout(timer);
-        console.log({ userData });
+      let match;
+      let recipient;
+      // extract lnurlp: from the description text
+      if (
+        (match = (userData.element.textContent || "").match(/lnurlp:(\S+)/i))
+      ) {
+        recipient = match[1];
+      } else {
+        // if we did not find anything let's look for an ⚡ emoji
+        const zapElement = userData.element.querySelector(
+          'img[src*="26a1.svg"]'
+        );
+        // it is hard to find the :zap: emoij. Twitter uses images for that but has an alt text with the emoij
+        // but there could be some control characters somewhere...somehow...no idea...
+        // for that reason we check if there is any character with the zap char code in the alt string.
 
-        let match;
-        let recipient;
-        // extract lnurlp: from the description text
-        if (
-          (match = (userData.element.textContent || "").match(/lnurlp:(\S+)/i))
-        ) {
-          recipient = match[1];
-        } else {
-          // if we did not find anything let's look for an ⚡ emoji
-          const zapElement = userData.element.querySelector(
-            'img[src*="26a1.svg"]'
-          );
-          // it is hard to find the :zap: emoij. Twitter uses images for that but has an alt text with the emoij
-          // but there could be some control characters somewhere...somehow...no idea...
-          // for that reason we check if there is any character with the zap char code in the alt string.
-
-          //const emojis = userData.element.querySelectorAll("img");
-          //const zapElement = Array.from(emojis).find((img) => {
-          //  return Array.from(img.alt.trim()).some(
-          //    (c) => c.charCodeAt(0) === 9889
-          //  );
-          //});
-          // if we find a ⚡ emoji we use the text of the next sibling and try to extract a lnurl
-          if (zapElement) {
-            if (
-              (match = (zapElement.nextSibling?.textContent || "").match(
-                /(\S+@\S+)/
-              ))
-            ) {
-              recipient = match[1];
-            }
+        //const emojis = userData.element.querySelectorAll("img");
+        //const zapElement = Array.from(emojis).find((img) => {
+        //  return Array.from(img.alt.trim()).some(
+        //    (c) => c.charCodeAt(0) === 9889
+        //  );
+        //});
+        // if we find a ⚡ emoji we use the text of the next sibling and try to extract a lnurl
+        if (zapElement) {
+          if (
+            (match = (zapElement.nextSibling?.textContent || "").match(
+              /(\S+@\S+)/
+            ))
+          ) {
+            recipient = match[1];
           }
         }
-
-        // if we still did not find anything ignore it.
-        if (!recipient) {
-          resolve();
-          return;
-        }
-
-        resolve([
-          {
-            method: "lnurl",
-            recipient,
-            ...getOriginData(),
-            icon: userData.imageUrl,
-            name: userData.name,
-          },
-        ]);
       }
+
+      // if we still did not find anything ignore it.
+      if (!recipient) {
+        return;
+      }
+
+      setLightningData([
+        {
+          method: "lnurl",
+          recipient,
+          ...getOriginData(),
+          icon: userData.imageUrl,
+          name: userData.name,
+        },
+      ]);
     }
+  }
 
-    const observer = new MutationObserver(twitterDOMChanged);
-    observer.observe(document, { childList: true, subtree: true });
-    // On slow connections the observer is added after the DOM is fully loaded.
-    // Therefore the callback twitterDOMChanged needs to also be called manually.
-    twitterDOMChanged([], observer);
-
-    timer = setTimeout(() => {
-      observer.disconnect();
-      resolve();
-    }, timeout);
+  if (!window.LBE_TWITTER_MUTATION_OBSERVER) {
+    window.LBE_TWITTER_MUTATION_OBSERVER = new MutationObserver(
+      twitterDOMChanged
+    );
+  }
+  window.LBE_TWITTER_MUTATION_OBSERVER.observe(document, {
+    childList: true,
+    subtree: true,
   });
+  // On slow connections the observer is added after the DOM is fully loaded.
+  // Therefore the callback twitterDOMChanged needs to also be called manually.
+  twitterDOMChanged([], window.LBE_TWITTER_MUTATION_OBSERVER);
 }
 
 const twitter = {

--- a/src/extension/content-script/batteries/YouTubeVideo.ts
+++ b/src/extension/content-script/batteries/YouTubeVideo.ts
@@ -1,13 +1,17 @@
 import getOriginData from "../originData";
-import { Battery } from "../../../types";
+import setLightningData from "../setLightningData";
 
 const urlMatcher = /^https:\/\/www\.youtube.com\/watch.*/;
 
-const battery = (): Promise<[Battery] | void> => {
-  const videoDescription = document.querySelector("#description .content");
-  const channelLink = document.querySelector(".ytd-channel-name a");
+const battery = (): void => {
+  const videoDescription = document.querySelector(
+    "#columns #primary #primary-inner #meta-contents #description .content"
+  );
+  const channelLink = document.querySelector(
+    "#columns #primary #primary-inner #meta-contents .ytd-channel-name a"
+  );
   if (!videoDescription || !channelLink) {
-    return Promise.resolve();
+    return;
   }
   const text = videoDescription.textContent || "";
   let match;
@@ -21,13 +25,15 @@ const battery = (): Promise<[Battery] | void> => {
   else if ((match = text.match(/(⚡️:?|lightning:|lnurl:)(\S+@\S+)/i))) {
     recipient = match[2];
   } else {
-    return Promise.resolve();
+    return;
   }
 
   const name = channelLink.textContent || "";
   const imageUrl =
-    document.querySelector<HTMLImageElement>("#meta-contents img")?.src || "";
-  return Promise.resolve([
+    document.querySelector<HTMLImageElement>(
+      "#columns #primary #primary-inner #meta-contents img"
+    )?.src || "";
+  setLightningData([
     {
       method: "lnurl",
       recipient,

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -4,6 +4,7 @@ import Twitter from "./Twitter";
 import YouTubeVideo from "./YouTubeVideo";
 // import YouTubeChannel from "./YouTubeChannel";
 
+// Order is important as the first one for which the URL matches will be used
 const enhancements = [Twitter, YouTubeVideo, Monetization];
 
 async function extractLightningData() {

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -12,9 +12,9 @@ async function LBE_EXTRACT_LIGHTNING_DATA() {
 
   // get maching extractors/enhancements for the current URL
   // NOTE: this does not mean that data can be found. Because of that we run all possible ones
-  const matching = enhancements.filter((e) => {
-    return document.location.toString().match(e.urlMatcher);
-  });
+  const matching = enhancements.filter((e) =>
+    document.location.toString().match(e.urlMatcher)
+  );
 
   const batteriesRunning = matching.map((enhancement) => {
     return enhancement.battery().then((data) => {

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -1,17 +1,9 @@
 import utils from "../../../common/lib/utils";
-import { Battery } from "../../../types";
 // import GitHubRepo from "./GitHubRepo";
 import Monetization from "./Monetization";
 import Twitter from "./Twitter";
 import YouTubeVideo from "./YouTubeVideo";
 // import YouTubeChannel from "./YouTubeChannel";
-
-declare global {
-  interface Window {
-    LBE_LIGHTNING_DATA: [Battery] | null;
-    LBE_EXTRACT_LIGHTNING_DATA_RUNNING: boolean;
-  }
-}
 
 const enhancements = [Monetization, Twitter, YouTubeVideo];
 

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -16,35 +16,24 @@ declare global {
 const enhancements = [Monetization, Twitter, YouTubeVideo];
 
 async function LBE_EXTRACT_LIGHTNING_DATA() {
-  // prevent the function from being called multiple times
-  // this could happen because the browser.tabs.onUpdated event is fired multiple times
-  if (window["LBE_EXTRACT_LIGHTNING_DATA_RUNNING"]) {
-    return;
-  }
-  // reset potential previous data (e.g. if navigation happens through JS and not a full page load)
-  window.LBE_LIGHTNING_DATA = null;
+  let lightningData = null;
+
   // get maching extractors/enhancements for the current URL
   // NOTE: this does not mean that data can be found. Because of that we run all possible ones
   const matching = enhancements.filter((e) => {
     return document.location.toString().match(e.urlMatcher);
   });
 
-  // Set the running flag. This prevents the function from running multiple times
-  // because of the way web navigation events work the function call could be triggered multiple times
-  // there is no clear event to identify that a user has navigated on the website. we rely on the `browser.tabs.onUpdated` event.
-  window.LBE_EXTRACT_LIGHTNING_DATA_RUNNING = true;
-
   const batteriesRunning = matching.map((enhancement) => {
     return enhancement.battery().then((data) => {
       if (data) {
-        window.LBE_LIGHTNING_DATA = data;
+        lightningData = data;
         utils.call("setIcon", { icon: "active" });
       }
     });
   });
-  // reset lock
+
   await Promise.all(batteriesRunning);
-  window.LBE_EXTRACT_LIGHTNING_DATA_RUNNING = false;
-  return window.LBE_LIGHTNING_DATA;
+  return lightningData;
 }
 export default LBE_EXTRACT_LIGHTNING_DATA;

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -15,7 +15,7 @@ declare global {
 
 const enhancements = [Monetization, Twitter, YouTubeVideo];
 
-function LBE_EXTRACT_LIGHTNING_DATA() {
+async function LBE_EXTRACT_LIGHTNING_DATA() {
   // prevent the function from being called multiple times
   // this could happen because the browser.tabs.onUpdated event is fired multiple times
   if (window["LBE_EXTRACT_LIGHTNING_DATA_RUNNING"]) {
@@ -43,8 +43,8 @@ function LBE_EXTRACT_LIGHTNING_DATA() {
     });
   });
   // reset lock
-  Promise.all(batteriesRunning).then(() => {
-    window.LBE_EXTRACT_LIGHTNING_DATA_RUNNING = false;
-  });
+  await Promise.all(batteriesRunning);
+  window.LBE_EXTRACT_LIGHTNING_DATA_RUNNING = false;
+  return window.LBE_LIGHTNING_DATA;
 }
 export default LBE_EXTRACT_LIGHTNING_DATA;

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -1,31 +1,18 @@
-import utils from "../../../common/lib/utils";
 // import GitHubRepo from "./GitHubRepo";
 import Monetization from "./Monetization";
 import Twitter from "./Twitter";
 import YouTubeVideo from "./YouTubeVideo";
 // import YouTubeChannel from "./YouTubeChannel";
 
-const enhancements = [Monetization, Twitter, YouTubeVideo];
+const enhancements = [Twitter, YouTubeVideo, Monetization];
 
-async function LBE_EXTRACT_LIGHTNING_DATA() {
-  let lightningData = null;
-
-  // get maching extractors/enhancements for the current URL
-  // NOTE: this does not mean that data can be found. Because of that we run all possible ones
-  const matching = enhancements.filter((e) =>
+async function extractLightningData() {
+  const match = enhancements.find((e) =>
     document.location.toString().match(e.urlMatcher)
   );
 
-  const batteriesRunning = matching.map((enhancement) => {
-    return enhancement.battery().then((data) => {
-      if (data) {
-        lightningData = data;
-        utils.call("setIcon", { icon: "active" });
-      }
-    });
-  });
-
-  await Promise.all(batteriesRunning);
-  return lightningData;
+  if (match) {
+    match.battery();
+  }
 }
-export default LBE_EXTRACT_LIGHTNING_DATA;
+export default extractLightningData;

--- a/src/extension/content-script/index.js
+++ b/src/extension/content-script/index.js
@@ -12,11 +12,13 @@ if (shouldInject()) {
   // extract LN data from websites
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === "lightningData") {
+      // Lightning data was requested from the popup.
       LBE_EXTRACT_LIGHTNING_DATA().then(sendResponse);
       return true;
+    } else if (request.type === "tabUpdated") {
+      LBE_EXTRACT_LIGHTNING_DATA();
     }
   });
-  LBE_EXTRACT_LIGHTNING_DATA();
 
   // message listener to listen to inpage webln calls
   // those calls get passed on to the background script

--- a/src/extension/content-script/index.js
+++ b/src/extension/content-script/index.js
@@ -8,8 +8,6 @@ import LBE_EXTRACT_LIGHTNING_DATA from "./batteries";
 
 if (shouldInject()) {
   injectScript();
-  // TODO: make optional
-  window.LBE_EXTRACT_LIGHTNING_DATA = LBE_EXTRACT_LIGHTNING_DATA;
 
   // extract LN data from websites
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/src/extension/content-script/index.js
+++ b/src/extension/content-script/index.js
@@ -4,19 +4,15 @@ import shouldInject from "./shouldInject";
 import injectScript from "./injectScript";
 
 //import { enhancements, loadEnhancements } from "../inpage-script/enhancements";
-import LBE_EXTRACT_LIGHTNING_DATA from "./batteries";
+import extractLightningData from "./batteries";
 
 if (shouldInject()) {
   injectScript();
 
   // extract LN data from websites
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.type === "lightningData") {
-      // Lightning data was requested from the popup.
-      LBE_EXTRACT_LIGHTNING_DATA().then(sendResponse);
-      return true;
-    } else if (request.type === "tabUpdated") {
-      LBE_EXTRACT_LIGHTNING_DATA();
+    if (request.type === "extractLightningData") {
+      extractLightningData();
     }
   });
 

--- a/src/extension/content-script/index.js
+++ b/src/extension/content-script/index.js
@@ -11,6 +11,15 @@ if (shouldInject()) {
   // TODO: make optional
   window.LBE_EXTRACT_LIGHTNING_DATA = LBE_EXTRACT_LIGHTNING_DATA;
 
+  // extract LN data from websites
+  browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.type === "lightningData") {
+      LBE_EXTRACT_LIGHTNING_DATA().then(sendResponse);
+      return true;
+    }
+  });
+  LBE_EXTRACT_LIGHTNING_DATA();
+
   // message listener to listen to inpage webln calls
   // those calls get passed on to the background script
   // (the inpage script can not do that directly, but only the inpage script can make webln availabe to the page)

--- a/src/extension/content-script/setLightningData.ts
+++ b/src/extension/content-script/setLightningData.ts
@@ -1,0 +1,14 @@
+import browser from "webextension-polyfill";
+
+import utils from "../../common/lib/utils";
+import { Battery } from "../../types";
+
+const setLightningData = (data: [Battery]): void => {
+  browser.runtime.sendMessage({
+    application: "LBE",
+    type: "lightningData",
+    args: data,
+  });
+  utils.call("setIcon", { icon: "active" });
+};
+export default setLightningData;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
   "permissions": [
     "notifications",
     "activeTab",
+    "tabs",
     "storage",
     "unlimitedStorage",
     "*://*/*"


### PR DESCRIPTION
The content script listens for messages (send from the home screen) with the type “lightningData”. 
It will async grab the data and send it back to the Home screen.

Benefits:
- Currently when lightning data wasn't directly available when opening the popup, the popup will only be updated after re-opening it. With this change, **the popup screen will be live updated** once the lightning data is available.
- No global window properties.