### PR TITLE
feat: add fee amount to tx table

### DIFF
--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -85,6 +85,7 @@ export default function TransactionsTable({ transactions }: Props) {
                   <Disclosure.Panel>
                     <div className="mt-1 ml-9 text-xs text-gray-500 dark:text-gray-400">
                       {tx.description}
+                      <p>Fee: {tx.totalFees} sat</p>
                       {tx.preimage && (
                         <p className="truncate">Preimage: {tx.preimage}</p>
                       )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export type Transaction = {
   preimage: string;
   badges: IBadge[];
   totalAmount: string;
+  totalFees: string;
   description: string;
   location: string;
 };


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #810 

#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
Added the transaction fee information to the transaction detail view.

#### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/85003930/166132131-c91d285e-2664-4801-be66-92f5479f5e14.png)

#### How Has This Been Tested?
Sent a tx, checked the value of the fee in the `object` and verify that it displays in the UI.

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
