### PR TITLE
feat: update balance info after payment

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -30,7 +30,7 @@ function AccountMenu() {
     await utils.call("selectAccount", {
       id: accountId,
     });
-    auth.getAccountInfo(accountId);
+    auth.fetchAccountInfo(accountId);
   }
 
   function openOptions(path: string) {

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -14,9 +14,9 @@ interface AuthContextType {
    */
   setAccountId: (id: string) => void;
   /**
-   * Get's the additional account info: alias/balance
+   * Fetch the additional account info: alias/balance and update account
    */
-  getAccountInfo: (id?: string) => void;
+  fetchAccountInfo: (id?: string) => void;
 }
 
 const AuthContext = createContext<AuthContextType>({} as AuthContextType);
@@ -28,7 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const unlock = (password: string, callback: VoidFunction) => {
     return api.unlock(password).then((response) => {
       setAccountId(response.currentAccountId);
-      getAccountInfo(response.currentAccountId);
+      fetchAccountInfo(response.currentAccountId);
 
       // callback - e.g. navigate to the requested route after unlocking
       callback();
@@ -44,7 +44,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const setAccountId = (id: string) => setAccount({ id });
 
-  const getAccountInfo = async (accountId?: string) => {
+  const fetchAccountInfo = async (accountId?: string) => {
     const id = accountId || account?.id;
     if (!id) return;
     return api.swr.getAccountInfo(id, setAccount);
@@ -60,7 +60,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           window.close();
         } else if (response.unlocked) {
           setAccountId(response.currentAccountId);
-          getAccountInfo(response.currentAccountId);
+          fetchAccountInfo(response.currentAccountId);
         } else {
           setAccount(null);
         }
@@ -77,7 +77,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const value = {
     account,
     setAccountId,
-    getAccountInfo,
+    fetchAccountInfo,
     loading,
     unlock,
     lock,

--- a/src/app/screens/Receive.tsx
+++ b/src/app/screens/Receive.tsx
@@ -56,7 +56,7 @@ function Receive() {
     })
       .then(() => {
         setPaid(true);
-        auth.getAccountInfo(); // Update balance.
+        auth.fetchAccountInfo(); // Update balance.
       })
       .catch((err) => console.error(err))
       .finally(() => {


### PR DESCRIPTION
Currently after sending a payment with webln or lnurl pay, the balance isn't directly updated.

Current:
Scenario: Tipping on Twitter -> Balance stays the same until reopening the popup.
Scenario: Deposit sats on Kollider -> Prompt appears to make a payment, after payment, the prompt closes. When opening the popup, it first shows the old cached balance and then starts to fetch the new balance.

Desired:
Scenario: Tipping on Twitter -> Balance directly updates after a successful payment.
Scenario: Deposit sats on Kollider -> Prompt appears to make a payment, after payment, the prompt closes. When opening the popup, it directly shows the new balance.