### PR TITLE
fix 693: added pattern and title to TextField and Input for form validation of lnd and lndhub urls

### DIFF
--- a/src/app/components/Form/Input/index.tsx
+++ b/src/app/components/Form/Input/index.tsx
@@ -4,6 +4,8 @@ export default function Input({
   placeholder,
   type = "text",
   required = false,
+  pattern,
+  title,
   onChange,
   onFocus,
   onBlur,
@@ -22,6 +24,8 @@ export default function Input({
       className="shadow-sm focus:ring-orange-bitcoin focus:border-orange-bitcoin block w-full sm:text-sm border-gray-300 rounded-md placeholder-gray-400 dark:bg-gray-200 dark:placeholder-gray-600 dark:text-black"
       placeholder={placeholder}
       required={required}
+      pattern={pattern}
+      title={title}
       onChange={onChange}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/src/app/components/Form/TextField.tsx
+++ b/src/app/components/Form/TextField.tsx
@@ -6,6 +6,8 @@ const TextField = ({
   placeholder,
   type = "text",
   required = false,
+  pattern,
+  title,
   onChange,
   onFocus,
   onBlur,
@@ -30,6 +32,8 @@ const TextField = ({
         id={id}
         placeholder={placeholder}
         required={required}
+        pattern={pattern}
+        title={title}
         onChange={onChange}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/src/app/screens/Onboard/ConnectLnd/index.tsx
+++ b/src/app/screens/Onboard/ConnectLnd/index.tsx
@@ -136,7 +136,9 @@ export default function ConnectLnd() {
               <TextField
                 id="url"
                 label="REST API host and port"
-                placeholder="https://your-node:8080"
+                placeholder="https://your-node-url:8080"
+                pattern="https://.+"
+                title="https://your-node-url:8080"
                 onChange={handleChange}
                 required
               />

--- a/src/app/screens/Onboard/ConnectLndHub/index.tsx
+++ b/src/app/screens/Onboard/ConnectLndHub/index.tsx
@@ -106,6 +106,8 @@ export default function ConnectLndHub() {
                 type="text"
                 required
                 placeholder="lndhub://..."
+                pattern="lndhub://.+"
+                title="lndhub://..."
                 value={formData.uri}
                 onChange={handleChange}
               />


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #693 

#### Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Describe the changes you have made in this PR -
I added a form validation pattern for lndhub and lnd to specify requiring lndhub:// and https:// respectively
#### Screenshots of the changes (If any) -

#### How Has This Been Tested?

- [ x ] Test A: tried connecting to fake node url starting with: no prefix, http, https, http://    =>  failed all. tried connecting to fake node url starting with https:// => passed check but didn't connect because credentials were invalid.
- [ x ] Test B: tried connecting to real node url starting with: no prefix, http, https, http://    =>  failed all. tried connecting to real node url starting with https:// => passed check and connected with valid credentials.


#### Checklist:

- [ x ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ x ] New and existing tests pass locally with my changes
- [ x ] I have made corresponding changes to the documentation (If Any)
