### PR TITLE
Feature/keysend

### DIFF
--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -19,6 +19,7 @@ import Settings from "../../screens/Settings";
 import Unlock from "../../screens/Unlock";
 import ChooseConnector from "../../screens/Onboard/ChooseConnector";
 import Accounts from "../../screens/Accounts";
+import Keysend from "../../screens/Keysend";
 
 function Options() {
   return (
@@ -40,6 +41,7 @@ function Options() {
                 <Route index element={<Publishers />} />
               </Route>
               <Route path="send" element={<Send />} />
+              <Route path="keysend" element={<Keysend />} />
               <Route path="receive" element={<Receive />} />
               <Route path="lnurlPay" element={<LNURLPay />} />
               <Route path="confirmPayment" element={<ConfirmPayment />} />

--- a/src/app/router/Popup/Popup.tsx
+++ b/src/app/router/Popup/Popup.tsx
@@ -13,6 +13,7 @@ import { AuthProvider } from "../../context/AuthContext";
 import { AccountsProvider } from "../../context/AccountsContext";
 import RequireAuth from "../RequireAuth";
 import Navbar from "../../components/Navbar";
+import Keysend from "../../screens/Keysend";
 
 const POPUP_MAX_HEIGHT = 600;
 
@@ -34,6 +35,7 @@ function Popup() {
               <Route path="send" element={<Send />} />
               <Route path="receive" element={<Receive />} />
               <Route path="lnurlPay" element={<LNURLPay />} />
+              <Route path="keysend" element={<Keysend />} />
               <Route path="confirmPayment" element={<ConfirmPayment />} />
             </Route>
             <Route path="unlock" element={<Unlock />} />

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -17,6 +17,7 @@ import ConfirmSignMessage from "../../screens/ConfirmSignMessage";
 import ConfirmPayment from "../../screens/ConfirmPayment";
 import LNURLPay from "../../screens/LNURLPay";
 import LNURLAuth from "../../screens/LNURLAuth";
+import Keysend from "../../screens/Keysend";
 
 class Prompt extends Component<
   Record<string, unknown>,
@@ -97,6 +98,17 @@ class Prompt extends Component<
                 element={
                   <ConfirmPayment
                     paymentRequest={this.state.args?.paymentRequest as string}
+                    origin={this.state.origin}
+                  />
+                }
+              />
+              <Route
+                path="keysend"
+                element={
+                  <Keysend
+                    destination={this.state.args?.destination as string}
+                    valueSat={this.state.args?.amount as string}
+                    comment={this.state.args?.memo as string}
                     origin={this.state.origin}
                   />
                 }

--- a/src/app/screens/Keysend.tsx
+++ b/src/app/screens/Keysend.tsx
@@ -17,6 +17,9 @@ type Origin = {
 
 type Props = {
   origin?: Origin;
+  destination?: string;
+  comment?: string;
+  valueSat?: string;
 };
 
 function Keysend(props: Props) {
@@ -29,16 +32,17 @@ function Keysend(props: Props) {
         JSON.parse(searchParams.get("origin") as string)) ||
       getOriginData()
   );
-  const [comment, setComment] = useState("");
-  const [valueSat, setValueSat] = useState("");
+  const [comment, setComment] = useState(props.comment || "");
+  const [valueSat, setValueSat] = useState(props.valueSat || "");
+  const [pubkey] = useState(
+    props.destination || searchParams.get("destination")
+  );
   const [loadingConfirm, setLoadingConfirm] = useState(false);
   const [successAction, setSuccessAction] = useState<
     LNURLPaymentSuccessAction | undefined
   >();
 
   async function confirm() {
-    const pubkey = searchParams.get("destination");
-
     try {
       setLoadingConfirm(true);
       const payment = await utils.call(
@@ -47,7 +51,7 @@ function Keysend(props: Props) {
         {
           origin: {
             ...origin,
-            name: getRecipient(),
+            name: pubkey,
           },
         }
       );
@@ -74,10 +78,6 @@ function Keysend(props: Props) {
     if (!props.origin) {
       navigate(-1);
     }
-  }
-
-  function getRecipient() {
-    return searchParams.get("destination");
   }
 
   function renderAmount() {
@@ -122,6 +122,7 @@ function Keysend(props: Props) {
         <Input
           type="text"
           placeholder="optional"
+          value={comment}
           onChange={(e) => {
             setComment(e.target.value);
           }}
@@ -132,7 +133,7 @@ function Keysend(props: Props) {
 
   function elements() {
     const elements = [];
-    elements.push(["Send payment to", getRecipient()]);
+    elements.push(["Send payment to", pubkey]);
     elements.push(["Amount (Satoshi)", renderAmount()]);
     elements.push(["Comment", renderComment()]);
     return elements;

--- a/src/app/screens/Keysend.tsx
+++ b/src/app/screens/Keysend.tsx
@@ -1,22 +1,21 @@
-import { Fragment, useState, MouseEvent } from "react";
+import { Fragment, useState, MouseEvent, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { Transition } from "@headlessui/react";
 
-import { LNURLPaymentSuccessAction } from "../../types";
+import { LNURLPaymentSuccessAction, OriginData } from "../../types";
 import utils from "../../common/lib/utils";
 import getOriginData from "../../extension/content-script/originData";
 import { useAuth } from "../context/AuthContext";
+import msg from "../../common/lib/msg";
+import Checkbox from "../components/Form/Checkbox";
+import TextField from "../components/Form/TextField";
 
 import Button from "../components/Button";
 import Input from "../components/Form/Input";
 import PublisherCard from "../components/PublisherCard";
 
-type Origin = {
-  name: string;
-  icon: string;
-};
-
 type Props = {
-  origin?: Origin;
+  origin?: OriginData;
   destination?: string;
   comment?: string;
   valueSat?: string;
@@ -26,16 +25,21 @@ function Keysend(props: Props) {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const auth = useAuth();
+  const [rememberMe, setRememberMe] = useState(false);
   const [origin] = useState(
     props.origin ||
       (searchParams.get("origin") &&
         JSON.parse(searchParams.get("origin") as string)) ||
       getOriginData()
   );
+  const originRef = useRef(props.origin || getOriginData());
   const [comment, setComment] = useState(props.comment || "");
-  const [valueSat, setValueSat] = useState(props.valueSat || "");
-  const [pubkey] = useState(
+  const [amount, setAmount] = useState(props.valueSat || "");
+  const [destination] = useState(
     props.destination || searchParams.get("destination")
+  );
+  const [budget, setBudget] = useState(
+    ((parseInt(amount) || 0) * 10).toString()
   );
   const [loadingConfirm, setLoadingConfirm] = useState(false);
   const [successAction, setSuccessAction] = useState<
@@ -43,15 +47,18 @@ function Keysend(props: Props) {
   >();
 
   async function confirm() {
+    if (rememberMe && budget) {
+      await saveBudget();
+    }
     try {
       setLoadingConfirm(true);
       const payment = await utils.call(
         "sendPaymentKeySend",
-        { pubkey, valueSat, comment },
+        { destination, amount, comment },
         {
           origin: {
             ...origin,
-            name: pubkey,
+            name: destination,
           },
         }
       );
@@ -87,29 +94,29 @@ function Keysend(props: Props) {
           type="number"
           min={+0 / 1000}
           max={+1000000 / 1000}
-          value={valueSat}
-          onChange={(e) => setValueSat(e.target.value)}
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
         />
         <div className="flex space-x-1.5 mt-2">
           <Button
             fullWidth
             label="100 sat⚡"
-            onClick={() => setValueSat("100")}
+            onClick={() => setAmount("100")}
           />
           <Button
             fullWidth
             label="1K sat⚡"
-            onClick={() => setValueSat("1000")}
+            onClick={() => setAmount("1000")}
           />
           <Button
             fullWidth
             label="5K sat⚡"
-            onClick={() => setValueSat("5000")}
+            onClick={() => setAmount("5000")}
           />
           <Button
             fullWidth
             label="10K sat⚡"
-            onClick={() => setValueSat("10000")}
+            onClick={() => setAmount("10000")}
           />
         </div>
       </div>
@@ -133,10 +140,19 @@ function Keysend(props: Props) {
 
   function elements() {
     const elements = [];
-    elements.push(["Send payment to", pubkey]);
+    elements.push(["Send payment to", destination]);
     elements.push(["Amount (Satoshi)", renderAmount()]);
     elements.push(["Comment", renderComment()]);
     return elements;
+  }
+  function saveBudget() {
+    if (!budget) return;
+    return msg.request("addAllowance", {
+      totalBudget: parseInt(budget),
+      host: originRef.current.host,
+      name: originRef.current.name,
+      imageURL: originRef.current.icon,
+    });
   }
 
   function renderSuccessAction() {
@@ -214,8 +230,51 @@ function Keysend(props: Props) {
                   fullWidth
                   primary
                   loading={loadingConfirm}
-                  disabled={loadingConfirm || !valueSat}
+                  disabled={loadingConfirm || !amount}
                 />
+              </div>
+              <div className="mb-8">
+                <div className="flex items-center">
+                  <Checkbox
+                    id="remember_me"
+                    name="remember_me"
+                    checked={rememberMe}
+                    onChange={(event) => {
+                      setRememberMe(event.target.checked);
+                    }}
+                  />
+                  <label
+                    htmlFor="remember_me"
+                    className="ml-2 block text-sm text-gray-900 font-medium dark:text-white"
+                  >
+                    Remember and set a budget
+                  </label>
+                </div>
+
+                <Transition
+                  show={rememberMe}
+                  enter="transition duration-100 ease-out"
+                  enterFrom="scale-95 opacity-0"
+                  enterTo="scale-100 opacity-100"
+                  leave="transition duration-75 ease-out"
+                  leaveFrom="scale-100 opacity-100"
+                  leaveTo="scale-95 opacity-0"
+                >
+                  <p className="mt-4 mb-3 text-gray-500 text-sm">
+                    You may set a balance to not be asked for confirmation on
+                    payments until it is exhausted.
+                  </p>
+                  <div>
+                    <TextField
+                      id="budget"
+                      label="Budget"
+                      placeholder="sat"
+                      value={budget}
+                      type="number"
+                      onChange={(event) => setBudget(event.target.value)}
+                    />
+                  </div>
+                </Transition>
               </div>
 
               <p className="mb-3 underline text-sm text-gray-300">

--- a/src/app/screens/Keysend.tsx
+++ b/src/app/screens/Keysend.tsx
@@ -1,0 +1,241 @@
+import { Fragment, useState, MouseEvent } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { LNURLPaymentSuccessAction } from "../../types";
+import utils from "../../common/lib/utils";
+import getOriginData from "../../extension/content-script/originData";
+import { useAuth } from "../context/AuthContext";
+
+import Button from "../components/Button";
+import Input from "../components/Form/Input";
+import PublisherCard from "../components/PublisherCard";
+
+type Origin = {
+  name: string;
+  icon: string;
+};
+
+type Props = {
+  origin?: Origin;
+};
+
+function Keysend(props: Props) {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const auth = useAuth();
+  const [origin] = useState(
+    props.origin ||
+      (searchParams.get("origin") &&
+        JSON.parse(searchParams.get("origin") as string)) ||
+      getOriginData()
+  );
+  const [comment, setComment] = useState("");
+  const [valueSat, setValueSat] = useState("");
+  const [loadingConfirm, setLoadingConfirm] = useState(false);
+  const [successAction, setSuccessAction] = useState<
+    LNURLPaymentSuccessAction | undefined
+  >();
+
+  async function confirm() {
+    const pubkey = searchParams.get("destination");
+
+    try {
+      setLoadingConfirm(true);
+      const payment = await utils.call(
+        "sendPaymentKeySend",
+        { pubkey, valueSat, comment },
+        {
+          origin: {
+            ...origin,
+            name: getRecipient(),
+          },
+        }
+      );
+      console.log(payment);
+
+      setSuccessAction({
+        tag: "message",
+        message: `Keysend paid! Preimage: ${payment.preimage}`,
+      });
+
+      auth.fetchAccountInfo(); // Update balance.
+    } catch (e) {
+      console.log(e);
+      if (e instanceof Error) {
+        alert(`Error: ${e.message}`);
+      }
+    } finally {
+      setLoadingConfirm(false);
+    }
+  }
+
+  function reject(e: MouseEvent) {
+    e.preventDefault();
+    if (!props.origin) {
+      navigate(-1);
+    }
+  }
+
+  function getRecipient() {
+    return searchParams.get("destination");
+  }
+
+  function renderAmount() {
+    return (
+      <div className="mt-1 flex flex-col">
+        <Input
+          type="number"
+          min={+0 / 1000}
+          max={+1000000 / 1000}
+          value={valueSat}
+          onChange={(e) => setValueSat(e.target.value)}
+        />
+        <div className="flex space-x-1.5 mt-2">
+          <Button
+            fullWidth
+            label="100 sat⚡"
+            onClick={() => setValueSat("100")}
+          />
+          <Button
+            fullWidth
+            label="1K sat⚡"
+            onClick={() => setValueSat("1000")}
+          />
+          <Button
+            fullWidth
+            label="5K sat⚡"
+            onClick={() => setValueSat("5000")}
+          />
+          <Button
+            fullWidth
+            label="10K sat⚡"
+            onClick={() => setValueSat("10000")}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  function renderComment() {
+    return (
+      <div className="flex flex-col">
+        <Input
+          type="text"
+          placeholder="optional"
+          onChange={(e) => {
+            setComment(e.target.value);
+          }}
+        />
+      </div>
+    );
+  }
+
+  function elements() {
+    const elements = [];
+    elements.push(["Send payment to", getRecipient()]);
+    elements.push(["Amount (Satoshi)", renderAmount()]);
+    elements.push(["Comment", renderComment()]);
+    return elements;
+  }
+
+  function renderSuccessAction() {
+    if (!successAction) return;
+    let descriptionList;
+    if (successAction.tag === "url") {
+      descriptionList = [
+        ["Description", successAction.description],
+        [
+          "Url",
+          <>
+            {successAction.url}
+            <div className="mt-4">
+              <Button
+                onClick={() => {
+                  if (successAction.url) utils.openUrl(successAction.url);
+                }}
+                label="Open"
+                primary
+              />
+            </div>
+          </>,
+        ],
+      ];
+    } else if (successAction.tag === "message") {
+      descriptionList = [["Message", successAction.message]];
+    }
+
+    return (
+      <>
+        <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+          {descriptionList &&
+            descriptionList.map(([dt, dd], i) => (
+              <Fragment key={`dl-item-${i}`}>
+                <dt className="text-sm font-semibold text-gray-500">{dt}</dt>
+                <dd className="text-sm mb-4 dark:text-white">{dd}</dd>
+              </Fragment>
+            ))}
+        </dl>
+        <div className="text-center">
+          <button
+            className="underline text-sm text-gray-500"
+            onClick={() => window.close()}
+          >
+            Close
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div>
+      <PublisherCard
+        title={origin.name}
+        description={origin.description}
+        image={origin.icon}
+      />
+      <div className="p-4 max-w-screen-sm mx-auto">
+        {!successAction ? (
+          <>
+            <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+              {elements().map(([t, d], i) => (
+                <Fragment key={`element-${i}`}>
+                  <dt className="text-sm font-semibold text-gray-500">{t}</dt>
+                  <dd className="text-sm mb-4 dark:text-white">{d}</dd>
+                </Fragment>
+              ))}
+            </dl>
+            <div className="text-center">
+              <div className="mb-5">
+                <Button
+                  onClick={confirm}
+                  label="Confirm"
+                  fullWidth
+                  primary
+                  loading={loadingConfirm}
+                  disabled={loadingConfirm || !valueSat}
+                />
+              </div>
+
+              <p className="mb-3 underline text-sm text-gray-300">
+                Only connect with sites you trust.
+              </p>
+
+              <a
+                className="underline text-sm text-gray-500"
+                href="#"
+                onClick={reject}
+              >
+                Cancel
+              </a>
+            </div>
+          </>
+        ) : (
+          renderSuccessAction()
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Keysend;

--- a/src/app/screens/Send.tsx
+++ b/src/app/screens/Send.tsx
@@ -33,6 +33,8 @@ function Send() {
       if (lnurl) {
         await lnurlLib.getDetails(lnurl); // throws if invalid.
         navigate(`/lnurlPay?lnurl=${lnurl}`);
+      } else if (isPubKey(invoice)) {
+        navigate(`/keysend?destination=${invoice}`);
       } else {
         parsePaymentRequest({ request: invoice }); // throws if invalid.
         navigate(`/confirmPayment?paymentRequest=${invoice}`);
@@ -117,3 +119,9 @@ function Send() {
 }
 
 export default Send;
+function isPubKey(invoice: string) {
+  return (
+    invoice.length == 66 &&
+    (invoice.startsWith("02") || invoice.startsWith("03"))
+  );
+}

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -70,6 +70,11 @@ const utils = {
   stringToUint8Array: (str: string) => {
     return Uint8Array.from(str, (x) => x.charCodeAt(0));
   },
+  genRanHex: (size: number) => {
+    return [...Array(size)]
+      .map(() => Math.floor(Math.random() * 16).toString(16))
+      .join("");
+  },
   publishPaymentNotification: (
     message: Message,
     paymentRequestDetails: PaymentRequestDetails,

--- a/src/extension/background-script/actions/ln/index.js
+++ b/src/extension/background-script/actions/ln/index.js
@@ -6,6 +6,7 @@ import signMessage from "./signMessage";
 import getInfo from "./getInfo";
 import makeInvoice from "./makeInvoice";
 import verifyMessage from "./verifyMessage";
+import sendPaymentKeySend from "./sendPaymentKeySend";
 
 const connectorCall = (method) => {
   return async (message, sender) => {
@@ -37,6 +38,7 @@ export {
   getBalance,
   getTransactions,
   sendPayment,
+  sendPaymentKeySend,
   checkPayment,
   signMessage,
   makeInvoice,

--- a/src/extension/background-script/actions/ln/sendPayment.ts
+++ b/src/extension/background-script/actions/ln/sendPayment.ts
@@ -21,6 +21,10 @@ export default async function sendPayment(message: Message) {
 
   const response = await connector.sendPayment({
     paymentRequest,
+    offer: "",
+    pubkey: "",
+    amount: 0,
+    memo: "",
   });
   utils.publishPaymentNotification(message, paymentRequestDetails, response);
   return response;

--- a/src/extension/background-script/actions/ln/sendPaymentKeySend.ts
+++ b/src/extension/background-script/actions/ln/sendPaymentKeySend.ts
@@ -2,11 +2,12 @@ import PubSub from "pubsub-js";
 
 import { Message } from "../../../../types";
 import state from "../../state";
+import utils from "../../../../common/lib/utils";
 
 export default async function sendPaymentKeySend(message: Message) {
   PubSub.publish(`ln.sendPaymentKeySend.start`, message);
-  const { pubkey, valueSat, comment } = message.args;
-  if (typeof pubkey !== "string" || typeof valueSat !== "string") {
+  const { destination, amount, comment } = message.args;
+  if (typeof destination !== "string" || typeof amount !== "string") {
     return {
       error: "destination or amount missing.",
     };
@@ -17,9 +18,27 @@ export default async function sendPaymentKeySend(message: Message) {
   const response = await connector.sendPaymentKeySend({
     paymentRequest: "",
     offer: "",
-    pubkey: pubkey,
-    amount: parseInt(valueSat),
+    pubkey: destination,
+    amount: parseInt(amount),
     memo: typeof comment == "string" ? comment : "",
   });
+  utils.publishPaymentNotification(
+    message,
+    {
+      cltv_delta: 0,
+      created_at: "",
+      description: comment as string,
+      destination: destination,
+      expires_at: "",
+      features: [],
+      id: "",
+      is_expired: false,
+      mtokens: "",
+      network: "",
+      safe_tokens: 0,
+      tokens: 0,
+    },
+    response
+  );
   return response;
 }

--- a/src/extension/background-script/actions/ln/sendPaymentKeySend.ts
+++ b/src/extension/background-script/actions/ln/sendPaymentKeySend.ts
@@ -1,0 +1,25 @@
+import PubSub from "pubsub-js";
+
+import { Message } from "../../../../types";
+import state from "../../state";
+
+export default async function sendPaymentKeySend(message: Message) {
+  PubSub.publish(`ln.sendPaymentKeySend.start`, message);
+  const { pubkey, valueSat, comment } = message.args;
+  if (typeof pubkey !== "string" || typeof valueSat !== "string") {
+    return {
+      error: "destination or amount missing.",
+    };
+  }
+
+  const connector = await state.getState().getConnector();
+
+  const response = await connector.sendPaymentKeySend({
+    paymentRequest: "",
+    offer: "",
+    pubkey: pubkey,
+    amount: parseInt(valueSat),
+    memo: typeof comment == "string" ? comment : "",
+  });
+  return response;
+}

--- a/src/extension/background-script/actions/lnurl/index.ts
+++ b/src/extension/background-script/actions/lnurl/index.ts
@@ -212,6 +212,10 @@ export async function lnurlPay(message: Message) {
 
   const response = await connector.sendPayment({
     paymentRequest,
+    offer: "",
+    pubkey: "",
+    amount: 0,
+    memo: "",
   });
   utils.publishPaymentNotification(message, paymentRequestDetails, response);
   return response;

--- a/src/extension/background-script/actions/webln/index.ts
+++ b/src/extension/background-script/actions/webln/index.ts
@@ -1,4 +1,5 @@
-import sendPaymentOrPrompt from "./sendPaymentOrPrompt";
+import { sendPaymentOrPrompt } from "./sendPaymentOrPrompt";
+import keysendOrPrompt from "./keysendOrPrompt";
 import signMessageOrPrompt from "./signMessageOrPrompt";
 
-export { sendPaymentOrPrompt, signMessageOrPrompt };
+export { sendPaymentOrPrompt, keysendOrPrompt, signMessageOrPrompt };

--- a/src/extension/background-script/actions/webln/keysendOrPrompt.ts
+++ b/src/extension/background-script/actions/webln/keysendOrPrompt.ts
@@ -1,0 +1,24 @@
+import { Message } from "../../../../types";
+import {
+  checkAllowance,
+  sendPaymentWithAllowance,
+  payWithPrompt,
+} from "./sendPaymentOrPrompt";
+
+const keysendOrPrompt = async (message: Message) => {
+  const destination = message.args.destination;
+  const amount = message.args.amount;
+  if (typeof destination !== "string" || typeof amount !== "string") {
+    return {
+      error: "Destination or amount missing.",
+    };
+  }
+
+  if (await checkAllowance(message.origin.host, parseInt(amount))) {
+    return sendPaymentWithAllowance(message, true);
+  } else {
+    return payWithPrompt(message, "keysend");
+  }
+};
+
+export default keysendOrPrompt;

--- a/src/extension/background-script/connectors/connector.interface.ts
+++ b/src/extension/background-script/connectors/connector.interface.ts
@@ -43,6 +43,10 @@ export type SendPaymentResponse =
 
 export interface SendPaymentArgs {
   paymentRequest: string;
+  offer: string;
+  pubkey: string;
+  amount: number;
+  memo: string;
 }
 
 export interface CheckPaymentArgs {
@@ -88,6 +92,7 @@ export default interface Connector {
   getBalance(): Promise<GetBalanceResponse>;
   makeInvoice(args: MakeInvoiceArgs): Promise<MakeInvoiceResponse>;
   sendPayment(args: SendPaymentArgs): Promise<SendPaymentResponse>;
+  sendPaymentKeySend(args: SendPaymentArgs): Promise<SendPaymentResponse>;
   checkPayment(args: CheckPaymentArgs): Promise<CheckPaymentResponse>;
   signMessage(args: SignMessageArgs): Promise<SignMessageResponse>;
   verifyMessage(args: VerifyMessageArgs): Promise<VerifyMessageResponse>;

--- a/src/extension/background-script/connectors/eclair.ts
+++ b/src/extension/background-script/connectors/eclair.ts
@@ -92,6 +92,11 @@ class Eclair implements Connector {
     };
   }
 
+  async sendPaymentKeySend(
+    args: SendPaymentArgs
+  ): Promise<SendPaymentResponse> {
+    throw new Error("not supported");
+  }
   async checkPayment(args: CheckPaymentArgs): Promise<CheckPaymentResponse> {
     const data = await this.request("/getreceivedinfo", {
       paymentHash: args.paymentHash,

--- a/src/extension/background-script/connectors/lnbits.ts
+++ b/src/extension/background-script/connectors/lnbits.ts
@@ -99,7 +99,11 @@ class LnBits implements Connector {
         return { error: e.message };
       });
   }
-
+  async sendPaymentKeySend(
+    args: SendPaymentArgs
+  ): Promise<SendPaymentResponse> {
+    throw new Error("not supported");
+  }
   async checkPayment(args: CheckPaymentArgs): Promise<CheckPaymentResponse> {
     const data = await this.request(
       "GET",

--- a/src/extension/background-script/connectors/lnd.ts
+++ b/src/extension/background-script/connectors/lnd.ts
@@ -81,7 +81,11 @@ class Lnd implements Connector {
       };
     });
   }
-
+  async sendPaymentKeySend(
+    args: SendPaymentArgs
+  ): Promise<SendPaymentResponse> {
+    throw new Error("not supported");
+  }
   async checkPayment(args: CheckPaymentArgs): Promise<CheckPaymentResponse> {
     const data = await this.request<{ settled: boolean }>(
       "GET",

--- a/src/extension/background-script/connectors/lndhub.ts
+++ b/src/extension/background-script/connectors/lndhub.ts
@@ -135,6 +135,60 @@ export default class LndHub implements Connector {
       },
     };
   }
+  async sendPaymentKeySend(
+    args: SendPaymentArgs
+  ): Promise<SendPaymentResponse> {
+    const data = await this.request<{
+      error: string;
+      message: string;
+      payment_error?: string;
+      payment_hash:
+        | {
+            type: string;
+            data: ArrayBuffer;
+          }
+        | string;
+      payment_preimage:
+        | {
+            type: string;
+            data: ArrayBuffer;
+          }
+        | string;
+      payment_route: { total_amt: number; total_fees: number };
+    }>("POST", "/keysend", {
+      destination: args.pubkey,
+      amount: args.amount,
+      memo: args.memo,
+    });
+    if (data.error) {
+      return { error: data.message };
+    }
+    if (data.payment_error) {
+      return { error: data.payment_error };
+    }
+    if (
+      typeof data.payment_hash === "object" &&
+      data.payment_hash.type === "Buffer"
+    ) {
+      data.payment_hash = Buffer.from(data.payment_hash.data).toString("hex");
+    }
+    if (
+      typeof data.payment_preimage === "object" &&
+      data.payment_preimage.type === "Buffer"
+    ) {
+      data.payment_preimage = Buffer.from(data.payment_preimage.data).toString(
+        "hex"
+      );
+    }
+
+    return {
+      data: {
+        preimage: data.payment_preimage as string,
+        paymentHash: data.payment_hash as string,
+        route: data.payment_route,
+      },
+    };
+  }
 
   async checkPayment(args: CheckPaymentArgs): Promise<CheckPaymentResponse> {
     const data = await this.request<{ paid: boolean }>(

--- a/src/extension/background-script/events/index.js
+++ b/src/extension/background-script/events/index.js
@@ -14,6 +14,8 @@ const subscribe = () => {
 
   PubSub.subscribe("ln.sendPayment.success", persistSuccessfullPayment);
   PubSub.subscribe("ln.sendPayment.success", updateAllowance);
+  PubSub.subscribe("ln.keysend.success", persistSuccessfullPayment);
+  PubSub.subscribe("ln.keysend.success", updateAllowance);
 
   PubSub.subscribe("lnurl.auth.success", lnurlAuthSuccessNotification);
   PubSub.subscribe("lnurl.auth.failed", lnurlAuthFailedNotification);

--- a/src/extension/background-script/router.js
+++ b/src/extension/background-script/router.js
@@ -34,6 +34,7 @@ const routes = {
   sendPaymentOrPrompt: webln.sendPaymentOrPrompt,
   signMessageOrPrompt: webln.signMessageOrPrompt,
   sendPayment: ln.sendPayment,
+  sendPaymentKeySend: ln.sendPaymentKeySend,
   checkPayment: ln.checkPayment,
   signMessage: ln.signMessage,
   verifyMessage: ln.verifyMessage,

--- a/src/extension/background-script/router.js
+++ b/src/extension/background-script/router.js
@@ -32,6 +32,7 @@ const routes = {
   lnurl,
   lnurlPay,
   sendPaymentOrPrompt: webln.sendPaymentOrPrompt,
+  keysendOrPrompt: webln.keysendOrPrompt,
   signMessageOrPrompt: webln.signMessageOrPrompt,
   sendPayment: ln.sendPayment,
   sendPaymentKeySend: ln.sendPaymentKeySend,

--- a/src/extension/ln/webln/index.ts
+++ b/src/extension/ln/webln/index.ts
@@ -60,6 +60,13 @@ export default class WebLNProvider {
     return this.execute("sendPaymentOrPrompt", { paymentRequest });
   }
 
+  keysend(destination: string, amount: number, memo: string) {
+    if (!this.enabled) {
+      throw new Error("Provider must be enabled before calling sendPayment");
+    }
+    return this.execute("keysendOrPrompt", { destination, amount, memo });
+  }
+
   makeInvoice(args: string | number | RequestInvoiceArgs) {
     if (!this.enabled) {
       throw new Error("Provider must be enabled before calling makeInvoice");

--- a/src/extension/ln/webln/index.ts
+++ b/src/extension/ln/webln/index.ts
@@ -60,11 +60,11 @@ export default class WebLNProvider {
     return this.execute("sendPaymentOrPrompt", { paymentRequest });
   }
 
-  keysend(destination: string, amount: number, memo: string) {
+  keysend(destination: string, amount: number, comment: string) {
     if (!this.enabled) {
       throw new Error("Provider must be enabled before calling sendPayment");
     }
-    return this.execute("keysendOrPrompt", { destination, amount, memo });
+    return this.execute("keysendOrPrompt", { destination, amount, comment });
   }
 
   makeInvoice(args: string | number | RequestInvoiceArgs) {

--- a/src/extension/ln/webln/index.ts
+++ b/src/extension/ln/webln/index.ts
@@ -6,6 +6,12 @@ type RequestInvoiceArgs = {
   defaultMemo?: string;
 };
 
+type KeysendArgs = {
+  destination: string;
+  comment: string;
+  amount: string;
+};
+
 export default class WebLNProvider {
   enabled: boolean;
   isEnabled: boolean;
@@ -60,11 +66,11 @@ export default class WebLNProvider {
     return this.execute("sendPaymentOrPrompt", { paymentRequest });
   }
 
-  keysend(destination: string, amount: number, comment: string) {
+  keysend(args: KeysendArgs) {
     if (!this.enabled) {
       throw new Error("Provider must be enabled before calling sendPayment");
     }
-    return this.execute("keysendOrPrompt", { destination, amount, comment });
+    return this.execute("keysendOrPrompt", args);
   }
 
   makeInvoice(args: string | number | RequestInvoiceArgs) {


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #671 
#### Type of change

- [x] New feature (non-breaking change which adds functionality)


#### Describe the changes you have made in this PR -
- Added a new keysend screen that is mostly copied over from the LNurlPay screen. This screen is triggered either by pasting in a pubkey in the send box (by checking for length and starting characters), or by a `webln.keysend` call.
- Added more fields to the `sendPaymentArgs` to allow for keysend and offer payments (later).
- Implements the keysend method for the `LND` and `LNDhub` connectors.
- Adds a webLN keysend function.
#### Screenshots of the changes (If any) -
![Schermafbeelding 2022-03-16 om 08 55 52](https://user-images.githubusercontent.com/33457577/158544112-baefac15-3535-4317-b557-de0007808e18.png)
#### How Has This Been Tested?
- webLN tested on https://amboss.space - check out the keysend billboard. Tested with lndhub.go backend.
- by pasting in random pubkeys and doing payments. Get a pubkey from lnd-2 on rtl.regtest.getalby.com - connect to alby-simnet-lnd-1 in the extension - make payment. Check status on RTL.

![Schermafbeelding 2022-03-16 om 09 05 57](https://user-images.githubusercontent.com/33457577/158544436-3415a536-8c14-42fc-9f35-537d629cdcc2.png)

I don't have any tests and also the code could use some refactoring since I have copy-pasted quite a bit. I think it would be more opportune if someone else picks this up.


#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation (If Any)
