### PR TITLE
feat: associate labels with its inputs (A11Y)

### DIFF
--- a/src/app/screens/Onboard/ConnectEclair/index.tsx
+++ b/src/app/screens/Onboard/ConnectEclair/index.tsx
@@ -80,6 +80,7 @@ export default function ConnectLnbits() {
               <div className="mt-1">
                 <Input
                   name="password"
+                  id="password"
                   type="text"
                   required
                   onChange={handleChange}
@@ -96,6 +97,7 @@ export default function ConnectLnbits() {
               <div className="mt-1">
                 <Input
                   name="url"
+                  id="url"
                   type="text"
                   value={formData.url}
                   required

--- a/src/app/screens/Onboard/ConnectLnbits/index.tsx
+++ b/src/app/screens/Onboard/ConnectLnbits/index.tsx
@@ -80,6 +80,7 @@ export default function ConnectLnbits() {
               <div className="mt-1">
                 <Input
                   name="adminkey"
+                  id="adminkey"
                   type="text"
                   required
                   onChange={handleChange}
@@ -96,6 +97,7 @@ export default function ConnectLnbits() {
               <div className="mt-1">
                 <Input
                   name="url"
+                  id="url"
                   type="text"
                   value={formData.url}
                   required

--- a/src/app/screens/Onboard/ConnectLnd/index.tsx
+++ b/src/app/screens/Onboard/ConnectLnd/index.tsx
@@ -143,12 +143,16 @@ export default function ConnectLnd() {
           </p>
           <div className="w-4/5">
             <div className="mt-6">
-              <label className="block font-medium text-gray-700 dark:text-white">
+              <label
+                htmlFor="url"
+                className="block font-medium text-gray-700 dark:text-white"
+              >
                 Address
               </label>
               <div className="mt-1">
                 <Input
                   name="url"
+                  id="url"
                   placeholder="https://"
                   onChange={handleChange}
                   required
@@ -157,12 +161,16 @@ export default function ConnectLnd() {
             </div>
             <div className="mt-6">
               <div>
-                <label className="block font-medium text-gray-700 dark:text-white">
+                <label
+                  htmlFor="macaroon"
+                  className="block font-medium text-gray-700 dark:text-white"
+                >
                   Macaroon
                 </label>
                 <div className="mt-1">
                   <Input
                     name="macaroon"
+                    id="macaroon"
                     value={formData.macaroon}
                     onChange={handleChange}
                     required

--- a/src/app/screens/Onboard/ConnectLndHub/index.tsx
+++ b/src/app/screens/Onboard/ConnectLndHub/index.tsx
@@ -110,7 +110,7 @@ export default function ConnectLndHub() {
           <div className="w-4/5">
             <div className="mt-6">
               <label
-                htmlFor="login"
+                htmlFor="uri"
                 className="block font-medium text-gray-700 dark:text-white"
               >
                 LNDHub Export URI
@@ -118,6 +118,7 @@ export default function ConnectLndHub() {
               <div className="mt-1">
                 <Input
                   name="uri"
+                  id="uri"
                   type="text"
                   required
                   placeholder="lndhub://..."

--- a/src/app/screens/Onboard/SetPassword/index.jsx
+++ b/src/app/screens/Onboard/SetPassword/index.jsx
@@ -84,6 +84,7 @@ export default function SetPassword() {
               <div className="mt-1">
                 <Input
                   name="password"
+                  id="password"
                   type="password"
                   autoFocus
                   required
@@ -104,6 +105,7 @@ export default function SetPassword() {
               <div className="mt-1">
                 <Input
                   name="passwordConfirmation"
+                  id="passwordConfirmation"
                   type="password"
                   required
                   onChange={handleChange}

--- a/src/app/screens/Receive.tsx
+++ b/src/app/screens/Receive.tsx
@@ -184,6 +184,7 @@ function Receive() {
               <div className="mt-1">
                 <Input
                   name="amount"
+                  id="amount"
                   placeholder="Amount in Satoshi..."
                   type="text"
                   onChange={handleChange}
@@ -201,6 +202,7 @@ function Receive() {
               <div className="mt-1">
                 <Input
                   name="description"
+                  id="description"
                   placeholder="For e.g. who is sending this payment?"
                   type="text"
                   onChange={handleChange}
@@ -215,6 +217,7 @@ function Receive() {
           <div className="mt-1">
             <Select
               name="expiration"
+              id="expiration"
               value={formData.expiration}
               onChange={handleChange}
             >

--- a/src/app/screens/Send.tsx
+++ b/src/app/screens/Send.tsx
@@ -101,6 +101,7 @@ function Send() {
         <div className="mt-1 mb-4">
           <Input
             name="invoice"
+            id="invoice"
             placeholder="Paste invoice, lnurl or lightning address"
             value={invoice}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>


### PR DESCRIPTION
Associating a `<label>` with an `<input>` element offers some major advantages:

- The label text is not only visually associated with its corresponding text input; it is programmatically associated with it too. This means that, for example, a screen reader will read out the label when the user is focused on the form input, making it easier for an assistive technology user to understand what data should be entered.
- When a user clicks or touches/taps a label, the browser passes the focus to its associated input (the resulting event is also raised for the input). That increased hit area for focusing the input provides an advantage to anyone trying to activate it — including those using a touch-screen device.

Thanks to @escapedcat I did a double-check on this and noticed we were still missing id attributes in a lot of places.