### PR TITLE
fix: set prompt search params only if defined

### DIFF
--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -93,16 +93,26 @@ const utils = {
     origin: OriginData;
     type: string;
   }): Promise<{ data: Type }> => {
-    const urlParams = new URLSearchParams({
-      args: JSON.stringify(message.args),
-      origin: JSON.stringify(message.origin),
-      type: message.type,
-    }).toString();
+    const urlParams = new URLSearchParams();
+    // passing on the message args to the prompt if present
+    if (message.args) {
+      urlParams.set("args", JSON.stringify(message.args));
+    }
+    // passing on the message origin to the prompt if present
+    if (message.origin) {
+      urlParams.set("origin", JSON.stringify(message.origin));
+    }
+    // type must always be present, this is used to route the request
+    urlParams.set("type", message.type);
+
+    const url = `${browser.runtime.getURL(
+      "prompt.html"
+    )}?${urlParams.toString()}`;
 
     return new Promise((resolve, reject) => {
       browser.windows
         .create({
-          url: `${browser.runtime.getURL("prompt.html")}?${urlParams}`,
+          url: url,
           type: "popup",
           width: 400,
           height: 600,


### PR DESCRIPTION
I think message.args is optional but currently we would add a `args=JSON.stringify(undefined)`
to the prompt URL.

This change only adds the param to the prompt URL if persent.

This might have been a bug introduced by changing how we create the query-string
(in https://github.com/getAlby/lightning-browser-extension/pull/786/files#diff-6aa3c99dd75ad2803ee2a158c3686f6f611f1bbaa59183f9648b97b8cf7abc10L33)

