### PR TITLE
chore: switch outdir to avoid allowjs overwrite warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    "outDir": "built",                              /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
@@ -69,5 +69,6 @@
     "skipLibCheck": true,                           /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src", "jest.setup.ts", "jest.config.ts", ]
+  "include": ["src", "jest.setup.ts", "jest.config.ts", ],
+  "exclude": ["built"]
 }


### PR DESCRIPTION
#### Type of change

- Config fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR

Update tsconfig to avoid warning  
Thanks @pavanjoshi914 for noticing

#### Screenshots of the changes 

![image](https://user-images.githubusercontent.com/1016218/159148996-52f04507-f426-4c52-b27a-48e92ee80a21.png)

#### How Has This Been Tested?

`yarn dev` & `yarn build` still working fine

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the documentation (If Any)
