### PR TITLE
fix: check description_hash only if defined

### DIFF
--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -106,7 +106,8 @@ const lnurl = {
       console.error();
     }
     switch (true) {
-      case paymentRequestDetails.description_hash !== metadataHash: // LN WALLET Verifies that h tag (description_hash) in provided invoice is a hash of metadata string converted to byte array in UTF-8 encoding
+      case paymentRequestDetails.description_hash &&
+        paymentRequestDetails.description_hash !== metadataHash: // LN WALLET Verifies that h tag (description_hash) in provided invoice is a hash of metadata string converted to byte array in UTF-8 encoding
       case paymentRequestDetails.mtokens !== String(amount): // LN WALLET Verifies that amount in provided invoice equals an amount previously specified by user
       case paymentInfo.successAction &&
         !["url", "message", "aes"].includes(paymentInfo.successAction.tag): // If successAction is not null: LN WALLET makes sure that tag value of is of supported type, aborts a payment otherwise


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #726

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -

Check if the `description_hash` field is defined before checking it's content equals to the manually assembled one.

#### How Has This Been Tested?

See #726. It would be repetitive to write it here again.

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
