### PR TITLE
Load account info after unlocking

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -54,7 +54,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const getAccountInfo = () => {
     const id = account?.id;
     if (!id) return;
-    setAccount({ id }); // Clear current info.
+    setAccount({ id }); // Clear current info which causes a loading indicator for the alias/balance
     return api.getAccountInfo().then((response) => {
       const { alias } = response.info;
       const balance = parseInt(response.balance.balance); // TODO: handle amounts

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -24,7 +24,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const unlock = (password: string, callback: VoidFunction) => {
     return api.unlock(password).then((response) => {
-      setAccount({ id: response.currentAccountId });
+      // set the account id to indicate the unlock for other components
+      setAccount({
+        id: response.currentAccountId,
+      });
+      // asynchronously load the account info
+      api.getAccountInfo().then((response) => {
+        const { alias } = response.info;
+        const balance = parseInt(response.balance.balance); // TODO: handle amounts
+        setAccount({
+          id: response.currentAccountId,
+          alias,
+          balance,
+        });
+      });
+
+      // callback - e.g. navigate to the requested route after unlocking
       callback();
     });
   };
@@ -40,7 +55,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const id = account?.id;
     if (!id) return;
     setAccount({ id }); // Clear current info.
-    api.getAccountInfo().then((response) => {
+    return api.getAccountInfo().then((response) => {
       const { alias } = response.info;
       const balance = parseInt(response.balance.balance); // TODO: handle amounts
       setAccount({ id, alias, balance });


### PR DESCRIPTION
this asynchronously loads the balance and account info after unlocking the accounts.

This fixes a bug that the balance is not shown directly after unlocking the popup.