### PR TITLE
fix: pre-defined amount buttons text wrapping

### DIFF
--- a/src/app/components/Button/Button.stories.tsx
+++ b/src/app/components/Button/Button.stories.tsx
@@ -14,12 +14,6 @@ export const Disabled = () => (
     <Button label="Button" primary loading disabled />
   </div>
 );
-export const Size = () => (
-  <div className="space-x-3">
-    <Button label="Normal" />
-    <Button label="Compact" compact />
-  </div>
-);
 
 export default {
   title: "Components/Buttons/Button",

--- a/src/app/components/Button/Button.stories.tsx
+++ b/src/app/components/Button/Button.stories.tsx
@@ -14,6 +14,12 @@ export const Disabled = () => (
     <Button label="Button" primary loading disabled />
   </div>
 );
+export const Size = () => (
+  <div className="space-x-3">
+    <Button label="Normal" />
+    <Button label="Compact" compact />
+  </div>
+);
 
 export default {
   title: "Components/Buttons/Button",

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -3,7 +3,7 @@ import Loading from "../Loading";
 
 export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   fullWidth?: boolean;
-  nowrap?: boolean;
+  small?: boolean;
   label: string;
   icon?: React.ReactNode;
   primary?: boolean;
@@ -22,22 +22,21 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
-  nowrap = false,
+  small = false,
 }: Props) {
   return (
     <button
       type={type}
       className={classNames(
         direction === "row" ? "flex-row" : "flex-col",
-        fullWidth ? "w-full px-0" : "px-7",
-        nowrap && "whitespace-nowrap",
+        fullWidth ? "w-full px-0 py-2" : small ? "px-4 py-1" : "px-7 py-2",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
           : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
-        "inline-flex justify-center items-center py-2 font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
+        "inline-flex justify-center items-center font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
       )}
       onClick={onClick}
       disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -24,25 +24,20 @@ export default function Button({
   loading = false,
   compact = false,
 }: Props) {
-  const px = fullWidth ? "px-0" : compact ? "px-4" : "px-7";
-  const py = compact ? "py-1" : "py-2";
   const iconMargin = compact ? "" : direction === "row" ? "mr-2" : "";
-
   return (
     <button
       type={type}
       className={classNames(
         direction === "row" ? "flex-row" : "flex-col",
         fullWidth && "w-full",
-        px,
-        py,
+        fullWidth ? "px-0 py-2" : "px-7 py-2",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
           : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
-        compact ? "text-sm" : "",
         "inline-flex justify-center items-center font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
       )}
       onClick={onClick}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -3,7 +3,7 @@ import Loading from "../Loading";
 
 export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   fullWidth?: boolean;
-  small?: boolean;
+  compact?: boolean;
   label: string;
   icon?: React.ReactNode;
   primary?: boolean;
@@ -22,31 +22,38 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
-  small = false,
+  compact = false,
 }: Props) {
+  const px = fullWidth ? "px-0" : compact ? "px-4" : "px-7";
+  const py = compact ? "py-1" : "py-2";
+  const iconMargin = compact ? "" : direction === "row" ? "mr-2" : "";
+
   return (
     <button
       type={type}
       className={classNames(
         direction === "row" ? "flex-row" : "flex-col",
-        fullWidth ? "w-full px-0 py-2" : small ? "px-4 py-1" : "px-7 py-2",
+        fullWidth && "w-full",
+        px,
+        py,
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
           : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
+        compact ? "text-sm" : "",
         "inline-flex justify-center items-center font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
       )}
       onClick={onClick}
       disabled={disabled}
     >
       {loading && (
-        <div className={direction === "row" ? "mr-2" : ""}>
+        <div className={iconMargin}>
           <Loading color={primary ? "white" : "black"} />
         </div>
       )}
-      {icon && <div className={direction === "row" ? "mr-2" : ""}>{icon}</div>}
+      {icon && <div className={iconMargin}>{icon}</div>}
       {label}
     </button>
   );

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -3,6 +3,7 @@ import Loading from "../Loading";
 
 export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   fullWidth?: boolean;
+  nowrap?: boolean;
   label: string;
   icon?: React.ReactNode;
   primary?: boolean;
@@ -21,6 +22,7 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
+  nowrap = false,
 }: Props) {
   return (
     <button
@@ -28,6 +30,7 @@ export default function Button({
       className={classNames(
         direction === "row" ? "flex-row" : "flex-col",
         fullWidth ? "w-full px-0" : "px-7",
+        nowrap && "whitespace-nowrap",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
           : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -3,7 +3,6 @@ import Loading from "../Loading";
 
 export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   fullWidth?: boolean;
-  compact?: boolean;
   label: string;
   icon?: React.ReactNode;
   primary?: boolean;
@@ -22,9 +21,7 @@ export default function Button({
   fullWidth = false,
   primary = false,
   loading = false,
-  compact = false,
 }: Props) {
-  const iconMargin = compact ? "" : direction === "row" ? "mr-2" : "";
   return (
     <button
       type={type}
@@ -44,11 +41,11 @@ export default function Button({
       disabled={disabled}
     >
       {loading && (
-        <div className={iconMargin}>
+        <div className={direction === "row" ? "mr-2" : ""}>
           <Loading color={primary ? "white" : "black"} />
         </div>
       )}
-      {icon && <div className={iconMargin}>{icon}</div>}
+      {icon}
       {label}
     </button>
   );

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 function SatButtons({ onClick }: Props) {
   return (
-    <div className="flex gap-2 mt-2">
+    <div className="flex gap-2 mt-2 text-sm">
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="100 ⚡"

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -1,4 +1,5 @@
 import Button from "../Button";
+import { SatoshiV2Icon } from "@bitcoin-design/bitcoin-icons-react/filled";
 
 type Props = {
   onClick: (amount: string) => void;
@@ -6,11 +7,35 @@ type Props = {
 
 function SatButtons({ onClick }: Props) {
   return (
-    <div className="grid grid-rows-2 lg:grid-rows-1 grid-flow-col gap-2 mt-2 text-sm">
-      <Button label="100 sat⚡" onClick={() => onClick("100")} small />
-      <Button label="1K sat⚡" onClick={() => onClick("1000")} small />
-      <Button label="5K sat⚡" onClick={() => onClick("5000")} small />
-      <Button label="10K sat⚡" onClick={() => onClick("10000")} small />
+    <div className="flex gap-2 mt-2">
+      <Button
+        icon={<SatoshiV2Icon className="w-4 h-4" />}
+        label="100 ⚡"
+        onClick={() => onClick("100")}
+        fullWidth
+        compact
+      />
+      <Button
+        icon={<SatoshiV2Icon className="w-4 h-4" />}
+        label="1K ⚡"
+        onClick={() => onClick("1000")}
+        fullWidth
+        compact
+      />
+      <Button
+        icon={<SatoshiV2Icon className="w-4 h-4" />}
+        label="5K ⚡"
+        onClick={() => onClick("5000")}
+        fullWidth
+        compact
+      />
+      <Button
+        icon={<SatoshiV2Icon className="w-4 h-4" />}
+        label="10K ⚡"
+        onClick={() => onClick("10000")}
+        fullWidth
+        compact
+      />
     </div>
   );
 }

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -7,10 +7,30 @@ type Props = {
 function SatButtons({ onClick }: Props) {
   return (
     <div className="flex space-x-1.5 mt-2">
-      <Button fullWidth label="100 sat⚡" onClick={() => onClick("100")} />
-      <Button fullWidth label="1K sat⚡" onClick={() => onClick("1000")} />
-      <Button fullWidth label="5K sat⚡" onClick={() => onClick("5000")} />
-      <Button fullWidth label="10K sat⚡" onClick={() => onClick("10000")} />
+      <Button
+        nowrap
+        fullWidth
+        label="100 sat⚡"
+        onClick={() => onClick("100")}
+      />
+      <Button
+        nowrap
+        fullWidth
+        label="1K sat⚡"
+        onClick={() => onClick("1000")}
+      />
+      <Button
+        nowrap
+        fullWidth
+        label="5K sat⚡"
+        onClick={() => onClick("5000")}
+      />
+      <Button
+        nowrap
+        fullWidth
+        label="10K sat⚡"
+        onClick={() => onClick("10000")}
+      />
     </div>
   );
 }

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 function SatButtons({ onClick }: Props) {
   return (
-    <div className="flex gap-2 mt-2 text-sm">
+    <div className="flex gap-2 mt-2">
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="100 ⚡"

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -13,28 +13,24 @@ function SatButtons({ onClick }: Props) {
         label="100 ⚡"
         onClick={() => onClick("100")}
         fullWidth
-        compact
       />
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="1K ⚡"
         onClick={() => onClick("1000")}
         fullWidth
-        compact
       />
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="5K ⚡"
         onClick={() => onClick("5000")}
         fullWidth
-        compact
       />
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="10K ⚡"
         onClick={() => onClick("10000")}
         fullWidth
-        compact
       />
     </div>
   );

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -6,31 +6,11 @@ type Props = {
 
 function SatButtons({ onClick }: Props) {
   return (
-    <div className="flex space-x-1.5 mt-2">
-      <Button
-        nowrap
-        fullWidth
-        label="100 sat⚡"
-        onClick={() => onClick("100")}
-      />
-      <Button
-        nowrap
-        fullWidth
-        label="1K sat⚡"
-        onClick={() => onClick("1000")}
-      />
-      <Button
-        nowrap
-        fullWidth
-        label="5K sat⚡"
-        onClick={() => onClick("5000")}
-      />
-      <Button
-        nowrap
-        fullWidth
-        label="10K sat⚡"
-        onClick={() => onClick("10000")}
-      />
+    <div className="grid grid-rows-2 lg:grid-rows-1 grid-flow-col gap-2 mt-2 text-sm">
+      <Button label="100 sat⚡" onClick={() => onClick("100")} small />
+      <Button label="1K sat⚡" onClick={() => onClick("1000")} small />
+      <Button label="5K sat⚡" onClick={() => onClick("5000")} small />
+      <Button label="10K sat⚡" onClick={() => onClick("10000")} small />
     </div>
   );
 }

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -77,7 +77,7 @@ function AccountsScreen() {
       <div className="shadow border-b border-gray-200 dark:border-gray-500 sm:rounded-lg bg-white dark:bg-gray-800">
         <div className="p-6">
           <Button
-            icon={<PlusIcon className="w-5 h-5" />}
+            icon={<PlusIcon className="w-5 h-5 mr-2" />}
             label="Add account"
             primary
             onClick={() => navigate(`/accounts/new`)}

--- a/src/app/screens/Receive.tsx
+++ b/src/app/screens/Receive.tsx
@@ -117,7 +117,7 @@ function Receive() {
                     }
                   }
                 }}
-                icon={<CopyIcon className="w-6 h-6" />}
+                icon={<CopyIcon className="w-6 h-6 mr-2" />}
                 label={copyLabel}
               />
             </div>


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #727 

#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -

 - Added a `small` prop to `Button` which changes the padding from `px-7 py-2` to `px-4 py-1`
 - Changed `SatButtons` component to use `grid` and `grid-rows-2 lg:grid-rows-1` instead of `flex` for layout

#### Screenshots of the changes (If any) -

 - Before (using chrome on linux) 
![image](https://user-images.githubusercontent.com/8001706/160247974-f3fde0d7-deb1-4cf8-8310-74ea004699f6.png)

 - After (using chrome on linux) 
![image](https://user-images.githubusercontent.com/8001706/160248021-a3c0223b-96d8-4d5d-84b4-fa00070ac4cd.png)

#### How Has This Been Tested?

I tested this locally on Firefox and Brave (chrome) and I was able to reproduce and fix the issue.
I was not able to test this on windows since I do no have access to a windows pc.

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
