### PR TITLE
Fix styling to match other screens and some grammar updates

### DIFF
--- a/src/app/screens/Onboard/ConnectLndHub/index.tsx
+++ b/src/app/screens/Onboard/ConnectLndHub/index.tsx
@@ -76,9 +76,9 @@ export default function ConnectLndHub() {
         <div className="lg:w-1/2">
           <h1 className="text-3xl font-bold">Connect to LNDHub (BlueWallet)</h1>
           <p className="text-gray-500 mt-6">
-            in BlueWallet, choose the wallet you want to connect, open it, click
+            In BlueWallet, choose the wallet you want to connect, open it, click
             on "...", click on Export/Backup to display the QR code and scan it
-            with your webcam
+            with your webcam.
           </p>
           <div className="w-4/5">
             <div className="mt-6">

--- a/src/app/screens/Onboard/ConnectLndHub/index.tsx
+++ b/src/app/screens/Onboard/ConnectLndHub/index.tsx
@@ -75,7 +75,7 @@ export default function ConnectLndHub() {
       <div className="relative mt-24 lg:flex space-x-8">
         <div className="lg:w-1/2">
           <h1 className="text-3xl font-bold">Connect to LNDHub (BlueWallet)</h1>
-          <p className="text-gray-500 text-sm">
+          <p className="text-gray-500 mt-6">
             in BlueWallet, choose the wallet you want to connect, open it, click
             on "...", click on Export/Backup to display the QR code and scan it
             with your webcam

--- a/src/app/screens/Onboard/NewWallet/index.tsx
+++ b/src/app/screens/Onboard/NewWallet/index.tsx
@@ -126,7 +126,7 @@ export default function NewWallet() {
           ) : (
             <div className="w-4/5">
               <div className="mt-6">
-                <strong>Remember, not your keys, not your coins.</strong>
+                <strong>Remember, not your keys, not your coins. </strong>
                 This quick setup uses a custodial service to manage your wallet.
               </div>
             </div>


### PR DESCRIPTION
I noticed that in the onboarding section the instructions for LNDHub are styled differently than the instructions for the other options. This might be intentional but I don't think it is. The LNDHub instructions are smaller and have no margin, the other ```p``` elements are all styled with ```mt-6``` and no text size defined. It's a small difference but noticeable I think. All I did was change the styling to match the other screens so that it is uniform.

Here are screenshots of what I mean:

Current LNDHub styling: 
![image](https://user-images.githubusercontent.com/85003930/141234318-854ff569-450d-478c-bdc2-3de7b89b2365.png)

Styling of other instruction elements:
![image](https://user-images.githubusercontent.com/85003930/141234719-6f50778b-bf89-4178-b6b1-a0071d926d37.png)

New LNDHub styling:
![image](https://user-images.githubusercontent.com/85003930/141235258-0233f8cb-752d-473b-ad8b-1bc4ba783472.png)

I also just added capitalization and punctuation for this sentence. I know these are small changes but I think eventually we will want the whole interface to be super polished like this.

Another side note is that there are no instructions currently for LNBits so we may want to add something there.

The last change I made, and I know this is such a small detail, but I kind of like to make things pixel perfect. Is I added a space on the 'Create new wallet' page because currently 'Remember, not your keys, not your coins.This quick setup uses a custodial service to manage your wallet.' is all one block of text with no space between the sentences. When it should be 'Remember, not your keys, not your coins. This quick setup uses a custodial service to manage your wallet.'