### PR TITLE
refactor: use normal list instead of checked list in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 #### Link this PR to an issue
-Fixes #ISSUE-NUMBER (eg. Fixes #147)
+Fixes #ISSUE-NUMBER
 
-#### Type of change
+#### Type of change (Remove other not matching type)
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Documentation update
 
 #### Describe the changes you have made in this PR -
 
@@ -16,12 +16,8 @@ Fixes #ISSUE-NUMBER (eg. Fixes #147)
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
-- [ ] Test A
-- [ ] Test B
-
-
 #### Checklist:
 
 - [ ] My code follows the style guidelines of this project and performed a self-review of my own code
 - [ ] New and existing tests pass locally with my changes
-- [ ] I have made corresponding changes to the documentation (If Any)
+- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)


### PR DESCRIPTION


#### Link this PR to an issue
Fixes #702 

#### Describe the changes you have made in this PR -
1. remove example of linking of the issue (so that PR which is not linked with any issue, doesn't get linked to the issue number shown in the example)
2. use a normal list instead of a checked list
3. for the checklist section still using a checklist to enforce certain tasks
4. for checklist section using double spaces inside square brackets so that only checked  item appear in pull request overview (


#### Checklist:

- [X] My code follows the style guidelines of this project and performed a self-review of my own code
- [X] New and existing tests pass locally with my changes
