### PR TITLE
chore: lint only staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
-yarn tsc --noEmit

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "src/**/*.{js,jsx,ts,tsx,json}": [
+    "eslint --fix --max-warnings 0",
+    "prettier --write",
+  ],
+  "src/**/*.{ts,tsx}": () => "tsc --noEmit",
+};

--- a/package.json
+++ b/package.json
@@ -35,12 +35,6 @@
     "build-storybook": "build-storybook",
     "prepare": "husky install"
   },
-  "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json}": [
-      "eslint --fix --max-warnings 0",
-      "prettier --write"
-    ]
-  },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@bitcoin-design/bitcoin-icons-react": "^0.1.9",


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -

The typescript compiler currently checks all ts files on pre-committing. This should just be the staged files.
