### PR TITLE
fix: lndhub keysend bugs

### DIFF
--- a/src/extension/background-script/connectors/lndhub.ts
+++ b/src/extension/background-script/connectors/lndhub.ts
@@ -136,11 +136,6 @@ export default class LndHub implements Connector {
     };
   }
   async keysend(args: KeysendArgs): Promise<SendPaymentResponse> {
-    //hex encode the record values
-    const records_hex: Record<string, string> = {};
-    for (const key in args.customRecords) {
-      records_hex[key] = Buffer.from(args.customRecords[key]).toString("hex");
-    }
     const data = await this.request<{
       error: string;
       message: string;
@@ -161,7 +156,7 @@ export default class LndHub implements Connector {
     }>("POST", "/keysend", {
       destination: args.pubkey,
       amount: args.amount,
-      dest_custom_records: records_hex,
+      customRecords: args.customRecords,
     });
     if (data.error) {
       throw new Error(data.message);


### PR DESCRIPTION
This is a slight bug in the LNDhub connector's keysend function because of confusion between LND's / LNDhub.go's API.

[LNDhub API reference](https://github.com/getAlby/lndhub.go/blob/main/controllers/keysend.ctrl.go#L30)
Custom records should not be hex encoded here.

Tested on amboss.space billboard with webLN.