### PR TITLE
Replace slider with sat amount buttons when sending

### DIFF
--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -10,6 +10,7 @@ type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   loading?: boolean;
   disabled?: boolean;
   direction?: "row" | "column";
+	lessPadding?: boolean;
 };
 
 export default function Button({
@@ -22,6 +23,7 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
+	lessPadding = false,
 }: Props) {
   return (
     <button
@@ -35,7 +37,8 @@ export default function Button({
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
-        "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
+        "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150",
+				lessPadding && "!px-1"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -38,7 +38,7 @@ export default function Button({
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
         "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150",
-				lessPadding && "!px-2"
+				lessPadding && "!px-[0.425rem]"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -10,7 +10,6 @@ type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   loading?: boolean;
   disabled?: boolean;
   direction?: "row" | "column";
-  noPadding?: boolean;
 };
 
 export default function Button({
@@ -23,22 +22,20 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
-  noPadding = false,
 }: Props) {
   return (
     <button
       type={type}
       className={classNames(
         direction === "row" ? "flex-row" : "flex-col",
-        fullWidth && "w-full",
+        fullWidth && "w-full px-0",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
           : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
-        "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150",
-        noPadding && "!px-0"
+        "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -38,7 +38,7 @@ export default function Button({
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
         "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150",
-				lessPadding && "!px-1"
+				lessPadding && "!px-2"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -10,7 +10,7 @@ type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   loading?: boolean;
   disabled?: boolean;
   direction?: "row" | "column";
-	lessPadding?: boolean;
+  noPadding?: boolean;
 };
 
 export default function Button({
@@ -23,7 +23,7 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
-	lessPadding = false,
+  noPadding = false,
 }: Props) {
   return (
     <button
@@ -38,7 +38,7 @@ export default function Button({
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
         "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150",
-				lessPadding && "!px-[0.425rem]"
+        noPadding && "!px-0"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -28,14 +28,14 @@ export default function Button({
       type={type}
       className={classNames(
         direction === "row" ? "flex-row" : "flex-col",
-        fullWidth && "w-full px-0",
+        fullWidth ? "w-full px-0" : "px-7",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
           : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
-        "inline-flex justify-center items-center px-7 py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
+        "inline-flex justify-center items-center py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -47,7 +47,7 @@ function LNURLPay(props: Props) {
   const [successAction, setSuccessAction] = useState<
     LNURLPaymentSuccessAction | undefined
   >();
-
+  const [clear, setClear] = useState<boolean>(false);
   useEffect(() => {
     if (searchParams) {
       // lnurl was passed as querystring
@@ -174,15 +174,60 @@ function LNURLPay(props: Props) {
               setValueMSat(newValue);
             }}
           />
-          <input
-            className="mt-2"
-            type="range"
-            min={minSendable}
-            max={maxSendable}
-            step="1000"
-            value={valueMSat || 0}
-            onChange={(e) => setValueMSat(parseInt(e.target.value))}
-          />
+          <div className="flex flex-wrap justify-center mt-2">
+            <div className="m-2">
+              <Button
+                label="10"
+                onClick={() => {
+                  if (clear === false) {
+                    setValueMSat(10000);
+                    setClear(true);
+                  } else {
+                    setValueMSat(valueMSat + 10000);
+                  }
+                }}
+              />
+            </div>
+            <div className="m-2">
+              <Button
+                label="100"
+                onClick={() => {
+                  if (clear === false) {
+                    setValueMSat(100000);
+                    setClear(true);
+                  } else {
+                    setValueMSat(valueMSat + 100000);
+                  }
+                }}
+              />
+            </div>
+            <div className="m-2">
+              <Button
+                label="1000"
+                onClick={() => {
+                  if (clear === false) {
+                    setValueMSat(1000000);
+                    setClear(true);
+                  } else {
+                    setValueMSat(valueMSat + 1000000);
+                  }
+                }}
+              />
+            </div>
+            <div className="mt-2 ml-2 mr-2">
+              <Button
+                label="10000"
+                onClick={() => {
+                  if (clear === false) {
+                    setValueMSat(10000000);
+                    setClear(true);
+                  } else {
+                    setValueMSat(valueMSat + 10000000);
+                  }
+                }}
+              />
+            </div>
+          </div>
         </div>
       );
     }
@@ -190,7 +235,7 @@ function LNURLPay(props: Props) {
 
   function renderComment() {
     return (
-      <div className="mt-1 flex flex-col">
+      <div className="flex flex-col">
         <Input
           type="text"
           placeholder="optional"

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -177,7 +177,6 @@ function LNURLPay(props: Props) {
           <div className="flex space-x-1.5 mt-2">
             <Button
               fullWidth
-              noPadding
               label="100 sat⚡"
               onClick={() => {
                 setValueMSat(100000);
@@ -185,7 +184,6 @@ function LNURLPay(props: Props) {
             />
             <Button
               fullWidth
-              noPadding
               label="1K sat⚡"
               onClick={() => {
                 setValueMSat(1000000);
@@ -193,7 +191,6 @@ function LNURLPay(props: Props) {
             />
             <Button
               fullWidth
-              noPadding
               label="5K sat⚡"
               onClick={() => {
                 setValueMSat(5000000);
@@ -201,7 +198,6 @@ function LNURLPay(props: Props) {
             />
             <Button
               fullWidth
-              noPadding
               label="10K sat⚡"
               onClick={() => {
                 setValueMSat(10000000);

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -175,8 +175,9 @@ function LNURLPay(props: Props) {
             }}
           />
           <div className="flex flex-wrap justify-center mt-2">
-            <div className="m-2">
+            <div className="m-1">
               <Button
+								lessPadding
                 label="10 sat⚡"
                 onClick={() => {
                   if (clear === false) {
@@ -188,8 +189,9 @@ function LNURLPay(props: Props) {
                 }}
               />
             </div>
-            <div className="m-2">
+            <div className="m-1">
               <Button
+								lessPadding
                 label="100 sat⚡"
                 onClick={() => {
                   if (clear === false) {
@@ -201,8 +203,9 @@ function LNURLPay(props: Props) {
                 }}
               />
             </div>
-            <div className="m-2">
+            <div className="m-1">
               <Button
+								lessPadding
                 label="1K sat⚡"
                 onClick={() => {
                   if (clear === false) {
@@ -214,8 +217,9 @@ function LNURLPay(props: Props) {
                 }}
               />
             </div>
-            <div className="mt-2 ml-2 mr-2">
+            <div className="m-1">
               <Button
+								lessPadding
                 label="10K sat⚡"
                 onClick={() => {
                   if (clear === false) {

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -174,8 +174,8 @@ function LNURLPay(props: Props) {
               setValueMSat(newValue);
             }}
           />
-          <div className="flex flex-wrap justify-center mt-2">
-            <div className="m-1">
+          <div className="flex flex-wrap justify-between mt-2">
+            <div>
               <Button
 								lessPadding
                 label="10 sat⚡"
@@ -189,7 +189,7 @@ function LNURLPay(props: Props) {
                 }}
               />
             </div>
-            <div className="m-1">
+            <div>
               <Button
 								lessPadding
                 label="100 sat⚡"
@@ -203,7 +203,7 @@ function LNURLPay(props: Props) {
                 }}
               />
             </div>
-            <div className="m-1">
+            <div>
               <Button
 								lessPadding
                 label="1K sat⚡"
@@ -217,7 +217,7 @@ function LNURLPay(props: Props) {
                 }}
               />
             </div>
-            <div className="m-1">
+            <div>
               <Button
 								lessPadding
                 label="10K sat⚡"

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -174,43 +174,39 @@ function LNURLPay(props: Props) {
               setValueMSat(newValue);
             }}
           />
-          <div className="flex flex-wrap justify-between mt-2">
-            <div>
-              <Button
-                lessPadding
-                label="100 sat⚡"
-                onClick={() => {
-                  setValueMSat(100000);
-                }}
-              />
-            </div>
-            <div>
-              <Button
-                lessPadding
-                label="1K sat⚡"
-                onClick={() => {
-                  setValueMSat(1000000);
-                }}
-              />
-            </div>
-            <div>
-              <Button
-                lessPadding
-                label="5K sat⚡"
-                onClick={() => {
-                  setValueMSat(5000000);
-                }}
-              />
-            </div>
-            <div>
-              <Button
-                lessPadding
-                label="10K sat⚡"
-                onClick={() => {
-                  setValueMSat(10000000);
-                }}
-              />
-            </div>
+          <div className="flex space-x-1.5 mt-2">
+            <Button
+              fullWidth
+              noPadding
+              label="100 sat⚡"
+              onClick={() => {
+                setValueMSat(100000);
+              }}
+            />
+            <Button
+              fullWidth
+              noPadding
+              label="1K sat⚡"
+              onClick={() => {
+                setValueMSat(1000000);
+              }}
+            />
+            <Button
+              fullWidth
+              noPadding
+              label="5K sat⚡"
+              onClick={() => {
+                setValueMSat(5000000);
+              }}
+            />
+            <Button
+              fullWidth
+              noPadding
+              label="10K sat⚡"
+              onClick={() => {
+                setValueMSat(10000000);
+              }}
+            />
           </div>
         </div>
       );

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -178,20 +178,6 @@ function LNURLPay(props: Props) {
             <div>
               <Button
 								lessPadding
-                label="10 sat⚡"
-                onClick={() => {
-                  if (clear === false) {
-                    setValueMSat(10000);
-                    setClear(true);
-                  } else {
-                    setValueMSat(valueMSat + 10000);
-                  }
-                }}
-              />
-            </div>
-            <div>
-              <Button
-								lessPadding
                 label="100 sat⚡"
                 onClick={() => {
                   if (clear === false) {
@@ -213,6 +199,20 @@ function LNURLPay(props: Props) {
                     setClear(true);
                   } else {
                     setValueMSat(valueMSat + 1000000);
+                  }
+                }}
+              />
+            </div>
+            <div>
+              <Button
+								lessPadding
+                label="5K sat⚡"
+                onClick={() => {
+                  if (clear === false) {
+                    setValueMSat(5000000);
+                    setClear(true);
+                  } else {
+                    setValueMSat(valueMSat + 5000000);
                   }
                 }}
               />

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -47,7 +47,7 @@ function LNURLPay(props: Props) {
   const [successAction, setSuccessAction] = useState<
     LNURLPaymentSuccessAction | undefined
   >();
-  const [clear, setClear] = useState<boolean>(false);
+
   useEffect(() => {
     if (searchParams) {
       // lnurl was passed as querystring
@@ -177,57 +177,37 @@ function LNURLPay(props: Props) {
           <div className="flex flex-wrap justify-between mt-2">
             <div>
               <Button
-								lessPadding
+                lessPadding
                 label="100 sat⚡"
                 onClick={() => {
-                  if (clear === false) {
-                    setValueMSat(100000);
-                    setClear(true);
-                  } else {
-                    setValueMSat(valueMSat + 100000);
-                  }
+                  setValueMSat(100000);
                 }}
               />
             </div>
             <div>
               <Button
-								lessPadding
+                lessPadding
                 label="1K sat⚡"
                 onClick={() => {
-                  if (clear === false) {
-                    setValueMSat(1000000);
-                    setClear(true);
-                  } else {
-                    setValueMSat(valueMSat + 1000000);
-                  }
+                  setValueMSat(1000000);
                 }}
               />
             </div>
             <div>
               <Button
-								lessPadding
+                lessPadding
                 label="5K sat⚡"
                 onClick={() => {
-                  if (clear === false) {
-                    setValueMSat(5000000);
-                    setClear(true);
-                  } else {
-                    setValueMSat(valueMSat + 5000000);
-                  }
+                  setValueMSat(5000000);
                 }}
               />
             </div>
             <div>
               <Button
-								lessPadding
+                lessPadding
                 label="10K sat⚡"
                 onClick={() => {
-                  if (clear === false) {
-                    setValueMSat(10000000);
-                    setClear(true);
-                  } else {
-                    setValueMSat(valueMSat + 10000000);
-                  }
+                  setValueMSat(10000000);
                 }}
               />
             </div>

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -177,7 +177,7 @@ function LNURLPay(props: Props) {
           <div className="flex flex-wrap justify-center mt-2">
             <div className="m-2">
               <Button
-                label="10"
+                label="10 sat⚡"
                 onClick={() => {
                   if (clear === false) {
                     setValueMSat(10000);
@@ -190,7 +190,7 @@ function LNURLPay(props: Props) {
             </div>
             <div className="m-2">
               <Button
-                label="100"
+                label="100 sat⚡"
                 onClick={() => {
                   if (clear === false) {
                     setValueMSat(100000);
@@ -203,7 +203,7 @@ function LNURLPay(props: Props) {
             </div>
             <div className="m-2">
               <Button
-                label="1000"
+                label="1K sat⚡"
                 onClick={() => {
                   if (clear === false) {
                     setValueMSat(1000000);
@@ -216,7 +216,7 @@ function LNURLPay(props: Props) {
             </div>
             <div className="mt-2 ml-2 mr-2">
               <Button
-                label="10000"
+                label="10K sat⚡"
                 onClick={() => {
                   if (clear === false) {
                     setValueMSat(10000000);

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -48,6 +48,22 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
     setValue(e.target.value);
   }
 
+  function handleButtonChange(amount: number) {
+    setError("");
+    if (
+      invoiceAttributes.minimumAmount &&
+      amount < invoiceAttributes.minimumAmount
+    ) {
+      setError("Amount is less than minimum");
+    } else if (
+      invoiceAttributes.maximumAmount &&
+      amount > invoiceAttributes.maximumAmount
+    ) {
+      setError("Amount exceeds maximum");
+    }
+    setValue(amount);
+  }
+
   function handleMemoChange(e: React.ChangeEvent<HTMLInputElement>) {
     setMemo(e.target.value);
   }
@@ -96,7 +112,7 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                         noPadding
                         label="100 sat⚡"
                         onClick={() => {
-                          setValue(100);
+                          handleButtonChange(100);
                         }}
                       />
                       <Button
@@ -104,7 +120,7 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                         noPadding
                         label="1K sat⚡"
                         onClick={() => {
-                          setValue(1000);
+                          handleButtonChange(1000);
                         }}
                       />
                       <Button
@@ -112,7 +128,7 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                         noPadding
                         label="5K sat⚡"
                         onClick={() => {
-                          setValue(5000);
+                          handleButtonChange(5000);
                         }}
                       />
                       <Button
@@ -120,7 +136,7 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                         noPadding
                         label="10K sat⚡"
                         onClick={() => {
-                          setValue(10000);
+                          handleButtonChange(10000);
                         }}
                       />
                     </div>

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -109,7 +109,6 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                     <div className="flex space-x-1.5 mt-2">
                       <Button
                         fullWidth
-                        noPadding
                         label="100 sat⚡"
                         onClick={() => {
                           handleButtonChange(100);
@@ -117,7 +116,6 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                       />
                       <Button
                         fullWidth
-                        noPadding
                         label="1K sat⚡"
                         onClick={() => {
                           handleButtonChange(1000);
@@ -125,7 +123,6 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                       />
                       <Button
                         fullWidth
-                        noPadding
                         label="5K sat⚡"
                         onClick={() => {
                           handleButtonChange(5000);
@@ -133,7 +130,6 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                       />
                       <Button
                         fullWidth
-                        noPadding
                         label="10K sat⚡"
                         onClick={() => {
                           handleButtonChange(10000);

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -90,14 +90,40 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                 />
                 {invoiceAttributes.minimumAmount &&
                   invoiceAttributes.maximumAmount && (
-                    <input
-                      className="mt-2"
-                      type="range"
-                      min={invoiceAttributes.minimumAmount}
-                      max={invoiceAttributes.maximumAmount}
-                      value={value}
-                      onChange={handleValueChange}
-                    />
+                    <div className="flex space-x-1.5 mt-2">
+                      <Button
+                        fullWidth
+                        noPadding
+                        label="100 sat⚡"
+                        onClick={() => {
+                          setValue(100);
+                        }}
+                      />
+                      <Button
+                        fullWidth
+                        noPadding
+                        label="1K sat⚡"
+                        onClick={() => {
+                          setValue(1000);
+                        }}
+                      />
+                      <Button
+                        fullWidth
+                        noPadding
+                        label="5K sat⚡"
+                        onClick={() => {
+                          setValue(5000);
+                        }}
+                      />
+                      <Button
+                        fullWidth
+                        noPadding
+                        label="10K sat⚡"
+                        onClick={() => {
+                          setValue(10000);
+                        }}
+                      />
+                    </div>
                   )}
                 {error && <p className="text-red-500">{error}</p>}
               </div>


### PR DESCRIPTION
As requested in #529, I have removed the slider on the sending sats screen. I replaced it with 4 buttons with pre-determined satoshi amounts for each: 10, 100, 1000 and 10000. For the functionality I made it so that when you click each button it adds the satoshi amount to the input, I thought this may be useful rather than only allowing for the number to be set once.

What does everyone think about this?

Screenshot:
![image](https://user-images.githubusercontent.com/85003930/150292621-9d7bb8dd-1eae-4769-b202-6bdec113bd1b.png)

I think there is another screen I will have to adjust but I thought I would get feedback on this first and if everyone likes it then I can update the other one as well.