### PR TITLE
convert BalanceCard to tsx

### DIFF
--- a/src/app/components/BalanceCard/index.tsx
+++ b/src/app/components/BalanceCard/index.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import Skeleton from "react-loading-skeleton";
 
+type Props = {
+  alias: string;
+  crypto: string;
+  fiat: string;
+};
+
 const skeletonStyle = {
   opacity: 0.5,
 };
 
-export default function Card({ alias, crypto, fiat }) {
+function BalanceCard({ alias, crypto, fiat }: Props) {
   return (
     <div className={`bg-blue-bitcoin p-6 pb-2 rounded-2xl shadow-lg`}>
       <p className="text-sm	font-normal text-white">
@@ -20,3 +26,5 @@ export default function Card({ alias, crypto, fiat }) {
     </div>
   );
 }
+
+export default BalanceCard;


### PR DESCRIPTION
For the conversion, I tried to orient myself on [AllowanceMenu](https://github.com/getAlby/lightning-browser-extension/blob/master/src/app/components/AllowanceMenu/index.tsx)

But it's a bit inconsistent since [Badge](https://github.com/getAlby/lightning-browser-extension/blob/master/src/app/components/Badge/index.tsx) makes the default export in the function instead of the end.

If there is some room for improvement, just tell me :)