### PR TITLE
add vimeo tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Then run the following:
 
 - **Firefox**
 
-  - Load the Add-on via `about:debugging` => `This Firefox` as temporary Add-on. (`about:debugging#/runtime/this-firfox`)
+  - Load the Add-on via `about:debugging` => `This Firefox` as temporary Add-on. (`about:debugging#/runtime/this-firefox`)
   - Choose a .xpi file or the `manifest.json` file in the extension's dist directory: `dist/development/firefox`
   - [debugging details](https://extensionworkshop.com/documentation/develop/debugging/#debugging_popups)
   - To see the debug console click "inspect" on the list of temporary extensions (`about:debugging#/runtime/this-firefox`)

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -13,7 +13,10 @@ const fromInternetIdentifier = (address: string) => {
       /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
     )
   ) {
-    const [name, host] = address.split("@");
+    let [name, host] = address.split("@");
+    // remove invisible characters %EF%B8%8F
+    name = name.replace(/[^ -~]+/g, "");
+    host = host.replace(/[^ -~]+/g, "");
     return `https://${host}/.well-known/lnurlp/${name}`;
   }
   return null;

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -4,9 +4,8 @@ import setLightningData from "../setLightningData";
 const urlMatcher = /^https:\/\/vimeo.com\/.*/;
 
 const battery = (): void => {
-  document.getElementsByClassName("first")[0].innerHTML;
-  const videoDescription = document.querySelector(".first");
-  const channelLink = document.querySelector(".js-user_link");
+  const videoDescription = document.querySelector("[data-description-content]");
+  const channelLink = document.querySelector(".clip_info-subline--watch");
   if (!videoDescription || !channelLink) {
     return;
   }

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -1,0 +1,48 @@
+import getOriginData from "../originData";
+import setLightningData from "../setLightningData";
+
+const urlMatcher = /^https:\/\/vimeo.com\/.*/;
+
+const battery = (): void => {
+  document.getElementsByClassName("first")[0].innerHTML;
+  const videoDescription = document.querySelector(".first");
+  const channelLink = document.querySelector(".js-user_link");
+  if (!videoDescription || !channelLink) {
+    return;
+  }
+  const text = videoDescription.textContent || "";
+  let match;
+  let recipient;
+  // check for an lnurl
+  if ((match = text.match(/(lnurlp:)(\S+)/i))) {
+    recipient = match[2];
+  }
+  // if there is no lnurl we check for a zap emoji with a lightning address
+  // we check for the @-sign to try to limit the possibility to match some invalid text (e.g. random emoji usage)
+  else if ((match = text.match(/(⚡:?|lightning:|lnurl:)\s?(\S+@\S+)/i))) {
+    recipient = match[2];
+  } else {
+    return;
+  }
+
+  const name = channelLink.textContent || "";
+  const imageUrl =
+    document.querySelector<HTMLImageElement>(".clip_info-subline--watch img")
+      ?.src || "";
+  setLightningData([
+    {
+      method: "lnurl",
+      recipient,
+      ...getOriginData(),
+      name,
+      icon: imageUrl,
+    },
+  ]);
+};
+
+const VimeoVideo = {
+  urlMatcher,
+  battery,
+};
+
+export default VimeoVideo;

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -1,7 +1,7 @@
 import getOriginData from "../originData";
 import setLightningData from "../setLightningData";
 
-const urlMatcher = /^https:\/\/vimeo.com\/.*/;
+const urlMatcher = /^https:\/\/vimeo.com\/.*\d{4,}\/?$/;
 
 const battery = (): void => {
   const videoDescription = document.querySelector("[data-description-content]");

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -5,7 +5,7 @@ const urlMatcher = /^https:\/\/vimeo.com\/.*/;
 
 const battery = (): void => {
   const videoDescription = document.querySelector("[data-description-content]");
-  const channelLink = document.querySelector(".clip_info-subline--watch");
+  const channelLink = document.querySelector(".clip_info-subline--watch span");
   if (!videoDescription || !channelLink) {
     return;
   }

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -5,7 +5,9 @@ const urlMatcher = /^https:\/\/vimeo.com\/.*\d{4,}\/?$/;
 
 const battery = (): void => {
   const videoDescription = document.querySelector("[data-description-content]");
-  const channelLink = document.querySelector(".clip_info-subline--watch span");
+  const channelLink = document.querySelector(
+    ".clip_info-subline--watch .js-user_link"
+  );
   if (!videoDescription || !channelLink) {
     return;
   }

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -6,6 +6,7 @@ import YouTubeVideo from "./YouTubeVideo";
 import YouTubeChannel from "./YouTubeChannel";
 import Peertube from "./Peertube";
 // import YouTubeChannel from "./YouTubeChannel";
+import VimeoVideo from "./VimeoVideo";
 
 // Order is important as the first one for which the URL matches will be used
 // Monetization must likely be always the last one
@@ -14,6 +15,7 @@ const enhancements = [
   YouTubeVideo,
   YouTubeChannel,
   Peertube,
+  VimeoVideo,
   Monetization,
 ];
 


### PR DESCRIPTION
add tips on vimeo: here's demo video: https://vimeo.com/670055676

also fixed a strange bug that was adding these characters while parsing lightningaddress to lnurlp url `https://lntxbot.com/.well-known/lnurlp/%EF%B8%8Fpseudozach`. this was causing lnurlp tips on youtube/vimeo to fail silently.