### PR TITLE
feat: accounts context (updating accounts troughout the whole app)

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import {
@@ -7,10 +7,9 @@ import {
   PlusIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
 
-import api from "../../../common/lib/api";
 import utils from "../../../common/lib/utils";
 import { useAuth } from "../../context/AuthContext";
-import type { Accounts } from "../../../types";
+import { useAccounts } from "../../context/AccountsContext";
 
 import Badge from "../Badge";
 import Menu from "../Menu";
@@ -18,13 +17,12 @@ import Menu from "../Menu";
 function AccountMenu() {
   const auth = useAuth();
   const navigate = useNavigate();
-  const [accounts, setAccounts] = useState<Accounts>({});
+  const { accounts, getAccounts } = useAccounts();
 
   useEffect(() => {
-    api.getAccounts().then((response) => {
-      setAccounts(response);
-    });
-  }, [auth.account]);
+    getAccounts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function selectAccount(accountId: string) {
     auth.setAccountId(accountId);

--- a/src/app/context/AccountsContext.tsx
+++ b/src/app/context/AccountsContext.tsx
@@ -1,0 +1,29 @@
+import { useState, createContext, useContext } from "react";
+
+import type { Accounts } from "../../types";
+import api from "../../common/lib/api";
+
+interface AccountsContextType {
+  accounts: Accounts;
+  getAccounts: () => void;
+}
+
+const AccountsContext = createContext({} as AccountsContextType);
+
+export function AccountsProvider({ children }: { children: React.ReactNode }) {
+  const [accounts, setAccounts] = useState<Accounts>({});
+
+  function getAccounts() {
+    api.getAccounts().then(setAccounts);
+  }
+
+  return (
+    <AccountsContext.Provider value={{ accounts, getAccounts }}>
+      {children}
+    </AccountsContext.Provider>
+  );
+}
+
+export function useAccounts() {
+  return useContext(AccountsContext);
+}

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -19,7 +19,7 @@ interface AuthContextType {
   fetchAccountInfo: (id?: string) => Promise<AccountInfo | undefined>;
 }
 
-const AuthContext = createContext<AuthContextType>({} as AuthContextType);
+const AuthContext = createContext({} as AuthContextType);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [account, setAccount] = useState<AuthContextType["account"]>(null);

--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -1,6 +1,7 @@
 import { HashRouter, Navigate, Outlet, Routes, Route } from "react-router-dom";
 
 import { AuthProvider } from "../../context/AuthContext";
+import { AccountsProvider } from "../../context/AccountsContext";
 import { useAuth } from "../../context/AuthContext";
 import connectorRoutes from "../connectorRoutes";
 
@@ -22,63 +23,65 @@ import Accounts from "../../screens/Accounts";
 function Options() {
   return (
     <AuthProvider>
-      <HashRouter>
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <RequireAuth>
-                <Layout />
-              </RequireAuth>
-            }
-          >
-            <Route index element={<Navigate to="/publishers" replace />} />
-            <Route path="publishers">
-              <Route path=":id" element={<Publisher />} />
-              <Route index element={<Publishers />} />
-            </Route>
-            <Route path="send" element={<Send />} />
-            <Route path="receive" element={<Receive />} />
-            <Route path="lnurlPay" element={<LNURLPay />} />
-            <Route path="confirmPayment" element={<ConfirmPayment />} />
-            <Route path="settings" element={<Settings />} />
-            <Route path="accounts">
+      <AccountsProvider>
+        <HashRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <RequireAuth>
+                  <Layout />
+                </RequireAuth>
+              }
+            >
+              <Route index element={<Navigate to="/publishers" replace />} />
+              <Route path="publishers">
+                <Route path=":id" element={<Publisher />} />
+                <Route index element={<Publishers />} />
+              </Route>
+              <Route path="send" element={<Send />} />
+              <Route path="receive" element={<Receive />} />
+              <Route path="lnurlPay" element={<LNURLPay />} />
+              <Route path="confirmPayment" element={<ConfirmPayment />} />
+              <Route path="settings" element={<Settings />} />
+              <Route path="accounts">
+                <Route
+                  path="new"
+                  element={
+                    <Container>
+                      <Outlet />
+                    </Container>
+                  }
+                >
+                  <Route
+                    index
+                    element={
+                      <ChooseConnector title="Add a new lightning account" />
+                    }
+                  />
+                  {connectorRoutes.map((connectorRoute) => (
+                    <Route
+                      key={connectorRoute.path}
+                      path={connectorRoute.path}
+                      element={connectorRoute.element}
+                    />
+                  ))}
+                </Route>
+                <Route index element={<Accounts />} />
+              </Route>
               <Route
-                path="new"
+                path="test-connection"
                 element={
                   <Container>
-                    <Outlet />
+                    <TestConnection />
                   </Container>
                 }
-              >
-                <Route
-                  index
-                  element={
-                    <ChooseConnector title="Add a new lightning account" />
-                  }
-                />
-                {connectorRoutes.map((connectorRoute) => (
-                  <Route
-                    key={connectorRoute.path}
-                    path={connectorRoute.path}
-                    element={connectorRoute.element}
-                  />
-                ))}
-              </Route>
-              <Route index element={<Accounts />} />
+              />
             </Route>
-            <Route
-              path="test-connection"
-              element={
-                <Container>
-                  <TestConnection />
-                </Container>
-              }
-            />
-          </Route>
-          <Route path="unlock" element={<Unlock />} />
-        </Routes>
-      </HashRouter>
+            <Route path="unlock" element={<Unlock />} />
+          </Routes>
+        </HashRouter>
+      </AccountsProvider>
     </AuthProvider>
   );
 }

--- a/src/app/router/Popup/Popup.tsx
+++ b/src/app/router/Popup/Popup.tsx
@@ -10,6 +10,7 @@ import LNURLPay from "../../screens/LNURLPay";
 import ConfirmPayment from "../../screens/ConfirmPayment";
 
 import { AuthProvider } from "../../context/AuthContext";
+import { AccountsProvider } from "../../context/AccountsContext";
 import RequireAuth from "../RequireAuth";
 import Navbar from "../../components/Navbar";
 
@@ -18,25 +19,27 @@ const POPUP_MAX_HEIGHT = 600;
 function Popup() {
   return (
     <AuthProvider>
-      <HashRouter>
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <RequireAuth>
-                <Layout />
-              </RequireAuth>
-            }
-          >
-            <Route index element={<Home />} />
-            <Route path="send" element={<Send />} />
-            <Route path="receive" element={<Receive />} />
-            <Route path="lnurlPay" element={<LNURLPay />} />
-            <Route path="confirmPayment" element={<ConfirmPayment />} />
-          </Route>
-          <Route path="unlock" element={<Unlock />} />
-        </Routes>
-      </HashRouter>
+      <AccountsProvider>
+        <HashRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <RequireAuth>
+                  <Layout />
+                </RequireAuth>
+              }
+            >
+              <Route index element={<Home />} />
+              <Route path="send" element={<Send />} />
+              <Route path="receive" element={<Receive />} />
+              <Route path="lnurlPay" element={<LNURLPay />} />
+              <Route path="confirmPayment" element={<ConfirmPayment />} />
+            </Route>
+            <Route path="unlock" element={<Unlock />} />
+          </Routes>
+        </HashRouter>
+      </AccountsProvider>
     </AuthProvider>
   );
 }

