### PR TITLE
feat(hooks): use yarn to run precommit hooks instead of npx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
-npx tsc --noEmit
+yarn lint-staged
+yarn tsc --noEmit


### PR DESCRIPTION
Fixes: #645 

use yarn instead of npx to run precommit hook
