### PR TITLE
fix: default screen shortly rendered before the allowance view

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -23,21 +23,29 @@ dayjs.extend(relativeTime);
 function Home() {
   const [allowance, setAllowance] = useState<Allowance | null>(null);
   const [payments, setPayments] = useState<Transaction[]>([]);
+  const [loadingAllowance, setLoadingAllowance] = useState(true);
   const [loadingPayments, setLoadingPayments] = useState(true);
   const [loadingSendSats, setLoadingSendSats] = useState(false);
   const [lnData, setLnData] = useState<Battery[]>([]);
   const navigate = useNavigate();
 
-  function loadAllowance() {
-    browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+  async function loadAllowance() {
+    try {
+      const tabs = await browser.tabs.query({
+        active: true,
+        currentWindow: true,
+      });
       const [currentTab] = tabs;
       const url = new URL(currentTab.url as string);
-      api.getAllowance(url.host).then((result) => {
-        if (result.enabled) {
-          setAllowance(result);
-        }
-      });
-    });
+      const result = await api.getAllowance(url.host);
+      if (result.enabled) {
+        setAllowance(result);
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoadingAllowance(false);
+    }
   }
 
   function loadPayments() {
@@ -231,6 +239,10 @@ function Home() {
         )}
       </div>
     );
+  }
+
+  if (loadingAllowance) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
Currently, if you are on a website that has an allowance it will shortly render the DefaultView before showing the AllowanceView. Although it's a split second, this looks buggy / messy thus it would be better to wait for the allowance to be loaded (which is really fast).
