### PR TITLE
fix: incorrect unlock styling in prompt

### DIFF
--- a/src/app/screens/Unlock/index.tsx
+++ b/src/app/screens/Unlock/index.tsx
@@ -42,7 +42,7 @@ function Unlock() {
   }
 
   return (
-    <div className="p-8 bg-white dark:bg-gray-800 shadow-lg">
+    <div className="p-8">
       <div className="flex justify-center">
         <div className="w-40 dark:text-white">
           <AlbyLogo />


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -

Removed backgound and shadow from the unlock screen. Those should be decided by the background styling from the prompt template.

#### Screenshots of the changes (If any) -
Before:
<img width="407" alt="Schermafbeelding 2022-03-26 om 18 23 12" src="https://user-images.githubusercontent.com/12894112/160250566-d34318ac-e02d-4fd9-98a0-39299784a62e.png">

After:
<img width="408" alt="Schermafbeelding 2022-03-26 om 18 23 32" src="https://user-images.githubusercontent.com/12894112/160250572-1d5b3b01-0866-4d4f-ab35-4c3117267dcc.png">
