### PR TITLE
feat: scan twitter location for lightning address

### DIFF
--- a/src/extension/content-script/batteries/Twitter.ts
+++ b/src/extension/content-script/batteries/Twitter.ts
@@ -91,7 +91,7 @@ function battery(): void {
         const zapElements = new Set([
           ...userData.element.querySelectorAll('img[src*="26a1.svg"]'),
           ...(userData.location
-            ? userData.location.querySelectorAll('img[src*="26a1.svg"')
+            ? userData.location.querySelectorAll('img[src*="26a1.svg"]')
             : []),
         ]);
         // it is hard to find the :zap: emoij. Twitter uses images for that but has an alt text with the emoij

--- a/src/extension/content-script/batteries/Twitter.ts
+++ b/src/extension/content-script/batteries/Twitter.ts
@@ -90,9 +90,7 @@ function battery(): void {
         // if we did not find anything let's look for an ⚡ emoji
         const zapElements = new Set([
           ...userData.element.querySelectorAll('img[src*="26a1.svg"]'),
-          ...(userData.location
-            ? userData.location.querySelectorAll('img[src*="26a1.svg"]')
-            : []),
+...(userData.location?.querySelectorAll('img[src*="26a1.svg"]') || []),
         ]);
         // it is hard to find the :zap: emoij. Twitter uses images for that but has an alt text with the emoij
         // but there could be some control characters somewhere...somehow...no idea...

--- a/src/extension/content-script/batteries/Twitter.ts
+++ b/src/extension/content-script/batteries/Twitter.ts
@@ -41,9 +41,13 @@ function getUserData(username: string) {
     const imageUrl = document.querySelector<HTMLImageElement>(
       `[data-testid="primaryColumn"] a[href="/${username}/photo" i] img`
     )?.src;
+    const location = document.querySelector<HTMLElement>(
+      `[data-testid="primaryColumn"] [data-testid="UserLocation"]`
+    );
     if (element && imageUrl) {
       return {
         element,
+        location,
         imageUrl,
         name: document.title,
       };
@@ -84,9 +88,12 @@ function battery(): void {
         recipient = match[1];
       } else {
         // if we did not find anything let's look for an ⚡ emoji
-        const zapElements = userData.element.querySelectorAll(
-          'img[src*="26a1.svg"]'
-        );
+        const zapElements = new Set([
+          ...userData.element.querySelectorAll('img[src*="26a1.svg"]'),
+          ...(userData.location
+            ? userData.location.querySelectorAll('img[src*="26a1.svg"')
+            : []),
+        ]);
         // it is hard to find the :zap: emoij. Twitter uses images for that but has an alt text with the emoij
         // but there could be some control characters somewhere...somehow...no idea...
         // for that reason we check if there is any character with the zap char code in the alt string.

--- a/src/extension/content-script/batteries/Twitter.ts
+++ b/src/extension/content-script/batteries/Twitter.ts
@@ -90,7 +90,8 @@ function battery(): void {
         // if we did not find anything let's look for an ⚡ emoji
         const zapElements = new Set([
           ...userData.element.querySelectorAll('img[src*="26a1.svg"]'),
-...(userData.location?.querySelectorAll('img[src*="26a1.svg"]') || []),
+          ...(userData.location?.querySelectorAll('img[src*="26a1.svg"]') ||
+            []),
         ]);
         // it is hard to find the :zap: emoij. Twitter uses images for that but has an alt text with the emoij
         // but there could be some control characters somewhere...somehow...no idea...


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #814 

#### Type of change (Remove other not matching type)
- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
Add the `location` to the data returned from `getUserData`. It is only available on the profile page. In the battery function, we screen for the zap emoji, if `location` was passed in the `userData` object.

#### Screenshots of the changes (If any) -

#### How Has This Been Tested?
I tested in Chrome and Firefox by loading the extension in dev mode.

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
