### PR TITLE
fix: accountmenu taking too much height in prompts

### DIFF
--- a/src/app/components/AccountMenu/AccountMenu.stories.tsx
+++ b/src/app/components/AccountMenu/AccountMenu.stories.tsx
@@ -6,7 +6,7 @@ import AcountMenu from ".";
 export const Default = () => (
   <div className="relative bg-gray-100 w-40 flex justify-between pl-3 rounded-md">
     <span>Wallet</span>
-    <AcountMenu />
+    <AcountMenu title="node" subtitle="1000 sats" />
   </div>
 );
 

--- a/src/app/components/AccountMenu/index.test.tsx
+++ b/src/app/components/AccountMenu/index.test.tsx
@@ -5,6 +5,11 @@ import * as AccountsContext from "../../context/AccountsContext";
 import AccountMenu from ".";
 import type { Accounts } from "../../../types";
 
+const defaultProps = {
+  title: "node",
+  subtitle: "1000 sats",
+};
+
 const mockAccounts: Accounts = {
   "1": { id: "1", connector: "lnd", config: "", name: "LND account" },
   "2": { id: "2", connector: "galoy", config: "", name: "Galoy account" },
@@ -19,7 +24,7 @@ describe("AccountMenu", () => {
   test("renders the toggle button", async () => {
     render(
       <BrowserRouter>
-        <AccountMenu />
+        <AccountMenu {...defaultProps} />
       </BrowserRouter>
     );
 
@@ -29,7 +34,7 @@ describe("AccountMenu", () => {
   test("displays accounts and options", async () => {
     render(
       <BrowserRouter>
-        <AccountMenu />
+        <AccountMenu {...defaultProps} />
       </BrowserRouter>
     );
 
@@ -46,7 +51,7 @@ describe("AccountMenu", () => {
   test("displays accounts without options", async () => {
     render(
       <BrowserRouter>
-        <AccountMenu showOptions={false} />
+        <AccountMenu showOptions={false} {...defaultProps} />
       </BrowserRouter>
     );
 

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -6,6 +6,7 @@ import {
   CaretDownIcon,
   PlusIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
+import Skeleton from "react-loading-skeleton";
 
 import utils from "../../../common/lib/utils";
 import { useAuth } from "../../context/AuthContext";
@@ -15,10 +16,12 @@ import Badge from "../Badge";
 import Menu from "../Menu";
 
 export type Props = {
+  title: string;
+  subtitle: string;
   showOptions?: boolean;
 };
 
-function AccountMenu({ showOptions = true }: Props) {
+function AccountMenu({ title, subtitle, showOptions = true }: Props) {
   const auth = useAuth();
   const navigate = useNavigate();
   const { accounts, getAccounts } = useAccounts();
@@ -51,57 +54,73 @@ function AccountMenu({ showOptions = true }: Props) {
   }
 
   return (
-    <Menu as="div">
-      <Menu.Button className="h-full px-2 rounded-r-md hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors duration-200">
-        <CaretDownIcon className="h-4 w-4 dark:text-white" />
-        <span className="sr-only">Toggle Dropdown</span>
-      </Menu.Button>
-      <Menu.List position="left">
-        <Menu.Subheader>Switch account</Menu.Subheader>
-        {Object.keys(accounts).map((accountId) => {
-          const account = accounts[accountId];
-          return (
-            <Menu.ItemButton
-              key={accountId}
-              onClick={() => {
-                selectAccount(accountId);
-              }}
-              disabled={loading}
-            >
-              <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-500" />
-              {account.name}&nbsp;
-              <Badge
-                label={account.connector}
-                color="blue-500"
-                textColor="white"
-                small
-              />
-            </Menu.ItemButton>
-          );
-        })}
-        {showOptions && (
-          <>
-            <Menu.Divider />
-            <Menu.ItemButton
-              onClick={() => {
-                openOptions("accounts/new");
-              }}
-            >
-              <PlusIcon className="h-5 w-5 mr-2 text-gray-500" />
-              Add a new account
-            </Menu.ItemButton>
-            <Menu.ItemButton
-              onClick={() => {
-                openOptions("accounts");
-              }}
-            >
-              <AddressBookIcon className="h-5 w-5 mr-2 text-gray-500" />
-              Accounts
-            </Menu.ItemButton>
-          </>
-        )}
-      </Menu.List>
-    </Menu>
+    <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-gray-600">
+      <div className="flex items-center">
+        <WalletIcon className="-ml-1 w-8 h-8 opacity-50 dark:text-white" />
+      </div>
+      <div
+        className={`flex-auto mx-2 py-1 ${!title && !subtitle ? "w-28" : ""}`}
+      >
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          {title || <Skeleton />}
+        </div>
+        <div className="text-xs dark:text-white">
+          {subtitle || <Skeleton />}
+        </div>
+      </div>
+
+      <Menu as="div">
+        <Menu.Button className="h-full px-2 rounded-r-md hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors duration-200">
+          <CaretDownIcon className="h-4 w-4 dark:text-white" />
+          <span className="sr-only">Toggle Dropdown</span>
+        </Menu.Button>
+        <Menu.List position="left">
+          <Menu.Subheader>Switch account</Menu.Subheader>
+          {Object.keys(accounts).map((accountId) => {
+            const account = accounts[accountId];
+            return (
+              <Menu.ItemButton
+                key={accountId}
+                onClick={() => {
+                  selectAccount(accountId);
+                }}
+                disabled={loading}
+              >
+                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-500" />
+                {account.name}&nbsp;
+                <Badge
+                  label={account.connector}
+                  color="blue-500"
+                  textColor="white"
+                  small
+                />
+              </Menu.ItemButton>
+            );
+          })}
+          {showOptions && (
+            <>
+              <Menu.Divider />
+              <Menu.ItemButton
+                onClick={() => {
+                  openOptions("accounts/new");
+                }}
+              >
+                <PlusIcon className="h-5 w-5 mr-2 text-gray-500" />
+                Add a new account
+              </Menu.ItemButton>
+              <Menu.ItemButton
+                onClick={() => {
+                  openOptions("accounts");
+                }}
+              >
+                <AddressBookIcon className="h-5 w-5 mr-2 text-gray-500" />
+                Accounts
+              </Menu.ItemButton>
+            </>
+          )}
+        </Menu.List>
+      </Menu>
+    </div>
   );
 }
 

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -1,56 +1,26 @@
-import Skeleton from "react-loading-skeleton";
-import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
-
 import AccountMenu from "../AccountMenu";
 import UserMenu from "../UserMenu";
 
 type Props = {
   title: string;
   subtitle: string;
-  showAccountMenuOptions?: boolean;
-  showUserMenu?: boolean;
   children?: React.ReactNode;
 };
 
-export default function Navbar({
-  title,
-  subtitle,
-  showAccountMenuOptions = true,
-  showUserMenu = true,
-  children,
-}: Props) {
+export default function Navbar({ title, subtitle, children }: Props) {
   return (
     <div className="px-4 py-2 bg-white flex justify-between items-center border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
       <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
-        <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-gray-600">
-          <div className="flex items-center">
-            <WalletIcon className="-ml-1 w-8 h-8 opacity-50 dark:text-white" />
-          </div>
-          <div
-            className={`flex-auto mx-2 py-1 ${
-              !title && !subtitle ? "w-28" : ""
-            }`}
-          >
-            <div className="text-xs text-gray-500 dark:text-gray-400">
-              {title || <Skeleton />}
-            </div>
-            <div className="text-xs dark:text-white">
-              {subtitle || <Skeleton />}
-            </div>
-          </div>
-          <AccountMenu showOptions={showAccountMenuOptions} />
-        </div>
+        <AccountMenu title={title} subtitle={subtitle} />
       </div>
       {children && (
         <div>
           <nav className="flex space-x-8">{children}</nav>
         </div>
       )}
-      {showUserMenu && (
-        <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
-          <UserMenu />
-        </div>
-      )}
+      <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
+        <UserMenu />
+      </div>
     </div>
   );
 }

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -22,7 +22,7 @@ import LNURLPay from "../../screens/LNURLPay";
 import LNURLAuth from "../../screens/LNURLAuth";
 import LNURLWithdraw from "../../screens/LNURLWithdraw";
 import Keysend from "../../screens/ConfirmKeysend";
-import Navbar from "../../components/Navbar";
+import AccountMenu from "../../components/AccountMenu";
 
 class Prompt extends Component<
   Record<string, unknown>,
@@ -158,20 +158,21 @@ const Layout = () => {
 
   return (
     <>
-      <Navbar
-        title={
-          typeof auth.account?.name === "string"
-            ? `${auth.account?.name} - ${auth.account?.alias}`
-            : ""
-        }
-        subtitle={
-          typeof auth.account?.balance === "number"
-            ? `${auth.account.balance} sat`
-            : ""
-        }
-        showAccountMenuOptions={false}
-        showUserMenu={false}
-      />
+      <div className="px-4 py-2 bg-white flex border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
+        <AccountMenu
+          title={
+            typeof auth.account?.name === "string"
+              ? `${auth.account?.name} - ${auth.account?.alias}`
+              : ""
+          }
+          subtitle={
+            typeof auth.account?.balance === "number"
+              ? `${auth.account.balance} sat`
+              : ""
+          }
+          showOptions={false}
+        />
+      </div>
 
       <Outlet />
     </>

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -162,7 +162,10 @@ const Layout = () => {
         <AccountMenu
           title={
             typeof auth.account?.name === "string"
-              ? `${auth.account?.name} - ${auth.account?.alias}`
+              ? `${auth.account?.name} - ${auth.account?.alias}`.substring(
+                  0,
+                  21
+                )
               : ""
           }
           subtitle={


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
I removed the need to include a complete `<Navbar /`> if you only need an AccountMenu and made use of substring to give the title a max length (as used in other routers).
This also removes the need for `showAccountMenuOptions` & `showUserMenu` props on the Navbar.

#### Screenshots of the changes (If any) -
Before:
<img width="401" alt="Schermafbeelding 2022-04-05 om 12 31 05" src="https://user-images.githubusercontent.com/12894112/161738114-a02824d3-89f4-4fc7-bb6a-46b563224d40.png">

After:
<img width="400" alt="Schermafbeelding 2022-04-05 om 12 58 28" src="https://user-images.githubusercontent.com/12894112/161739631-49c7bc2f-36cc-464f-a64e-15711d0f3c3f.png">



