### PR TITLE
Limit tx history in popup to most recent 10

### DIFF
--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -36,7 +36,7 @@ export default function TransactionsTable({ transactions }: Props) {
   return (
     <div className="shadow overflow-hidden rounded-lg">
       <div className="bg-white divide-y divide-gray-200">
-        {transactions.map((tx) => (
+        {transactions.slice(0, 10).map((tx) => (
           <div key={tx.id} className="px-3 py-2">
             <Disclosure>
               {({ open }) => (

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -36,7 +36,7 @@ export default function TransactionsTable({ transactions }: Props) {
   return (
     <div className="shadow overflow-hidden rounded-lg">
       <div className="bg-white divide-y divide-gray-200">
-        {transactions.slice(0, 10).map((tx) => (
+        {transactions.map((tx) => (
           <div key={tx.id} className="px-3 py-2">
             <Disclosure>
               {({ open }) => (

--- a/src/app/screens/Home/index.jsx
+++ b/src/app/screens/Home/index.jsx
@@ -172,7 +172,7 @@ function Home() {
         ) : (
           <div>
             <h2 className="mb-2 text-lg text-gray-900 font-semibold">
-              Transactions
+              Recent Transactions
             </h2>
             {payments.length > 0 ? (
               <TransactionsTable

--- a/src/app/screens/Home/index.jsx
+++ b/src/app/screens/Home/index.jsx
@@ -41,7 +41,7 @@ function Home() {
   }
 
   function loadPayments() {
-    utils.call("getPayments").then((result) => {
+    utils.call("getPayments", { limit: 10 }).then((result) => {
       setPayments(result?.payments);
       setLoadingPayments(false);
     });

--- a/src/extension/background-script/actions/payments/all.js
+++ b/src/extension/background-script/actions/payments/all.js
@@ -3,7 +3,12 @@ import db from "../../db";
 const all = async (message, sender) => {
   // TODO load transactions from the node and merge it
   // with the payments data stored locally
-  let payments = await db.payments.toCollection().reverse().sortBy("createdAt");
+  const limit = message.args.limit || 2121; // TODO: add pagination
+  let payments = await db.payments
+    .toCollection()
+    .limit(limit)
+    .reverse()
+    .sortBy("createdAt");
 
   return {
     data: {


### PR DESCRIPTION
Related to issue #310 I limited the number of transactions displaying in the popup to the most recent 10. I also updated the header to say 'Recent Transactions' so it is more clear that it does not include all of them. I just picked the number 10 but we can change it if everyone thinks that is too short, maybe 21 would be better?

![image](https://user-images.githubusercontent.com/85003930/145657932-f345feb3-cd48-4c13-9bff-4690320a5c9b.png)
