### PR TITLE
feat: AccountMenu in prompts

### DIFF
--- a/src/app/components/AccountMenu/index.test.tsx
+++ b/src/app/components/AccountMenu/index.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+
+import * as AccountsContext from "../../context/AccountsContext";
+import AccountMenu from ".";
+import type { Accounts } from "../../../types";
+
+const mockAccounts: Accounts = {
+  "1": { id: "1", connector: "lnd", config: "", name: "LND account" },
+  "2": { id: "2", connector: "galoy", config: "", name: "Galoy account" },
+};
+
+jest.spyOn(AccountsContext, "useAccounts").mockReturnValue({
+  accounts: mockAccounts,
+  getAccounts: jest.fn(),
+});
+
+describe("AccountMenu", () => {
+  test("renders the toggle button", async () => {
+    render(
+      <BrowserRouter>
+        <AccountMenu />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Toggle Dropdown");
+  });
+
+  test("displays accounts and options", async () => {
+    render(
+      <BrowserRouter>
+        <AccountMenu />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByText("Toggle Dropdown"));
+
+    await waitFor(() => screen.getByText("Switch account"));
+
+    expect(screen.getByText("LND account")).toBeInTheDocument();
+    expect(screen.getByText("Galoy account")).toBeInTheDocument();
+    expect(screen.getByText("Add a new account")).toBeInTheDocument();
+    expect(screen.getByText("Accounts")).toBeInTheDocument();
+  });
+
+  test("displays accounts without options", async () => {
+    render(
+      <BrowserRouter>
+        <AccountMenu showOptions={false} />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByText("Toggle Dropdown"));
+
+    expect(screen.getByText("LND account")).toBeInTheDocument();
+    expect(screen.getByText("Galoy account")).toBeInTheDocument();
+    expect(screen.queryByText("Add a new account")).not.toBeInTheDocument();
+    expect(screen.queryByText("Accounts")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -14,7 +14,11 @@ import { useAccounts } from "../../context/AccountsContext";
 import Badge from "../Badge";
 import Menu from "../Menu";
 
-function AccountMenu() {
+type Props = {
+  advanced?: boolean;
+};
+
+function AccountMenu({ advanced = true }: Props) {
   const auth = useAuth();
   const navigate = useNavigate();
   const { accounts, getAccounts } = useAccounts();
@@ -70,23 +74,27 @@ function AccountMenu() {
             </Menu.ItemButton>
           );
         })}
-        <Menu.Divider />
-        <Menu.ItemButton
-          onClick={() => {
-            openOptions("accounts/new");
-          }}
-        >
-          <PlusIcon className="h-5 w-5 mr-2 text-gray-500" />
-          Add a new account
-        </Menu.ItemButton>
-        <Menu.ItemButton
-          onClick={() => {
-            openOptions("accounts");
-          }}
-        >
-          <AddressBookIcon className="h-5 w-5 mr-2 text-gray-500" />
-          Accounts
-        </Menu.ItemButton>
+        {advanced && (
+          <>
+            <Menu.Divider />
+            <Menu.ItemButton
+              onClick={() => {
+                openOptions("accounts/new");
+              }}
+            >
+              <PlusIcon className="h-5 w-5 mr-2 text-gray-500" />
+              Add a new account
+            </Menu.ItemButton>
+            <Menu.ItemButton
+              onClick={() => {
+                openOptions("accounts");
+              }}
+            >
+              <AddressBookIcon className="h-5 w-5 mr-2 text-gray-500" />
+              Accounts
+            </Menu.ItemButton>
+          </>
+        )}
       </Menu.List>
     </Menu>
   );

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -14,7 +14,7 @@ import { useAccounts } from "../../context/AccountsContext";
 import Badge from "../Badge";
 import Menu from "../Menu";
 
-type Props = {
+export type Props = {
   showOptions?: boolean;
 };
 
@@ -51,6 +51,7 @@ function AccountMenu({ showOptions = true }: Props) {
     <Menu as="div">
       <Menu.Button className="h-full px-2 rounded-r-md hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors duration-200">
         <CaretDownIcon className="h-4 w-4 dark:text-white" />
+        <span className="sr-only">Toggle Dropdown</span>
       </Menu.Button>
       <Menu.List position="left">
         <Menu.Subheader>Switch account</Menu.Subheader>

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -15,10 +15,10 @@ import Badge from "../Badge";
 import Menu from "../Menu";
 
 type Props = {
-  advanced?: boolean;
+  showOptions?: boolean;
 };
 
-function AccountMenu({ advanced = true }: Props) {
+function AccountMenu({ showOptions = true }: Props) {
   const auth = useAuth();
   const navigate = useNavigate();
   const { accounts, getAccounts } = useAccounts();
@@ -74,7 +74,7 @@ function AccountMenu({ advanced = true }: Props) {
             </Menu.ItemButton>
           );
         })}
-        {advanced && (
+        {showOptions && (
           <>
             <Menu.Divider />
             <Menu.ItemButton

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -7,14 +7,16 @@ import UserMenu from "../UserMenu";
 type Props = {
   title: string;
   subtitle: string;
-  advanced?: boolean;
+  showAccountMenuOptions?: boolean;
+  showUserMenu?: boolean;
   children?: React.ReactNode;
 };
 
 export default function Navbar({
   title,
   subtitle,
-  advanced = true,
+  showAccountMenuOptions = true,
+  showUserMenu = true,
   children,
 }: Props) {
   return (
@@ -36,7 +38,7 @@ export default function Navbar({
               {subtitle || <Skeleton />}
             </div>
           </div>
-          <AccountMenu advanced={advanced} />
+          <AccountMenu showOptions={showAccountMenuOptions} />
         </div>
       </div>
       {children && (
@@ -44,7 +46,7 @@ export default function Navbar({
           <nav className="flex space-x-8">{children}</nav>
         </div>
       )}
-      {advanced && (
+      {showUserMenu && (
         <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
           <UserMenu />
         </div>

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -1,16 +1,22 @@
 import Skeleton from "react-loading-skeleton";
 import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 
-import UserMenu from "../UserMenu";
 import AccountMenu from "../AccountMenu";
+import UserMenu from "../UserMenu";
 
 type Props = {
   title: string;
   subtitle: string;
+  advanced?: boolean;
   children?: React.ReactNode;
 };
 
-export default function Navbar({ title, subtitle, children }: Props) {
+export default function Navbar({
+  title,
+  subtitle,
+  advanced = true,
+  children,
+}: Props) {
   return (
     <div className="px-4 py-2 bg-white flex justify-between items-center border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
       <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
@@ -30,7 +36,7 @@ export default function Navbar({ title, subtitle, children }: Props) {
               {subtitle || <Skeleton />}
             </div>
           </div>
-          <AccountMenu />
+          <AccountMenu advanced={advanced} />
         </div>
       </div>
       {children && (
@@ -38,9 +44,11 @@ export default function Navbar({ title, subtitle, children }: Props) {
           <nav className="flex space-x-8">{children}</nav>
         </div>
       )}
-      <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
-        <UserMenu />
-      </div>
+      {advanced && (
+        <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
+          <UserMenu />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -2,6 +2,7 @@ import { Component } from "react";
 import qs from "query-string";
 import { HashRouter, Outlet, Route, Routes, Navigate } from "react-router-dom";
 
+import { useAuth } from "../../context/AuthContext";
 import type {
   LNURLAuthServiceResponse,
   LNURLPayServiceResponse,
@@ -10,6 +11,7 @@ import type {
   RequestInvoiceArgs,
 } from "../../../types";
 import { AuthProvider } from "../../context/AuthContext";
+import { AccountsProvider } from "../../context/AccountsContext";
 import RequireAuth from "../RequireAuth";
 import Unlock from "../../screens/Unlock";
 import Enable from "../../screens/Enable";
@@ -20,6 +22,7 @@ import LNURLPay from "../../screens/LNURLPay";
 import LNURLAuth from "../../screens/LNURLAuth";
 import LNURLWithdraw from "../../screens/LNURLWithdraw";
 import Keysend from "../../screens/ConfirmKeysend";
+import Navbar from "../../components/Navbar";
 
 class Prompt extends Component<
   Record<string, unknown>,
@@ -44,107 +47,130 @@ class Prompt extends Component<
   render() {
     return (
       <AuthProvider>
-        <HashRouter>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <RequireAuth>
-                  <Outlet />
-                </RequireAuth>
-              }
-            >
+        <AccountsProvider>
+          <HashRouter>
+            <Routes>
               <Route
-                index
-                element={<Navigate to={`/${this.state.type}`} replace />}
-              />
-              <Route
-                path="enable"
-                element={<Enable origin={this.state.origin} />}
-              />
-              <Route
-                path="lnurlAuth"
+                path="/"
                 element={
-                  <LNURLAuth
-                    details={
-                      this.state.args?.lnurlDetails as LNURLAuthServiceResponse
-                    }
-                    origin={this.state.origin}
-                  />
+                  <RequireAuth>
+                    <Layout />
+                  </RequireAuth>
                 }
-              />
-              <Route
-                path="lnurlPay"
-                element={
-                  <LNURLPay
-                    details={
-                      this.state.args?.lnurlDetails as LNURLPayServiceResponse
-                    }
-                    origin={this.state.origin}
-                  />
-                }
-              />
-              <Route
-                path="lnurlWithdraw"
-                element={
-                  <LNURLWithdraw
-                    details={
-                      this.state.args
-                        ?.lnurlDetails as LNURLWithdrawServiceResponse
-                    }
-                    origin={this.state.origin}
-                  />
-                }
-              />
-              <Route
-                path="makeInvoice"
-                element={
-                  <MakeInvoice
-                    invoiceAttributes={
-                      this.state.args.invoiceAttributes as RequestInvoiceArgs
-                    }
-                    origin={this.state.origin}
-                  />
-                }
-              />
-              <Route
-                path="confirmPayment"
-                element={
-                  <ConfirmPayment
-                    paymentRequest={this.state.args?.paymentRequest as string}
-                    origin={this.state.origin}
-                  />
-                }
-              />
-              <Route
-                path="confirmKeysend"
-                element={
-                  <Keysend
-                    destination={this.state.args?.destination as string}
-                    valueSat={this.state.args?.amount as string}
-                    customRecords={
-                      this.state.args?.customRecords as Record<string, string>
-                    }
-                    origin={this.state.origin}
-                  />
-                }
-              />
-              <Route
-                path="confirmSignMessage"
-                element={
-                  <ConfirmSignMessage
-                    message={this.state.args?.message as string}
-                    origin={this.state.origin}
-                  />
-                }
-              />
-            </Route>
-            <Route path="unlock" element={<Unlock />} />
-          </Routes>
-        </HashRouter>
+              >
+                <Route
+                  index
+                  element={<Navigate to={`/${this.state.type}`} replace />}
+                />
+                <Route
+                  path="enable"
+                  element={<Enable origin={this.state.origin} />}
+                />
+                <Route
+                  path="lnurlAuth"
+                  element={
+                    <LNURLAuth
+                      details={
+                        this.state.args
+                          ?.lnurlDetails as LNURLAuthServiceResponse
+                      }
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="lnurlPay"
+                  element={
+                    <LNURLPay
+                      details={
+                        this.state.args?.lnurlDetails as LNURLPayServiceResponse
+                      }
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="lnurlWithdraw"
+                  element={
+                    <LNURLWithdraw
+                      details={
+                        this.state.args
+                          ?.lnurlDetails as LNURLWithdrawServiceResponse
+                      }
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="makeInvoice"
+                  element={
+                    <MakeInvoice
+                      invoiceAttributes={
+                        this.state.args.invoiceAttributes as RequestInvoiceArgs
+                      }
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="confirmPayment"
+                  element={
+                    <ConfirmPayment
+                      paymentRequest={this.state.args?.paymentRequest as string}
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="confirmKeysend"
+                  element={
+                    <Keysend
+                      destination={this.state.args?.destination as string}
+                      valueSat={this.state.args?.amount as string}
+                      customRecords={
+                        this.state.args?.customRecords as Record<string, string>
+                      }
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="confirmSignMessage"
+                  element={
+                    <ConfirmSignMessage
+                      message={this.state.args?.message as string}
+                      origin={this.state.origin}
+                    />
+                  }
+                />
+              </Route>
+              <Route path="unlock" element={<Unlock />} />
+            </Routes>
+          </HashRouter>
+        </AccountsProvider>
       </AuthProvider>
     );
   }
 }
+
+const Layout = () => {
+  const auth = useAuth();
+
+  return (
+    <>
+      <Navbar
+        title={auth.account?.alias || ""}
+        subtitle={
+          typeof auth.account?.balance === "number"
+            ? `${auth.account.balance} sat`
+            : ""
+        }
+        advanced={false}
+      />
+
+      <Outlet />
+    </>
+  );
+};
 
 export default Prompt;

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -165,7 +165,8 @@ const Layout = () => {
             ? `${auth.account.balance} sat`
             : ""
         }
-        advanced={false}
+        showAccountMenuOptions={false}
+        showUserMenu={false}
       />
 
       <Outlet />


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #675

#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
You can now see from the prompt which account is active and also switch your account.
Previously this was unclear.

We now have a more flexible `<Navbar />` that will show an "advanced" version by default. Meaning it will include a user menu and show advanced `<AccountMenu />` options. For the prompt screen I added the improved `<Navbar />` and disabled the advanced prop so it will just show a simplified account menu, that allows you to switch.

<img width="401" alt="Schermafbeelding 2022-03-22 om 09 28 32" src="https://user-images.githubusercontent.com/12894112/159438981-c7041b23-bcf1-4deb-ab56-ae695ef63775.png">
