### PR TITLE
Add tips button for when meta tag exists and also connected to site

### DIFF
--- a/src/app/screens/Home/index.jsx
+++ b/src/app/screens/Home/index.jsx
@@ -72,7 +72,36 @@ function Home() {
   function renderAllowanceView() {
     return (
       <>
-        <PublisherCard title={allowance.name} image={allowance.imageURL} />
+        <PublisherCard title={allowance.name} image={allowance.imageURL}>
+          {lnData.length > 0 && (
+            <Button
+              onClick={async () => {
+                try {
+                  setLoadingSendSats(true);
+                  const origin = {
+                    external: true,
+                    name: lnData[0].name,
+                    host: lnData[0].host,
+                    description: lnData[0].description,
+                    icon: lnData[0].icon,
+                  };
+                  navigate(
+                    `/lnurlPay?lnurl=${
+                      lnData[0].recipient
+                    }&origin=${encodeURIComponent(JSON.stringify(origin))}`
+                  );
+                } catch (e) {
+                  alert(e.message);
+                } finally {
+                  setLoadingSendSats(false);
+                }
+              }}
+              label="⚡️ Send Satoshis ⚡️"
+              primary
+              loading={loadingSendSats}
+            />
+          )}
+        </PublisherCard>
         <div className="px-4 pb-5">
           <div className="flex justify-between items-center py-3">
             {parseInt(allowance.totalBudget) > 0 ? (


### PR DESCRIPTION
As discussed in issue #607 and reported in our feedback board, the tips button was not displaying if a website had the meta tag but you were also connected to them as a publisher, with or without an allowance.

I have added the tips button to this screen so that you can still tip publishers even if you are connected to their website:

![image](https://user-images.githubusercontent.com/85003930/154853585-4447d741-0fb7-459c-8452-779146ed2bde.png)
