### PR TITLE
Proposal: improved lnurlpay screen

### DIFF
--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -55,7 +55,7 @@ export default function PublisherCard({
             )}
           </h2>
           {description && (
-            <p className="text-white opacity-75 truncate">{description}</p>
+            <p className="text-white opacity-60 truncate">{description}</p>
           )}
         </div>
       </div>

--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -6,46 +6,60 @@ const DEFAULT_IMAGE =
 
 export type Props = {
   title: string;
+  description?: string;
   image: string;
   url?: string;
   children?: React.ReactNode;
 };
 
-export default function PublisherCard({ title, image, url, children }: Props) {
+export default function PublisherCard({
+  title,
+  description,
+  image,
+  url,
+  children,
+}: Props) {
   const { data } = usePalette(image);
   return (
     <div
-      className="p-6 bg-gray-300 text-center"
+      className="p-4 bg-gray-300"
       style={{
-        backgroundColor: data.vibrant,
-        backgroundImage: `linear-gradient(${data.vibrant}, rgba(0, 0, 0, 0.3) 85%)`,
+        backgroundColor: data.muted,
+        backgroundImage: `linear-gradient(${data.muted}, rgba(0, 0, 0, 0.25) 75%)`,
       }}
     >
-      <img
-        className="w-24 h-24 object-cover rounded-xl shadow-xl mx-auto mb-4"
-        src={image}
-        alt=""
-        onError={(e) => {
-          const target = e.target as HTMLImageElement;
-          target.onerror = null;
-          target.src = DEFAULT_IMAGE;
-        }}
-      />
-      <h2 className="text-center mb-0 text-xl font-medium text-white">
-        {title}
+      <div className="flex sm:justify-center items-center">
+        <img
+          className="mr-3 w-18 h-18 border-solid border-2 border-white object-cover rounded-full shadow-xl"
+          src={image}
+          alt=""
+          onError={(e) => {
+            const target = e.target as HTMLImageElement;
+            target.onerror = null;
+            target.src = DEFAULT_IMAGE;
+          }}
+        />
+        <div className="overflow-hidden">
+          <h2 className="text-lg leading-5 font-bold text-white truncate">
+            {title}
 
-        {url && (
-          <a
-            href={url}
-            target="_blank"
-            className="inline-flex"
-            rel="noreferrer"
-          >
-            <LinkIcon className="inline-flex h-5 w-5" />
-          </a>
-        )}
-      </h2>
-      {children && <div className="mt-2">{children}</div>}
+            {url && (
+              <a
+                href={url}
+                target="_blank"
+                className="inline-flex"
+                rel="noreferrer"
+              >
+                <LinkIcon className="inline-flex h-5 w-5" />
+              </a>
+            )}
+          </h2>
+          {description && (
+            <p className="text-white opacity-75 truncate">{description}</p>
+          )}
+        </div>
+      </div>
+      {children && <div className="mt-4 text-center">{children}</div>}
     </div>
   );
 }

--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -30,7 +30,7 @@ export default function PublisherCard({
     >
       <div className="flex sm:justify-center items-center">
         <img
-          className="mr-3 w-18 h-18 border-solid border-2 border-white object-cover rounded-full shadow-xl"
+          className="mr-3 w-18 h-18 shrink-0 border-solid border-2 border-white object-cover rounded-full shadow-xl"
           src={image}
           alt=""
           onError={(e) => {

--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -40,7 +40,10 @@ export default function PublisherCard({
           }}
         />
         <div className="overflow-hidden">
-          <h2 className="text-lg leading-5 font-bold text-white truncate">
+          <h2
+            className="text-lg leading-5 font-bold text-white truncate"
+            title={title}
+          >
             {title}
 
             {url && (
@@ -55,7 +58,9 @@ export default function PublisherCard({
             )}
           </h2>
           {description && (
-            <p className="text-white opacity-60 truncate">{description}</p>
+            <p className="text-white opacity-60 truncate" title={description}>
+              {description}
+            </p>
           )}
         </div>
       </div>

--- a/src/app/screens/Home/index.jsx
+++ b/src/app/screens/Home/index.jsx
@@ -223,7 +223,11 @@ function Home() {
   return (
     <div>
       {!allowance && lnData.length > 0 && (
-        <PublisherCard title={lnData[0].name} image={lnData[0].icon}>
+        <PublisherCard
+          title={lnData[0].name}
+          description={lnData[0].description}
+          image={lnData[0].icon}
+        >
           <Button
             onClick={async () => {
               try {

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -14,10 +14,8 @@ import lnurl from "../../common/lib/lnurl";
 import getOriginData from "../../extension/content-script/originData";
 import { useAuth } from "../context/AuthContext";
 
-import Loading from "../components/Loading";
 import Button from "../components/Button";
 import Input from "../components/Form/Input";
-import PublisherCard from "../components/PublisherCard";
 
 type Origin = {
   name: string;
@@ -287,7 +285,12 @@ function LNURLPay(props: Props) {
   }
 
   function elements() {
-    if (!details) return [];
+    if (loading || !details)
+      return [
+        ["Send payment to", "loading..."],
+        ["Description", "loading..."],
+        ["Amount (Satoshi)", "loading..."],
+      ];
     const elements = [];
     elements.push(["Send payment to", getRecipient()]);
     elements.push(...formattedMetadata(details.metadata));
@@ -295,10 +298,10 @@ function LNURLPay(props: Props) {
       "Amount (Satoshi)",
       renderAmount(details.minSendable, details.maxSendable),
     ]);
-    if (details.commentAllowed && details.commentAllowed > 0) {
+    if (details?.commentAllowed > 0) {
       elements.push(["Comment", renderComment()]);
     }
-    if (details.payerData && details.payerData.name) {
+    if (details?.payerData?.name) {
       elements.push(["Name", renderName()]);
     }
     return elements;
@@ -355,54 +358,46 @@ function LNURLPay(props: Props) {
 
   return (
     <div>
-      <PublisherCard title={origin.name} image={origin.icon} />
-      {loading && (
-        <div className="flex justify-center">
-          <Loading />
-        </div>
-      )}
-      {!loading && (
-        <div className="p-4 max-w-screen-sm mx-auto">
-          {!successAction ? (
-            <>
-              <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
-                {elements().map(([t, d], i) => (
-                  <Fragment key={`element-${i}`}>
-                    <dt className="text-sm font-semibold text-gray-500">{t}</dt>
-                    <dd className="text-sm mb-4 dark:text-white">{d}</dd>
-                  </Fragment>
-                ))}
-              </dl>
-              <div className="text-center">
-                <div className="mb-5">
-                  <Button
-                    onClick={confirm}
-                    label="Confirm"
-                    fullWidth
-                    primary
-                    loading={loadingConfirm}
-                    disabled={loadingConfirm || !valueMSat}
-                  />
-                </div>
-
-                <p className="mb-3 underline text-sm text-gray-300">
-                  Only connect with sites you trust.
-                </p>
-
-                <a
-                  className="underline text-sm text-gray-500"
-                  href="#"
-                  onClick={reject}
-                >
-                  Cancel
-                </a>
+      <div className="p-4 max-w-screen-sm mx-auto">
+        {!successAction ? (
+          <>
+            <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+              {elements().map(([t, d], i) => (
+                <Fragment key={`element-${i}`}>
+                  <dt className="text-sm font-semibold text-gray-500">{t}</dt>
+                  <dd className="text-sm mb-4 dark:text-white">{d}</dd>
+                </Fragment>
+              ))}
+            </dl>
+            <div className="text-center">
+              <div className="mb-5">
+                <Button
+                  onClick={confirm}
+                  label="Confirm"
+                  fullWidth
+                  primary
+                  loading={loadingConfirm}
+                  disabled={loadingConfirm || !valueMSat}
+                />
               </div>
-            </>
-          ) : (
-            renderSuccessAction()
-          )}
-        </div>
-      )}
+
+              <p className="mb-3 underline text-sm text-gray-300">
+                Only connect with sites you trust.
+              </p>
+
+              <a
+                className="underline text-sm text-gray-500"
+                href="#"
+                onClick={reject}
+              >
+                Cancel
+              </a>
+            </div>
+          </>
+        ) : (
+          renderSuccessAction()
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../context/AuthContext";
 
 import Button from "../components/Button";
 import Input from "../components/Form/Input";
+import PublisherCard from "../components/PublisherCard";
 
 type Origin = {
   name: string;
@@ -358,6 +359,11 @@ function LNURLPay(props: Props) {
 
   return (
     <div>
+      <PublisherCard
+        title={origin.name}
+        description={origin.description}
+        image={origin.icon}
+      />
       <div className="p-4 max-w-screen-sm mx-auto">
         {!successAction ? (
           <>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,9 @@ module.exports = {
         xxxs: ".5rem",
         xxs: ".625rem",
       },
+      spacing: {
+        18: "4.5rem",
+      },
       colors: {
         "orange-bitcoin": "#f7931a",
         "orange-bitcoin-700": "#e78308",


### PR DESCRIPTION
I think the PublisherCard is unnecessary in the LNURLPay screen and takes too much space.
(Currently you'd have to scroll to see the confirm button).
My preference goes to solely using it for contextual info on the Home screen.

Before:
<img width="403" alt="Schermafbeelding 2022-02-03 om 21 34 13" src="https://user-images.githubusercontent.com/12894112/152424317-24da4704-24d8-483c-a7c4-aa83f864641b.png">

After:
<img width="386" alt="Schermafbeelding 2022-02-03 om 21 12 42" src="https://user-images.githubusercontent.com/12894112/152423481-79341ce3-7d25-43c1-887a-d608c337b532.png">
