### PR TITLE
feat: render publisher card with tipping button

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -75,11 +75,56 @@ function Home() {
     };
   }, []);
 
+  function renderPublisherCard() {
+    let title, description, image;
+    if (allowance) {
+      title = allowance.name;
+      image = allowance.imageURL;
+    } else if (lnData.length > 0) {
+      title = lnData[0].name;
+      description = lnData[0].description;
+      image = lnData[0].icon;
+    } else {
+      return;
+    }
+    return (
+      <PublisherCard title={title} description={description} image={image}>
+        {lnData.length > 0 && (
+          <Button
+            onClick={async () => {
+              try {
+                setLoadingSendSats(true);
+                const origin = {
+                  external: true,
+                  name: lnData[0].name,
+                  host: lnData[0].host,
+                  description: lnData[0].description,
+                  icon: lnData[0].icon,
+                };
+                navigate(
+                  `/lnurlPay?lnurl=${
+                    lnData[0].recipient
+                  }&origin=${encodeURIComponent(JSON.stringify(origin))}`
+                );
+              } catch (e) {
+                if (e instanceof Error) alert(e.message);
+              } finally {
+                setLoadingSendSats(false);
+              }
+            }}
+            label="⚡️ Send Satoshis ⚡️"
+            primary
+            loading={loadingSendSats}
+          />
+        )}
+      </PublisherCard>
+    );
+  }
+
   function renderAllowanceView() {
     if (!allowance) return;
     return (
       <>
-        <PublisherCard title={allowance.name} image={allowance.imageURL} />
         <div className="px-4 pb-5">
           <div className="flex justify-between items-center py-3">
             {+allowance.totalBudget > 0 ? (
@@ -235,40 +280,7 @@ function Home() {
 
   return (
     <div>
-      {!allowance && lnData.length > 0 && (
-        <PublisherCard
-          title={lnData[0].name}
-          description={lnData[0].description}
-          image={lnData[0].icon}
-        >
-          <Button
-            onClick={async () => {
-              try {
-                setLoadingSendSats(true);
-                const origin = {
-                  external: true,
-                  name: lnData[0].name,
-                  host: lnData[0].host,
-                  description: lnData[0].description,
-                  icon: lnData[0].icon,
-                };
-                navigate(
-                  `/lnurlPay?lnurl=${
-                    lnData[0].recipient
-                  }&origin=${encodeURIComponent(JSON.stringify(origin))}`
-                );
-              } catch (e) {
-                if (e instanceof Error) alert(e.message);
-              } finally {
-                setLoadingSendSats(false);
-              }
-            }}
-            label="⚡️ Send Satoshis ⚡️"
-            primary
-            loading={loadingSendSats}
-          />
-        </PublisherCard>
-      )}
+      {renderPublisherCard()}
       {allowance ? renderAllowanceView() : renderDefaultView()}
     </div>
   );


### PR DESCRIPTION
So far if an allowance was found we did not show the tipping button.
This means even though a website for example had the lightning meta tag the tipping button
was not shown IF the website also uses webln.

#### Link this PR to an issue
Fixes #607 
Ref #619 

#### Type of change

-  Bug fix (non-breaking change which fixes an issue)

#### Screenshots of the changes (If any) -
<img width="478" alt="image" src="https://user-images.githubusercontent.com/318/158987670-9ff8455a-f71e-4d7b-bb82-19650a9f5ad9.png">


#### How Has This Been Tested?

* Go to https://nodesignal.space/crew/
* Send a tip by clicking on one of the lightning addresses (this calls webln.enable() and saves an allowance)
* Go to https://nodesignal.space/ and check if the tipping button is shown in the extension popup

