### PR TITLE
refactor: use html input correctly

### DIFF
--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -20,10 +20,10 @@ type Props = {
 
 function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   const [modalIsOpen, setIsOpen] = useState(false);
-  const [budget, setBudget] = useState<number | undefined>(0);
+  const [budget, setBudget] = useState("0");
 
   function openModal() {
-    setBudget(allowance.totalBudget);
+    setBudget(allowance.totalBudget.toString());
     setIsOpen(true);
   }
 
@@ -34,7 +34,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   async function updateAllowance() {
     await utils.call("updateAllowance", {
       id: parseInt(allowance.id),
-      totalBudget: budget,
+      totalBudget: parseInt(budget),
     });
     onEdit && onEdit();
     closeModal();
@@ -90,13 +90,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
               placeholder="sat"
               value={budget}
               type="number"
-              onChange={(event) => {
-                setBudget(
-                  !isNaN(event.target.valueAsNumber)
-                    ? event.target.valueAsNumber
-                    : undefined
-                );
-              }}
+              onChange={(e) => setBudget(e.target.value)}
             />
           </div>
         </div>
@@ -105,7 +99,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
             onClick={updateAllowance}
             label="Save"
             primary
-            disabled={budget === undefined}
+            disabled={budget === ""}
           />
         </div>
       </Modal>

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -33,8 +33,8 @@ function ConfirmPayment(props: Props) {
   const paymentRequestRef = useRef(
     props.paymentRequest || searchParams.get("paymentRequest")
   );
-  const [budget, setBudget] = useState<number | undefined>(
-    (invoiceRef.current?.tokens || 0) * 10
+  const [budget, setBudget] = useState(
+    ((invoiceRef.current?.tokens || 0) * 10).toString()
   );
   const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -75,7 +75,7 @@ function ConfirmPayment(props: Props) {
   function saveBudget() {
     if (!budget) return;
     return msg.request("addAllowance", {
-      totalBudget: budget,
+      totalBudget: parseInt(budget),
       host: originRef.current.host,
       name: originRef.current.name,
       imageURL: originRef.current.icon,
@@ -156,9 +156,7 @@ function ConfirmPayment(props: Props) {
                     placeholder="sat"
                     value={budget}
                     type="number"
-                    onChange={(event) => {
-                      setBudget(parseInt(event.target.value) || undefined);
-                    }}
+                    onChange={(event) => setBudget(event.target.value)}
                   />
                 </div>
               </Transition>

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -40,11 +40,11 @@ function LNURLPay(props: Props) {
         JSON.parse(searchParams.get("origin") as string)) ||
       getOriginData()
   );
-  const [valueMSat, setValueMSat] = useState<number | undefined>(
-    details?.minSendable
+  const [valueSat, setValueSat] = useState(
+    (details?.minSendable && (details?.minSendable / 1000).toString()) || ""
   );
-  const [comment, setComment] = useState<string | undefined>();
-  const [userName, setUserName] = useState<string | undefined>();
+  const [comment, setComment] = useState("");
+  const [userName, setUserName] = useState("");
   const [loadingConfirm, setLoadingConfirm] = useState(false);
   const [successAction, setSuccessAction] = useState<
     LNURLPaymentSuccessAction | undefined
@@ -58,7 +58,7 @@ function LNURLPay(props: Props) {
         lnurl.getDetails(lnurlString).then((lnurlDetails) => {
           if (lnurlDetails.tag === "payRequest") {
             setDetails(lnurlDetails);
-            setValueMSat(lnurlDetails.minSendable);
+            setValueSat((lnurlDetails.minSendable / 1000).toString());
             setLoading(false);
           }
         });
@@ -90,7 +90,7 @@ function LNURLPay(props: Props) {
       setLoadingConfirm(true);
       // Get the invoice
       const params = {
-        amount: valueMSat, // user specified sum in MilliSatoshi
+        amount: parseInt(valueSat) * 1000, // user specified sum in MilliSatoshi
         comment, // https://github.com/fiatjaf/lnurl-rfc/blob/luds/12.md
         payerdata, // https://github.com/fiatjaf/lnurl-rfc/blob/luds/18.md
       };
@@ -105,7 +105,7 @@ function LNURLPay(props: Props) {
       const isValidInvoice = lnurl.verifyInvoice({
         paymentInfo,
         metadata: details.metadata,
-        amount: valueMSat || 0,
+        amount: parseInt(valueSat) * 1000,
         payerdata,
       });
       if (!isValidInvoice) {
@@ -188,43 +188,29 @@ function LNURLPay(props: Props) {
             type="number"
             min={minSendable / 1000}
             max={maxSendable / 1000}
-            value={valueMSat ? valueMSat / 1000 : undefined}
-            onChange={(e) => {
-              let newValue;
-              if (e.target.value) {
-                newValue = parseInt(e.target.value) * 1000;
-              }
-              setValueMSat(newValue);
-            }}
+            value={valueSat}
+            onChange={(e) => setValueSat(e.target.value)}
           />
           <div className="flex space-x-1.5 mt-2">
             <Button
               fullWidth
               label="100 sat⚡"
-              onClick={() => {
-                setValueMSat(100000);
-              }}
+              onClick={() => setValueSat("100")}
             />
             <Button
               fullWidth
               label="1K sat⚡"
-              onClick={() => {
-                setValueMSat(1000000);
-              }}
+              onClick={() => setValueSat("1000")}
             />
             <Button
               fullWidth
               label="5K sat⚡"
-              onClick={() => {
-                setValueMSat(5000000);
-              }}
+              onClick={() => setValueSat("5000")}
             />
             <Button
               fullWidth
               label="10K sat⚡"
-              onClick={() => {
-                setValueMSat(10000000);
-              }}
+              onClick={() => setValueSat("10000")}
             />
           </div>
         </div>
@@ -378,7 +364,7 @@ function LNURLPay(props: Props) {
                   fullWidth
                   primary
                   loading={loadingConfirm}
-                  disabled={loadingConfirm || !valueMSat}
+                  disabled={loadingConfirm || !valueSat}
                 />
               </div>
 

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -41,7 +41,7 @@ function LNURLPay(props: Props) {
       getOriginData()
   );
   const [valueSat, setValueSat] = useState(
-    (details?.minSendable && (details?.minSendable / 1000).toString()) || ""
+    (details?.minSendable && (+details?.minSendable / 1000).toString()) || ""
   );
   const [comment, setComment] = useState("");
   const [userName, setUserName] = useState("");
@@ -58,7 +58,9 @@ function LNURLPay(props: Props) {
         lnurl.getDetails(lnurlString).then((lnurlDetails) => {
           if (lnurlDetails.tag === "payRequest") {
             setDetails(lnurlDetails);
-            setValueSat((lnurlDetails.minSendable / 1000).toString());
+            if (lnurlDetails.minSendable) {
+              setValueSat((+lnurlDetails.minSendable / 1000).toString());
+            }
             setLoading(false);
           }
         });
@@ -180,14 +182,14 @@ function LNURLPay(props: Props) {
 
   function renderAmount(minSendable: number, maxSendable: number) {
     if (minSendable === maxSendable) {
-      return <p>{`${minSendable / 1000} sat`}</p>;
+      return <p>{`${+minSendable / 1000} sat`}</p>;
     } else {
       return (
         <div className="mt-1 flex flex-col">
           <Input
             type="number"
-            min={minSendable / 1000}
-            max={maxSendable / 1000}
+            min={+minSendable / 1000}
+            max={+maxSendable / 1000}
             value={valueSat}
             onChange={(e) => setValueSat(e.target.value)}
           />

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -32,32 +32,16 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
   );
   const [error, setError] = useState("");
 
-  function handleValueChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleValueChange(amount: string) {
     setError("");
     if (
       invoiceAttributes.minimumAmount &&
-      e.target.valueAsNumber < invoiceAttributes.minimumAmount
+      parseInt(amount) < invoiceAttributes.minimumAmount
     ) {
       setError("Amount is less than minimum");
     } else if (
       invoiceAttributes.maximumAmount &&
-      e.target.valueAsNumber > invoiceAttributes.maximumAmount
-    ) {
-      setError("Amount exceeds maximum");
-    }
-    setValue(e.target.value);
-  }
-
-  function handleButtonChange(amount: number) {
-    setError("");
-    if (
-      invoiceAttributes.minimumAmount &&
-      amount < invoiceAttributes.minimumAmount
-    ) {
-      setError("Amount is less than minimum");
-    } else if (
-      invoiceAttributes.maximumAmount &&
-      amount > invoiceAttributes.maximumAmount
+      parseInt(amount) > invoiceAttributes.maximumAmount
     ) {
       setError("Amount exceeds maximum");
     }
@@ -102,7 +86,7 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                   min={invoiceAttributes.minimumAmount}
                   max={invoiceAttributes.maximumAmount}
                   value={value}
-                  onChange={handleValueChange}
+                  onChange={(e) => handleValueChange(e.target.value)}
                 />
                 {invoiceAttributes.minimumAmount &&
                   invoiceAttributes.maximumAmount && (
@@ -110,34 +94,26 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
                       <Button
                         fullWidth
                         label="100 sat⚡"
-                        onClick={() => {
-                          handleButtonChange(100);
-                        }}
+                        onClick={() => handleValueChange("100")}
                       />
                       <Button
                         fullWidth
                         label="1K sat⚡"
-                        onClick={() => {
-                          handleButtonChange(1000);
-                        }}
+                        onClick={() => handleValueChange("1000")}
                       />
                       <Button
                         fullWidth
                         label="5K sat⚡"
-                        onClick={() => {
-                          handleButtonChange(5000);
-                        }}
+                        onClick={() => handleValueChange("5000")}
                       />
                       <Button
                         fullWidth
                         label="10K sat⚡"
-                        onClick={() => {
-                          handleButtonChange(10000);
-                        }}
+                        onClick={() => handleValueChange("10000")}
                       />
                     </div>
                   )}
-                {error && <p className="text-red-500">{error}</p>}
+                {error && <p className="mt-1 text-red-500">{error}</p>}
               </div>
             }
             description={


### PR DESCRIPTION
Inputs are currently using mixed types of number / undefined.
We should handle everything as a string (during input handling) and convert to number in the appropriate places (api's)

Results:
No more clumsy onChange handlers / falling back on undefined when empty.