### PR TITLE
feat: new wallet account creation with lightning address

### DIFF
--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -1,3 +1,11 @@
+import { useRef } from "react";
+
+import { classNames } from "../../../utils";
+
+type Props = {
+  suffix?: string;
+};
+
 export default function Input({
   name,
   id,
@@ -15,13 +23,22 @@ export default function Input({
   disabled,
   min,
   max,
-}: React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
+  suffix,
+}: React.InputHTMLAttributes<HTMLInputElement> & Props) {
+  const inputEl = useRef<HTMLInputElement>(null);
+  const outerStyles =
+    "shadow-sm rounded-md border border-gray-300 dark:bg-gray-200 focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:ring-1 transition duration-300";
+
+  const inputNode = (
     <input
+      ref={inputEl}
       type={type}
       name={name}
       id={id}
-      className="shadow-sm focus:ring-orange-bitcoin focus:border-orange-bitcoin block w-full sm:text-sm border-gray-300 rounded-md placeholder-gray-400 dark:bg-gray-200 dark:placeholder-gray-600 dark:text-black transition duration-300"
+      className={classNames(
+        "sm:text-sm block w-full placeholder-gray-400 dark:placeholder-gray-600 dark:text-black",
+        !suffix ? outerStyles : "border-0 focus:ring-0"
+      )}
       placeholder={placeholder}
       required={required}
       pattern={pattern}
@@ -36,5 +53,26 @@ export default function Input({
       min={min}
       max={max}
     />
+  );
+
+  if (!suffix) return inputNode;
+
+  return (
+    <div
+      className={classNames(
+        "flex items-stretch overflow-hidden",
+        outerStyles.replace(/focus/g, "focus-within")
+      )}
+    >
+      {inputNode}
+      <span
+        className="flex items-center pr-3 font-medium"
+        onClick={() => {
+          inputEl.current?.focus();
+        }}
+      >
+        {suffix}
+      </span>
+    </div>
   );
 }

--- a/src/app/components/form/TextField.tsx
+++ b/src/app/components/form/TextField.tsx
@@ -15,6 +15,8 @@ const TextField = ({
   autoFocus = false,
   autoComplete = "off",
   disabled,
+  minLength,
+  maxLength,
   min,
   max,
 }: React.InputHTMLAttributes<HTMLInputElement> & { label: string }) => (
@@ -41,6 +43,8 @@ const TextField = ({
         autoFocus={autoFocus}
         autoComplete={autoComplete}
         disabled={disabled}
+        minLength={minLength}
+        maxLength={maxLength}
         min={min}
         max={max}
       />

--- a/src/app/components/form/TextField.tsx
+++ b/src/app/components/form/TextField.tsx
@@ -1,5 +1,10 @@
 import Input from "./Input";
 
+type Props = {
+  label: string;
+  suffix?: string;
+};
+
 const TextField = ({
   id,
   label,
@@ -19,7 +24,8 @@ const TextField = ({
   maxLength,
   min,
   max,
-}: React.InputHTMLAttributes<HTMLInputElement> & { label: string }) => (
+  suffix,
+}: React.InputHTMLAttributes<HTMLInputElement> & Props) => (
   <>
     <label
       htmlFor={id}
@@ -47,6 +53,7 @@ const TextField = ({
         maxLength={maxLength}
         min={min}
         max={max}
+        suffix={suffix}
       />
     </div>
   </>

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -29,6 +29,7 @@ const faucetMemo = "LN Faucet";
 export default function TestConnection() {
   const [accountInfo, setAccountInfo] = useState<{
     alias: string;
+    name: string;
     balance: number;
   }>();
   const [errorMessage, setErrorMessage] = useState();
@@ -89,10 +90,11 @@ export default function TestConnection() {
     api
       .getAccountInfo()
       .then((response) => {
+        const name = response.name;
         const { alias } = response.info;
         const balance = parseInt(response.balance.balance);
 
-        setAccountInfo({ alias, balance });
+        setAccountInfo({ alias, balance, name });
       })
       .catch((e) => {
         console.error(e);
@@ -200,7 +202,7 @@ export default function TestConnection() {
               <div className="mt-6 shadow-lg p-4 rounded-xl">
                 <Card
                   color="bg-gray-100"
-                  alias={accountInfo.alias}
+                  alias={`${accountInfo.name} - ${accountInfo.alias}`}
                   satoshis={
                     typeof accountInfo.balance === "number"
                       ? `${accountInfo.balance} sat`

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -13,8 +13,11 @@ import Loading from "../../../components/Loading";
 export default function TestConnection() {
   const auth = useAuth();
   const { getAccounts } = useAccounts();
-  const [accountInfo, setAccountInfo] =
-    useState<{ alias: string; balance: number }>();
+  const [accountInfo, setAccountInfo] = useState<{
+    alias: string;
+    name: string;
+    balance: number;
+  }>();
   const [errorMessage, setErrorMessage] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -42,6 +45,7 @@ export default function TestConnection() {
         setAccountInfo({
           alias: accountInfo.alias,
           balance: accountInfo.balance,
+          name: accountInfo.name,
         });
       }
       getAccounts();
@@ -110,7 +114,7 @@ export default function TestConnection() {
                 <div className="mt-6 shadow-lg p-4 rounded-xl">
                   <Card
                     color="bg-gray-100"
-                    alias={accountInfo.alias}
+                    alias={`${accountInfo.name} - ${accountInfo.alias}`}
                     satoshis={
                       typeof accountInfo.balance === "number"
                         ? `${accountInfo.balance} sat`

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -177,9 +177,10 @@ export default function NewWallet() {
             />
           </div>
           <div className="mt-6">
-            <p className="text-gray-500 dark:text-gray-400">
+            <p className="mb-2 text-gray-500 dark:text-gray-400">
               Your Alby account also comes with an optional{" "}
               <a
+                className="underline"
                 href="https://lightningaddress.com/"
                 target="_blank"
                 rel="noreferrer"
@@ -189,6 +190,7 @@ export default function NewWallet() {
               . This is a simple way for anyone to send you Bitcoin on the
               Lightning Network. (
               <a
+                className="underline"
                 href="https://lightningaddress.com/"
                 target="_blank"
                 rel="noreferrer"
@@ -197,14 +199,17 @@ export default function NewWallet() {
               </a>
               )
             </p>
-            <TextField
-              id="lnAddress"
-              label="Choose your Lightning Address (optional)"
-              type="text"
-              onChange={(e) => {
-                setLnAddress(e.target.value.trim().split("@")[0]); // in case somebody enters a full address we simple remove the domain
-              }}
-            />
+            <div>
+              <TextField
+                id="lnAddress"
+                label="Choose your Lightning Address (optional)"
+                suffix="@getalby.com"
+                type="text"
+                onChange={(e) => {
+                  setLnAddress(e.target.value.trim().split("@")[0]); // in case somebody enters a full address we simple remove the domain
+                }}
+              />
+            </div>
           </div>
         </>
       )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface AccountInfo {
   id: string;
   alias: string;
   balance: number;
+  name: string;
 }
 
 export interface MetaData {


### PR DESCRIPTION
#### Describe the changes you have made in this PR

This PR changes the signup for a new alby account. 
We make it clear that the user gets an account on getalby.com and we require an email and a password. 
The user now can also directly create a lightning address during the signup. 

#### Type of change (Remove other not matching type)
- New feature (non-breaking change which adds functionality)

#### Screenshots of the changes (If any) -
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/318/160709190-9fd6fea5-b910-4448-a3e7-fa0386a98da4.png">

<img width="951" alt="image" src="https://user-images.githubusercontent.com/318/160708999-49fd6175-e15f-401b-8e0c-a771701a9ed2.png">


#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
