### PR TITLE
chore: always require native messaging permission

### DIFF
--- a/src/app/components/CompanionDownloadInfo.tsx
+++ b/src/app/components/CompanionDownloadInfo.tsx
@@ -11,9 +11,9 @@ function CompanionDownloadInfo() {
   // TODO: check if the companion app is already installed
   return (
     <div className="mt-6">
-      You are trying to connect to your node through Tor. Because browsers
-      cannot directly connect to your node please make sure you have the Alby
-      companion app installed. You can download it from{" "}
+      You are trying to connect to a node behind Tor. Because browsers cannot
+      directly connect to your node please make sure you have the Alby companion
+      app installed. You can download it from{" "}
       <a
         href={`https://getalby.com/install/companion/${getOS()}`}
         target="_blank"

--- a/src/app/components/CompanionDownloadInfo.tsx
+++ b/src/app/components/CompanionDownloadInfo.tsx
@@ -1,0 +1,29 @@
+import { ReceiveIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
+
+function CompanionDownloadInfo() {
+  function getOS() {
+    if (navigator.appVersion.indexOf("Win") != -1) return "Windows";
+    if (navigator.appVersion.indexOf("Mac") != -1) return "MacOS";
+    if (navigator.appVersion.indexOf("X11") != -1) return "UNIX";
+    if (navigator.appVersion.indexOf("Linux") != -1) return "Linux";
+  }
+
+  // TODO: check if the companion app is already installed
+  return (
+    <div className="mt-6">
+      You are trying to connect to your node through Tor. Because browsers
+      cannot directly connect to your node please make sure you have the Alby
+      companion app installed. You can download it from{" "}
+      <a
+        href={`https://getalby.com/install/companion/${getOS()}`}
+        target="_blank"
+        rel="noreferrer"
+      >
+        it here
+        <ReceiveIcon className="w-6 h-6 inline" />
+      </a>
+    </div>
+  );
+}
+
+export default CompanionDownloadInfo;

--- a/src/app/screens/Onboard/ConnectLnd/index.tsx
+++ b/src/app/screens/Onboard/ConnectLnd/index.tsx
@@ -1,7 +1,6 @@
 import { SendIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import browser from "webextension-polyfill";
 import utils from "../../../../common/lib/utils";
 import Button from "../../../components/Button";
 import TextField from "../../../components/Form/TextField";
@@ -51,15 +50,6 @@ export default function ConnectLnd() {
       // TODO: for native connectors we currently skip the validation because it is too slow (booting up Tor etc.)
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
-        const permissionGranted = await browser.permissions.request({
-          permissions: ["nativeMessaging"],
-        });
-        if (!permissionGranted) {
-          validation = {
-            valid: false,
-            error: "Native permissions are required to connect through Tor.",
-          };
-        }
       } else {
         validation = await utils.call("validateAccount", account);
       }

--- a/src/app/screens/Onboard/ConnectLnd/index.tsx
+++ b/src/app/screens/Onboard/ConnectLnd/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import utils from "../../../../common/lib/utils";
 import Button from "../../../components/Button";
 import TextField from "../../../components/Form/TextField";
+import CompanionDownloadInfo from "../../../components/CompanionDownloadInfo";
 
 const initialFormData = Object.freeze({
   url: "",
@@ -127,18 +128,20 @@ export default function ConnectLnd() {
             Connect to your LND node
           </h1>
           <p className="text-gray-500 mt-6 dark:text-gray-400">
-            You will need to retrieve the node url and an admin <br /> macaroon.
+            You need your node URL and a macaroon with read and send permissions
+            (e.g. admin.macaroon)
           </p>
           <div className="w-4/5">
             <div className="mt-6">
               <TextField
                 id="url"
-                label="Address"
-                placeholder="https://"
+                label="REST API host and port"
+                placeholder="https://your-node:8080"
                 onChange={handleChange}
                 required
               />
             </div>
+            {formData.url.match(/\.onion/i) && <CompanionDownloadInfo />}
             <div className="mt-6">
               <div>
                 <TextField

--- a/src/app/screens/Onboard/ConnectLnd/index.tsx
+++ b/src/app/screens/Onboard/ConnectLnd/index.tsx
@@ -146,7 +146,7 @@ export default function ConnectLnd() {
               <div>
                 <TextField
                   id="macaroon"
-                  label="Macaroon"
+                  label="Macaroon (HEX format)"
                   value={formData.macaroon}
                   onChange={handleChange}
                   required

--- a/src/app/screens/Onboard/ConnectLndHub/index.tsx
+++ b/src/app/screens/Onboard/ConnectLndHub/index.tsx
@@ -6,6 +6,7 @@ import utils from "../../../../common/lib/utils";
 import Button from "../../../components/Button";
 import QrcodeScanner from "../../../components/QrcodeScanner";
 import TextField from "../../../components/Form/TextField";
+import CompanionDownloadInfo from "../../../components/CompanionDownloadInfo";
 
 export default function ConnectLndHub() {
   const navigate = useNavigate();
@@ -108,6 +109,9 @@ export default function ConnectLndHub() {
                 value={formData.uri}
                 onChange={handleChange}
               />
+            </div>
+            {formData.uri.match(/\.onion/i) && <CompanionDownloadInfo />}
+            <div className="mt-6">
               <p className="text-center my-4 dark:text-white">OR</p>
               <QrcodeScanner
                 fps={10}

--- a/src/app/screens/Onboard/ConnectLndHub/index.tsx
+++ b/src/app/screens/Onboard/ConnectLndHub/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import browser from "webextension-polyfill";
 
 import utils from "../../../../common/lib/utils";
 
@@ -57,15 +56,6 @@ export default function ConnectLndHub() {
       // TODO: for native connectors we currently skip the validation because it is too slow (booting up Tor etc.)
       if (account.connector === "nativelndhub") {
         validation = { valid: true, error: "" };
-        const permissionGranted = await browser.permissions.request({
-          permissions: ["nativeMessaging"],
-        });
-        if (!permissionGranted) {
-          validation = {
-            valid: false,
-            error: "Native permissions are required to connect through Tor.",
-          };
-        }
       } else {
         validation = await utils.call("validateAccount", account);
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,10 +18,8 @@
     "tabs",
     "storage",
     "unlimitedStorage",
+    "nativeMessaging",
     "*://*/*"
-  ],
-  "optional_permissions": [
-    "nativeMessaging"
   ],
 
   "content_security_policy": "script-src 'self'; object-src 'self'",


### PR DESCRIPTION
On chrome based browsers we can not request permissions on they fly.
Requesting the native messaging permission requires a restart
This would kick the user out of the onboarding process.
To work around this we now always require the native messaging permission.