### PR TITLE
Add optional debug mode

### DIFF
--- a/src/extension/background-script/index.js
+++ b/src/extension/background-script/index.js
@@ -5,6 +5,7 @@ import utils from "../../common/lib/utils";
 import { router } from "./router";
 import state from "./state";
 import db from "./db";
+import connectors from "./connectors";
 
 import * as events from "./events";
 
@@ -113,6 +114,16 @@ async function init() {
 
   // Notify the content script that the tab has been updated.
   browser.tabs.onUpdated.addListener(extractLightningData);
+
+  if (state.getState().settings.debug) {
+    console.log("Debug mode enabled, use window.debugAlby");
+    window.debugAlby = {
+      state,
+      db,
+      connectors,
+      router,
+    };
+  }
 }
 
 // The onInstalled event is fired directly after the code is loaded.


### PR DESCRIPTION
This allows to easily access important objects from the background script console.
e.g.
debugAlby.state.getState().accounts gives you the list of accounts
debugAlby.connectors gives ja access to the connector classes

this helps with quickly testing certain changes in a REPL.