### PR TITLE
feat: use the new useroutes hook

### DIFF
--- a/src/app/router/Welcome/Welcome.jsx
+++ b/src/app/router/Welcome/Welcome.jsx
@@ -1,31 +1,35 @@
 import { useEffect, useState } from "react";
-import {
-  HashRouter as Router,
-  Routes,
-  Route,
-  useLocation,
-} from "react-router-dom";
+import { HashRouter as Router, useRoutes, useLocation } from "react-router-dom";
 
 import DevMenu from "../../components/DevMenu";
 import Steps from "../../components/Steps";
 import Intro from "../../screens/Onboard/Intro";
 import SetPassword from "../../screens/Onboard/SetPassword";
 import ChooseConnector from "../../screens/Onboard/ChooseConnector";
-import ConnectLnd from "../../screens/Onboard/ConnectLnd";
 import TestConnection from "../../screens/Onboard/TestConnection";
+import ConnectLnd from "../../screens/Onboard/ConnectLnd";
+import ConnectLndHub from "../../screens/Onboard/ConnectLndHub";
+import ConnectLnbits from "../../screens/Onboard/ConnectLnbits";
+import NewWallet from "../../screens/Onboard/NewWallet";
 
 const routes = [
-  { path: "/", component: Intro, name: "Welcome" },
-  { path: "/set-password", component: SetPassword, name: "Your Password" },
+  { path: "/", element: <Intro />, name: "Welcome" },
+  { path: "/set-password", element: <SetPassword />, name: "Your Password" },
   {
-    path: "/choose-connector/*",
-    component: ChooseConnector,
+    path: "/choose-connector",
     name: "Connect to Lightning",
+    children: [
+      { index: true, element: <ChooseConnector /> },
+      { path: "lnd", element: <ConnectLnd /> },
+      { path: "lnd-hub", element: <ConnectLndHub /> },
+      { path: "lnbits", element: <ConnectLnbits /> },
+      { path: "create-wallet", element: <NewWallet /> },
+    ],
   },
-  { path: "/test-connection", component: TestConnection, name: "Done" },
+  { path: "/test-connection", element: <TestConnection />, name: "Done" },
 ];
 
-const initialSteps = routes.map((route, index) => ({
+const initialSteps = routes.map((route) => ({
   id: route.name,
   status: "upcoming",
 }));
@@ -41,6 +45,7 @@ function WelcomeRouter() {
 function App() {
   const [steps, setSteps] = useState(initialSteps);
   let location = useLocation();
+  const routesElement = useRoutes(routes);
 
   // Update step progress based on active location.
   useEffect(() => {
@@ -73,15 +78,7 @@ function App() {
         <Steps steps={steps} />
       </div>
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Routes>
-          {routes.map((route, i) => (
-            <Route
-              key={i}
-              path={route.path}
-              element={<route.component routes={route.routes} />}
-            />
-          ))}
-        </Routes>
+        {routesElement}
       </div>
     </div>
   );

--- a/src/app/screens/Onboard/ChooseConnector/index.tsx
+++ b/src/app/screens/Onboard/ChooseConnector/index.tsx
@@ -1,11 +1,4 @@
-import { Routes, Route } from "react-router-dom";
-
 import LinkButton from "../../../components/LinkButton";
-
-import ConnectLnd from "../ConnectLnd";
-import ConnectLndHub from "../ConnectLndHub";
-import ConnectLnbits from "../ConnectLnbits";
-import NewWallet from "../NewWallet";
 
 import lnbits from "/static/assets/icons/lnbits.png";
 import lndhub from "/static/assets/icons/lndhub.png";
@@ -41,39 +34,26 @@ export default function ChooseConnector() {
   ];
 
   return (
-    <Routes>
-      <Route
-        path="/"
-        element={
-          <div className="relative mt-14 lg:grid  lg:gap-8 text-center">
-            <div className="relative">
-              <h1 className="text-3xl font-bold">
-                Do you have a lightning wallet?
-              </h1>
-              <p className="text-gray-500 my-6">
-                You need to first connect to a lightning wallet so that you can
-                interact with <br /> your favorite websites that accept bitcoin
-                lightning payments!
-              </p>
-              <div className="grid grid-cols-4 gap-4">
-                {connectors.map(({ to, title, description, logo }) => (
-                  <LinkButton
-                    key={to}
-                    to={to}
-                    title={title}
-                    description={description}
-                    logo={logo}
-                  />
-                ))}
-              </div>
-            </div>
-          </div>
-        }
-      />
-      <Route path="lnd" element={<ConnectLnd />} />
-      <Route path="lnd-hub" element={<ConnectLndHub />} />
-      <Route path="lnbits" element={<ConnectLnbits />} />
-      <Route path="create-wallet" element={<NewWallet />} />
-    </Routes>
+    <div className="relative mt-14 lg:grid  lg:gap-8 text-center">
+      <div className="relative">
+        <h1 className="text-3xl font-bold">Do you have a lightning wallet?</h1>
+        <p className="text-gray-500 my-6">
+          You need to first connect to a lightning wallet so that you can
+          interact with <br /> your favorite websites that accept bitcoin
+          lightning payments!
+        </p>
+        <div className="grid grid-cols-4 gap-4">
+          {connectors.map(({ to, title, description, logo }) => (
+            <LinkButton
+              key={to}
+              to={to}
+              title={title}
+              description={description}
+              logo={logo}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Refactor the current route object to be used with the new useRoutes hook.
Then we don't need to manually map the route object into <Routes /> & <Route /> anymore.

Also fixes: #479