### PR TITLE
Change grid to allow 5 connectors per row

### DIFF
--- a/src/app/screens/Onboard/ChooseConnector/index.tsx
+++ b/src/app/screens/Onboard/ChooseConnector/index.tsx
@@ -56,7 +56,7 @@ export default function ChooseConnector({ title, description }: Props) {
             </p>
           )}
         </div>
-        <div className="grid grid-cols-4 gap-4">
+        <div className="grid grid-cols-5 gap-5">
           {connectors.map(({ to, title, description, logo }) => (
             <LinkButton
               key={to}


### PR DESCRIPTION
@bumi wanted to have all on one row instead of having 1 connector by itself. 

![image](https://user-images.githubusercontent.com/85003930/150868570-7083fb5a-267f-4204-a787-f722e7aebea1.png)
