### PR TITLE
fix: button border should match input border color

### DIFF
--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -31,7 +31,7 @@ export default function Button({
         fullWidth ? "px-0 py-2" : "px-7 py-2",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
-          : `bg-white text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
+          : `bg-white text-gray-700 border border-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",

--- a/src/app/components/IconButton/index.tsx
+++ b/src/app/components/IconButton/index.tsx
@@ -6,7 +6,7 @@ type Props = {
 function IconButton({ onClick, icon }: Props) {
   return (
     <button
-      className="flex justify-center items-center w-8 h-8 bg-gray-50 rounded-md border border-gray-200 hover:bg-gray-100 transition-colors duration-200"
+      className="flex justify-center items-center w-8 h-8 bg-gray-50 rounded-md border border-gray-300 hover:bg-gray-100 transition-colors duration-200"
       onClick={onClick}
     >
       {icon}

--- a/src/app/components/LinkButton/index.tsx
+++ b/src/app/components/LinkButton/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 export default function LinkButton({ to, title, description, logo }: Props) {
   return (
     <Link to={to} className="block">
-      <div className="p-4 bg-white dark:bg-gray-800 h-96 text-center shadow-lg overflow-hidden border-b border-gray-200 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
+      <div className="p-4 bg-white dark:bg-gray-800 h-96 text-center shadow-lg overflow-hidden border-b border-gray-300 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
         <div className="my-12">
           <img src={logo} alt="logo" className="inline rounded-3xl w-32" />
         </div>


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
Currently the borders from buttons are slightly lighter than the borders from inputs.
This looks a bit weird for e.g. when placing the sat buttons below an input.