### PR TITLE
fix: add feedback when email already exists

### DIFF
--- a/src/app/screens/Onboard/NewWallet/index.tsx
+++ b/src/app/screens/Onboard/NewWallet/index.tsx
@@ -38,6 +38,8 @@ export default function NewWallet() {
         res.json().then((data) => {
           if (data.lndhub?.login && data.lndhub?.password && data.lndhub?.url) {
             setLndHubData(data.lndhub);
+          } else if (data.email[0] === "has already been taken") {
+            alert("Email already in use.");
           } else {
             console.error(data);
             alert(


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #703 (#650)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Describe the changes you have made in this PR -
Added check for email already in use


#### Screenshots of the changes (If any) -
![Screenshot from 2022-03-19 18-55-22](https://user-images.githubusercontent.com/64399555/159123272-c109c837-29c8-4ca1-a90d-57d3a5a33c68.png)

#### How Has This Been Tested?

Used the same email twice, used to get the `failed` message previously. After the code change, it shows the above message as displayed in the screenshot.


#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the documentation (If Any)
