### PR TITLE
fix: react modals should get focus after opening

### DIFF
--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -24,9 +24,12 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
 
   function openModal() {
     setBudget(allowance.totalBudget.toString());
-    // HACK!
-    // @headless-ui/menu restores focus after closing a menu, to the button that opened it.
-    // By slightly delaying opening the modal, react-modal's focus management won't be overruled.
+    /**
+     * @HACK
+     * @headless-ui/menu restores focus after closing a menu, to the button that opened it.
+     * By slightly delaying opening the modal, react-modal's focus management won't be overruled.
+     * {@link https://github.com/tailwindlabs/headlessui/issues/259}
+     */
     setTimeout(() => {
       setIsOpen(true);
     }, 50);

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -24,7 +24,12 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
 
   function openModal() {
     setBudget(allowance.totalBudget.toString());
-    setIsOpen(true);
+    // HACK!
+    // @headless-ui/menu restores focus after closing a menu, to the button that opened it.
+    // By slightly delaying opening the modal, react-modal's focus management won't be overruled.
+    setTimeout(() => {
+      setIsOpen(true);
+    }, 50);
   }
 
   function closeModal() {

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -115,7 +115,12 @@ function AccountsScreen() {
                           onClick={() => {
                             setCurrentAccountId(accountId);
                             setNewAccountName(account.name);
-                            setModalIsOpen(true);
+                            // HACK!
+                            // @headless-ui/menu restores focus after closing a menu, to the button that opened it.
+                            // By slightly delaying opening the modal, react-modal's focus management won't be overruled.
+                            setTimeout(() => {
+                              setModalIsOpen(true);
+                            }, 50);
                           }}
                         >
                           Edit

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -115,9 +115,12 @@ function AccountsScreen() {
                           onClick={() => {
                             setCurrentAccountId(accountId);
                             setNewAccountName(account.name);
-                            // HACK!
-                            // @headless-ui/menu restores focus after closing a menu, to the button that opened it.
-                            // By slightly delaying opening the modal, react-modal's focus management won't be overruled.
+                            /**
+                             * @HACK
+                             * @headless-ui/menu restores focus after closing a menu, to the button that opened it.
+                             * By slightly delaying opening the modal, react-modal's focus management won't be overruled.
+                             * {@link https://github.com/tailwindlabs/headlessui/issues/259}
+                             */
                             setTimeout(() => {
                               setModalIsOpen(true);
                             }, 50);


### PR DESCRIPTION
Modals triggered from a `<Menu />` currently don't receive focus.
This is because @headless-ui/menu restores focus after closing a menu, to the button that opened it.
There is currently no way to change this behavior so a hack is needed.

More info + added comment: https://github.com/tailwindlabs/headlessui/issues/259

Thanks @escapedcat for noticing it.