### PR TITLE
Capitalize Unlock button

### DIFF
--- a/src/app/screens/Unlock/index.jsx
+++ b/src/app/screens/Unlock/index.jsx
@@ -56,7 +56,7 @@ function Unlock() {
         </div>
         <Button
           type="submit"
-          label="unlock"
+          label="Unlock"
           fullWidth
           primary
           disabled={password === ""}


### PR DESCRIPTION
All of the other buttons within the app have capitalization, currently the unlock button is lowercase. I think it looks more official and inline with the rest of the styles if it is also capitalized.

Before:

![image](https://user-images.githubusercontent.com/85003930/145248761-0199e767-bfa8-4bf7-b90e-3854ce0b4954.png)

After:

![image](https://user-images.githubusercontent.com/85003930/145248818-1fe0d275-aa5c-410f-b8e3-50a8dbdc4cb3.png)
