### PR TITLE
feat: explanatory videos for account setup

### DIFF
--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   submitDisabled?: boolean;
   onSubmit: FormEventHandler;
   children: React.ReactNode;
+  video?: string;
 };
 
 function ConnectorForm({
@@ -21,6 +22,7 @@ function ConnectorForm({
   submitDisabled = false,
   onSubmit,
   children,
+  video,
 }: Props) {
   const navigate = useNavigate();
 
@@ -42,7 +44,28 @@ function ConnectorForm({
         </div>
         <div className="mt-16 lg:mt-0 lg:w-1/2">
           <div className="lg:flex h-full justify-center items-center">
-            <img src="assets/icons/satsymbol.svg" alt="sat" className="w-64" />
+            {video ? (
+              <div
+                className="flex-1 relative h-0"
+                style={{ paddingBottom: "56.25%" }}
+              >
+                <video
+                  className="absolute t-0 l-0 w-full h-full"
+                  width="1920"
+                  height="1080"
+                  controls
+                >
+                  <source src={video} type="video/mp4" />
+                  Your browser does not support the video tag.
+                </video>
+              </div>
+            ) : (
+              <img
+                src="assets/icons/satsymbol.svg"
+                alt="sat"
+                className="w-64"
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -49,14 +49,8 @@ function ConnectorForm({
                 className="flex-1 relative h-0"
                 style={{ paddingBottom: "56.25%" }}
               >
-                <video
-                  className="absolute t-0 l-0 w-full h-full"
-                  width="1920"
-                  height="1080"
-                  controls
-                >
+                <video className="absolute t-0 l-0 w-full h-full" controls>
                   <source src={video} type="video/mp4" />
-                  Your browser does not support the video tag.
                 </video>
               </div>
             ) : (

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -103,7 +103,7 @@ export default function ConnectUmbrel() {
       submitLoading={loading}
       submitDisabled={formData.url === "" || formData.macaroon === ""}
       onSubmit={handleSubmit}
-      video="https://cdn.getalby-assets.com/Connector-guides/in_extension_guide_umbrel.mp4"
+      video="https://cdn.getalby-assets.com/connector-guides/in_extension_guide_umbrel.mp4"
     >
       <TextField
         id="lndconnect"

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -103,6 +103,7 @@ export default function ConnectUmbrel() {
       submitLoading={loading}
       submitDisabled={formData.url === "" || formData.macaroon === ""}
       onSubmit={handleSubmit}
+      video="https://cdn.getalby-assets.com/Connector-guides/in_extension_guide_umbrel.mp4"
     >
       <TextField
         id="lndconnect"


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #686

#### Type of change (Remove other not matching type)
- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
This PR allows us to add an optional video for every connector and adds the first video for the Umbrel connector. If none is provided we still have the fallback to the sats symbol (like it was before). 

#### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/100827540/165303974-1fa46a3d-d202-4cc0-a2ef-25718dd51527.png)

#### How Has This Been Tested?

Tested on Firefox.

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
