### PR TITLE
fix: prevent switching accounts while in progress

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import {
@@ -18,6 +18,7 @@ function AccountMenu() {
   const auth = useAuth();
   const navigate = useNavigate();
   const { accounts, getAccounts } = useAccounts();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     getAccounts();
@@ -25,11 +26,13 @@ function AccountMenu() {
   }, []);
 
   async function selectAccount(accountId: string) {
+    setLoading(true);
     auth.setAccountId(accountId);
     await utils.call("selectAccount", {
       id: accountId,
     });
-    auth.fetchAccountInfo(accountId);
+    await auth.fetchAccountInfo(accountId);
+    setLoading(false);
   }
 
   function openOptions(path: string) {
@@ -58,6 +61,7 @@ function AccountMenu() {
               onClick={() => {
                 selectAccount(accountId);
               }}
+              disabled={loading}
             >
               <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-500" />
               {account.name}&nbsp;

--- a/src/app/components/Menu/MenuItemButton.tsx
+++ b/src/app/components/Menu/MenuItemButton.tsx
@@ -1,18 +1,24 @@
 import { Menu } from "@headlessui/react";
 
+import { classNames } from "../../utils/index";
+
 type Props = {
   children: React.ReactNode;
+  disabled?: boolean;
   onClick: () => void;
 };
 
-function MenuItemButton({ children, onClick }: Props) {
+function MenuItemButton({ children, disabled = false, onClick }: Props) {
   return (
     <Menu.Item>
       {({ active }) => (
         <button
-          className={`${
-            active ? "bg-gray-100" : ""
-          } flex items-center cursor-pointer text-gray-700 block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:text-white dark:hover:bg-gray-600`}
+          className={classNames(
+            active ? "bg-gray-100" : "",
+            disabled ? "cursor-not-allowed" : "cursor-pointer",
+            "flex items-center text-gray-700 block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:text-white dark:hover:bg-gray-600"
+          )}
+          disabled={disabled}
           onClick={onClick}
         >
           {children}


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)
#### Describe the changes you have made in this PR -

You should not be able to quickly jump between accounts, while it was still fetching a previous account.
This currently leads to bugs, showing the wrong balance for e.g. after fastly switching between different accounts.