--- a/src/app/screens/Accounts.tsx
+++ b/src/app/screens/Accounts.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   EllipsisIcon,
@@ -6,24 +5,18 @@ import {
   WalletIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
 
-import type { Accounts } from "../../types";
 import api from "../../common/lib/api";
 import { useAuth } from "../context/AuthContext";
+import { useAccounts } from "../context/AccountsContext";
 
 import Button from "../components/Button";
 import Container from "../components/Container";
 import Menu from "../components/Menu";
 
 function AccountsScreen() {
-  const [accounts, setAccounts] = useState<Accounts>({});
   const auth = useAuth();
+  const { accounts, getAccounts } = useAccounts();
   const navigate = useNavigate();
-
-  function getAccounts() {
-    api.getAccounts().then((response) => {
-      setAccounts(response);
-    });
-  }
 
   async function selectAccount(accountId: string) {
     auth.setAccountId(accountId);
@@ -50,10 +43,6 @@ function AccountsScreen() {
       }
     }
   }
-
-  useEffect(() => {
-    getAccounts();
-  }, []);
 
   return (
     <Container>

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import utils from "../../../../common/lib/utils";
 import api from "../../../../common/lib/api";
 import { useAuth } from "../../../context/AuthContext";
+import { useAccounts } from "../../../context/AccountsContext";
 
 import Button from "../../../components/Button";
 import Card from "../../../components/Card";
@@ -11,6 +12,7 @@ import Loading from "../../../components/Loading";
 
 export default function TestConnection() {
   const auth = useAuth();
+  const { getAccounts } = useAccounts();
   const [accountInfo, setAccountInfo] =
     useState<{ alias: string; balance: number }>();
   const [errorMessage, setErrorMessage] = useState("");
@@ -36,6 +38,7 @@ export default function TestConnection() {
           balance: accountInfo.balance,
         });
       }
+      getAccounts();
     } catch (e) {
       console.log(e);
       if (e instanceof Error) {


### PR DESCRIPTION
Create an Accounts context so accounts state can be used across multiple components easily.
For e.g. when an account get's deleted, it should resemble this in the Accounts list on the accounts screen but also in the AccountsMenu.