### PR TITLE
feat: material design surface overlay (simplified dark mode)

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -54,7 +54,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
   }
 
   return (
-    <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-gray-600">
+    <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-surface-12dp">
       <div className="flex items-center">
         <WalletIcon className="-ml-1 w-8 h-8 opacity-50 dark:text-white" />
       </div>
@@ -70,7 +70,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
       </div>
 
       <Menu as="div">
-        <Menu.Button className="h-full px-2 rounded-r-md hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors duration-200">
+        <Menu.Button className="h-full px-2 rounded-r-md hover:bg-gray-200 dark:hover:bg-white/10 transition-colors duration-200">
           <CaretDownIcon className="h-4 w-4 dark:text-white" />
           <span className="sr-only">Toggle Dropdown</span>
         </Menu.Button>

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -61,7 +61,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
       <div
         className={`flex-auto mx-2 py-1 ${!title && !subtitle ? "w-28" : ""}`}
       >
-        <div className="text-xs text-gray-500 dark:text-gray-400">
+        <div className="text-xs text-gray-700 dark:text-gray-400">
           {title || <Skeleton />}
         </div>
         <div className="text-xs dark:text-white">
@@ -86,7 +86,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                 }}
                 disabled={loading}
               >
-                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-500" />
+                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-700 dark:text-gray-300" />
                 {account.name}&nbsp;
                 <Badge
                   label={account.connector}
@@ -105,7 +105,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                   openOptions("accounts/new");
                 }}
               >
-                <PlusIcon className="h-5 w-5 mr-2 text-gray-500" />
+                <PlusIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
                 Add a new account
               </Menu.ItemButton>
               <Menu.ItemButton
@@ -113,7 +113,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                   openOptions("accounts");
                 }}
               >
-                <AddressBookIcon className="h-5 w-5 mr-2 text-gray-500" />
+                <AddressBookIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
                 Accounts
               </Menu.ItemButton>
             </>

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -85,13 +85,13 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
         overlayClassName="bg-black bg-opacity-25 fixed inset-0 flex justify-center items-center p-5"
         className="rounded-lg bg-white w-full max-w-lg"
       >
-        <div className="p-5 flex justify-between dark:bg-gray-800">
+        <div className="p-5 flex justify-between dark:bg-surface-02dp">
           <h2 className="text-2xl font-bold dark:text-white">Edit Allowance</h2>
           <button onClick={closeModal}>
             <CrossIcon className="w-6 h-6 dark:text-white" />
           </button>
         </div>
-        <div className="p-5 border-t border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
+        <div className="p-5 border-t border-b border-gray-200 dark:bg-surface-02dp dark:border-gray-500">
           <div className="w-60">
             <TextField
               id="budget"
@@ -104,7 +104,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
             />
           </div>
         </div>
-        <div className="flex justify-end p-5 dark:bg-gray-800">
+        <div className="flex justify-end p-5 dark:bg-surface-02dp">
           <Button
             onClick={updateAllowance}
             label="Save"

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -31,9 +31,9 @@ export default function Button({
         fullWidth ? "px-0 py-2" : "px-7 py-2",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
-          : `bg-white text-gray-700 border border-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500`,
+          : `bg-white text-gray-700 border border-gray-300 dark:bg-surface-02dp dark:text-gray-200 dark:border-gray-800`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
-        !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-gray-600",
+        !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-surface-16dp",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",
         "inline-flex justify-center items-center font-medium rounded-md shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
       )}

--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -26,7 +26,7 @@ function ConnectorForm({
 
   return (
     <form onSubmit={onSubmit}>
-      <div className="relative lg:flex mt-14 bg-white dark:bg-gray-800 px-10 py-12">
+      <div className="relative lg:flex mt-14 bg-white dark:bg-surface-02dp px-10 py-12">
         <div className="lg:w-1/2">
           <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
           {description && (

--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 function Header({ title, headerLeft, headerRight }: Props) {
   return (
-    <div className="relative flex justify-center items-center bg-white px-4 py-2 border-b border-gray-200 dark:bg-gray-700 dark:border-gray-500">
+    <div className="relative flex justify-center items-center bg-white px-4 py-2 border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
       <div className="absolute left-4">{headerLeft}</div>
       <h1 className="text-lg font-medium dark:text-white">{title}</h1>
       <div className="absolute right-4">{headerRight}</div>

--- a/src/app/components/IconButton/index.tsx
+++ b/src/app/components/IconButton/index.tsx
@@ -6,7 +6,7 @@ type Props = {
 function IconButton({ onClick, icon }: Props) {
   return (
     <button
-      className="flex justify-center items-center w-8 h-8 bg-gray-50 rounded-md border border-gray-300 hover:bg-gray-100 transition-colors duration-200"
+      className="flex justify-center items-center w-8 h-8 bg-gray-50 dark:bg-surface-04dp dark:text-white rounded-md border border-gray-300 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-surface-12dp transition-colors duration-200"
       onClick={onClick}
     >
       {icon}

--- a/src/app/components/LinkButton/index.tsx
+++ b/src/app/components/LinkButton/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 export default function LinkButton({ to, title, description, logo }: Props) {
   return (
     <Link to={to} className="block">
-      <div className="p-4 bg-white dark:bg-gray-800 h-96 text-center shadow-lg overflow-hidden border-b border-gray-300 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
+      <div className="p-4 bg-white dark:bg-surface-02dp h-96 text-center shadow-lg overflow-hidden border-b border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition duration-200">
         <div className="my-12">
           <img src={logo} alt="logo" className="inline rounded-3xl w-32" />
         </div>

--- a/src/app/components/LinkButton/index.tsx
+++ b/src/app/components/LinkButton/index.tsx
@@ -17,7 +17,7 @@ export default function LinkButton({ to, title, description, logo }: Props) {
         <div>
           <span className="block dark:text-white text-lg">{title}</span>
           {description && (
-            <span className="text-sm text-gray-500 dark:text-gray-300">
+            <span className="text-sm text-gray-700 dark:text-gray-300">
               {description}
             </span>
           )}

--- a/src/app/components/Menu/MenuDivider.tsx
+++ b/src/app/components/Menu/MenuDivider.tsx
@@ -1,5 +1,5 @@
 function MenuDivider() {
-  return <hr className="my-1 dark:border-gray-500" />;
+  return <hr className="my-1 dark:border-white/10" />;
 }
 
 export default MenuDivider;

--- a/src/app/components/Menu/MenuItemButton.tsx
+++ b/src/app/components/Menu/MenuItemButton.tsx
@@ -20,10 +20,10 @@ function MenuItemButton({
       {({ active }) => (
         <button
           className={classNames(
-            active ? "bg-gray-100" : "",
+            active ? "bg-gray-100 dark:bg-white/10" : "",
             danger ? "text-red-700" : "text-gray-700",
             disabled ? "cursor-not-allowed" : "cursor-pointer",
-            "flex items-center block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:text-white dark:hover:bg-gray-600"
+            "flex items-center block w-full text-left px-4 py-2 text-sm dark:text-white"
           )}
           disabled={disabled}
           onClick={onClick}

--- a/src/app/components/Menu/MenuList.tsx
+++ b/src/app/components/Menu/MenuList.tsx
@@ -22,7 +22,7 @@ function List({ position = "left", children }: Props) {
           position === "left"
             ? "left-0 origin-top-left"
             : "right-0 origin-top-right"
-        } absolute z-50 mt-2 py-1 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 dark:border dark:border-gray-500`}
+        } absolute z-50 mt-2 py-1 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-surface-12dp dark:border-0`}
       >
         {children}
       </Menu.Items>

--- a/src/app/components/Menu/MenuSubheader.tsx
+++ b/src/app/components/Menu/MenuSubheader.tsx
@@ -1,6 +1,6 @@
 function MenuSubheader({ children }: { children: string }) {
   return (
-    <span className="select-none px-4 text-gray-500 text-xxs font-medium uppercase dark:text-white">
+    <span className="select-none px-4 text-gray-600 text-xxs font-medium uppercase dark:text-white">
       {children}
     </span>
   );

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export default function Navbar({ title, subtitle, children }: Props) {
   return (
-    <div className="px-4 py-2 bg-white flex justify-between items-center border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
+    <div className="px-4 py-2 bg-white flex justify-between items-center border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
       <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
         <AccountMenu title={title} subtitle={subtitle} />
       </div>

--- a/src/app/components/Navbar/NavbarLink.tsx
+++ b/src/app/components/Navbar/NavbarLink.tsx
@@ -12,10 +12,10 @@ function NavbarLink({ children, end = false, href }: Props) {
       end={end}
       to={href}
       className={({ isActive }) =>
-        "block text-gray-500 hover:text-gray-700 px-1 font-semibold transition-colors duration-200 dark:text-gray-400" +
+        "block px-1 font-semibold transition-colors duration-200" +
         (isActive
           ? " text-orange-bitcoin hover:text-orange-bitcoin dark:text-orange-bitcoin"
-          : "")
+          : " text-gray-600 dark:text-gray-400 hover:text-gray-700")
       }
     >
       {children}

--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 function PaymentSummary({ amount, amountAlt, description }: Props) {
   return (
-    <div className="p-4 shadow bg-white rounded-lg dark:bg-gray-700">
+    <div className="p-4 shadow bg-white rounded-lg dark:bg-surface-02dp">
       <dl className="mb-0">
         <dt className="uppercase font-semibold text-gray-500 text-xs">
           Amount

--- a/src/app/components/PublishersTable/index.tsx
+++ b/src/app/components/PublishersTable/index.tsx
@@ -34,11 +34,11 @@ export default function PublishersTable({
   return (
     <div className="shadow overflow-hidden rounded-lg">
       <table className="min-w-full">
-        <tbody className="bg-white divide-y divide-gray-200 dark:bg-gray-800">
+        <tbody className="bg-white divide-y divide-gray-200 dark:bg-surface-02dp">
           {publishers.map((publisher) => (
             <tr
               key={publisher.id}
-              className="cursor-pointer hover:bg-gray-50 transition duration-200 dark:hover:bg-gray-700"
+              className="cursor-pointer hover:bg-gray-50 transition duration-200 dark:hover:bg-gray-800"
               onClick={() => navigateToPublisher(publisher.id)}
             >
               <td className="px-4 py-6 whitespace-nowrap">

--- a/src/app/components/PublishersTable/index.tsx
+++ b/src/app/components/PublishersTable/index.tsx
@@ -68,7 +68,7 @@ export default function PublishersTable({
                         />
                       )}
                     </div>
-                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                    <div className="text-sm text-gray-700 dark:text-gray-400">
                       {publisher.host} • {publisher.paymentsCount} payments
                     </div>
                   </div>

--- a/src/app/components/QrcodeScanner/index.tsx
+++ b/src/app/components/QrcodeScanner/index.tsx
@@ -111,7 +111,7 @@ function QrcodeScanner({
   }
 
   return (
-    <div className="shadow-sm bg-white rounded-md border border-gray-300 flex flex-col items-center dark:bg-gray-800 p-3">
+    <div className="shadow-sm bg-white rounded-md border border-gray-300 flex flex-col items-center dark:bg-surface-02dp p-3">
       {!isScanning && (
         <>
           <div className="flex justify-center text-center items-center">

--- a/src/app/components/Setting/index.tsx
+++ b/src/app/components/Setting/index.tsx
@@ -8,10 +8,10 @@ function Setting({ title, subtitle, children }: Props) {
   return (
     <div className="py-4 flex justify-between items-center">
       <div>
-        <span className="text-gray-700 dark:text-white font-medium">
+        <span className="text-gray-900 dark:text-white font-medium">
           {title}
         </span>
-        <p className="text-gray-400 text-sm">{subtitle}</p>
+        <p className="text-gray-500 text-sm">{subtitle}</p>
       </div>
       {children}
     </div>

--- a/src/app/components/Setting/index.tsx
+++ b/src/app/components/Setting/index.tsx
@@ -11,7 +11,7 @@ function Setting({ title, subtitle, children }: Props) {
         <span className="text-gray-900 dark:text-white font-medium">
           {title}
         </span>
-        <p className="text-gray-500 text-sm">{subtitle}</p>
+        <p className="text-gray-700 dark:text-gray-500 text-sm">{subtitle}</p>
       </div>
       {children}
     </div>

--- a/src/app/components/SuccessMessage/index.tsx
+++ b/src/app/components/SuccessMessage/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 function SuccessMessage({ message, onClose }: Props) {
   return (
     <>
-      <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+      <dl className="shadow bg-white dark:bg-surface-02dp pt-4 px-4 rounded-lg mb-6 overflow-hidden">
         <dt className="text-sm font-semibold text-gray-500">Message</dt>
         <dd className="text-sm mb-4 dark:text-white break-all">{message}</dd>
       </dl>

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -35,7 +35,7 @@ export default function TransactionsTable({ transactions }: Props) {
 
   return (
     <div className="shadow overflow-hidden rounded-lg">
-      <div className="bg-white divide-y divide-gray-200 dark:bg-gray-700">
+      <div className="bg-white divide-y divide-black/10 dark:divide-white/10 dark:bg-surface-02dp">
         {transactions.map((tx) => (
           <div key={tx.id} className="px-3 py-2">
             <Disclosure>

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -49,7 +49,7 @@ export default function TransactionsTable({ transactions }: Props) {
                       <div className="text-sm font-medium text-gray-900 truncate dark:text-white">
                         {tx.title}
                       </div>
-                      <p className="text-xs text-gray-500 capitalize dark:text-gray-400">
+                      <p className="text-xs text-gray-600 capitalize dark:text-gray-400">
                         {tx.type}
                       </p>
                     </div>
@@ -73,7 +73,7 @@ export default function TransactionsTable({ transactions }: Props) {
                             : "+"}
                           {tx.totalAmount} sat
                         </p>
-                        <p className="text-xs text-gray-400">{tx.date}</p>
+                        <p className="text-xs text-gray-600">{tx.date}</p>
                       </div>
                       <Disclosure.Button className="block h-0 mt-2 text-gray-500 hover:text-black dark:hover:text-white transition-color duration-200">
                         <CaretDownIcon
@@ -83,7 +83,7 @@ export default function TransactionsTable({ transactions }: Props) {
                     </div>
                   </div>
                   <Disclosure.Panel>
-                    <div className="mt-1 ml-9 text-xs text-gray-500 dark:text-gray-400">
+                    <div className="mt-1 ml-9 text-xs text-gray-600 dark:text-gray-400">
                       {tx.description}
                       {tx.preimage && (
                         <p className="truncate">Preimage: {tx.preimage}</p>

--- a/src/app/components/UserMenu/index.tsx
+++ b/src/app/components/UserMenu/index.tsx
@@ -40,7 +40,7 @@ export default function UserMenu() {
 
   return (
     <Menu as="div" className="relative">
-      <Menu.Button className="flex items-center text-gray-500 hover:text-black dark:hover:text-white transition-colors duration-200">
+      <Menu.Button className="flex items-center text-gray-700 hover:text-black dark:hover:text-white transition-colors duration-200">
         <MenuIcon className="h-6 w-6" />
       </Menu.Button>
       <Menu.List position="right">
@@ -49,7 +49,7 @@ export default function UserMenu() {
             openOptions("publishers");
           }}
         >
-          <TransactionsIcon className="h-5 w-5 mr-2 text-gray-500" />
+          <TransactionsIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
           Websites
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -57,7 +57,7 @@ export default function UserMenu() {
             navigate("/send");
           }}
         >
-          <SendIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-500" />
+          <SendIcon className="w-6 h-6 -ml-0.5 mr-2 text-gray-700 dark:text-gray-300" />
           Send
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -65,7 +65,7 @@ export default function UserMenu() {
             navigate("/receive");
           }}
         >
-          <ReceiveIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-500" />
+          <ReceiveIcon className="w-6 h-6 -ml-0.5 mr-2 text-gray-700 dark:text-gray-300" />
           Receive
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -73,7 +73,7 @@ export default function UserMenu() {
             openOptions("settings");
           }}
         >
-          <GearIcon className="h-5 w-5 mr-2 text-gray-500" />
+          <GearIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
           Settings
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -81,12 +81,12 @@ export default function UserMenu() {
             utils.openUrl("https://feedback.getalby.com");
           }}
         >
-          <QuestionIcon className="h-5 w-5 mr-2 text-gray-500" />
+          <QuestionIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
           Feedback
         </Menu.ItemButton>
         <Menu.Divider />
         <Menu.ItemButton onClick={lock}>
-          <LockIcon className="h-5 w-5 mr-2 text-gray-500" />
+          <LockIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
           Lock
         </Menu.ItemButton>
       </Menu.List>

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -38,7 +38,7 @@ export default function Input({
       name={name}
       id={id}
       className={classNames(
-        "block w-full placeholder-gray-400 dark:placeholder-gray-600 dark:text-white",
+        "block w-full placeholder-gray-500 dark:placeholder-gray-600 dark:text-white",
         !suffix && !endAdornment
           ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
           : "pr-0 border-0 focus:ring-0 bg-transparent"

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -29,7 +29,7 @@ export default function Input({
 }: React.InputHTMLAttributes<HTMLInputElement> & Props) {
   const inputEl = useRef<HTMLInputElement>(null);
   const outerStyles =
-    "shadow-sm rounded-md border border-gray-300 dark:bg-gray-200 transition duration-300";
+    "shadow-sm rounded-md border border-gray-300 dark:border-gray-800 bg-white dark:bg-black transition duration-300";
 
   const inputNode = (
     <input
@@ -38,10 +38,10 @@ export default function Input({
       name={name}
       id={id}
       className={classNames(
-        "block w-full placeholder-gray-400 dark:placeholder-gray-600 dark:text-black",
+        "block w-full placeholder-gray-400 dark:placeholder-gray-600 dark:text-white",
         !suffix && !endAdornment
-          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:ring-1`
-          : "pr-0 border-0 focus:ring-0"
+          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
+          : "pr-0 border-0 focus:ring-0 bg-transparent"
       )}
       placeholder={placeholder}
       required={required}
@@ -65,14 +65,14 @@ export default function Input({
     <div
       className={classNames(
         "flex items-stretch overflow-hidden",
-        "focus-within:ring-orange-bitcoin focus-within:border-orange-bitcoin focus-within:ring-1",
+        "focus-within:ring-orange-bitcoin focus-within:border-orange-bitcoin focus-within:dark:border-orange-bitcoin focus-within:ring-1",
         outerStyles
       )}
     >
       {inputNode}
       {suffix && (
         <span
-          className="flex items-center px-3 font-medium bg-white"
+          className="flex items-center px-3 font-medium bg-white dark:bg-surface-00dp dark:text-white"
           onClick={() => {
             inputEl.current?.focus();
           }}
@@ -81,7 +81,9 @@ export default function Input({
         </span>
       )}
       {endAdornment && (
-        <span className="flex items-center bg-white">{endAdornment}</span>
+        <span className="flex items-center bg-white dark:bg-black">
+          {endAdornment}
+        </span>
       )}
     </div>
   );

--- a/src/app/components/form/Select/index.tsx
+++ b/src/app/components/form/Select/index.tsx
@@ -5,7 +5,7 @@ type Props = React.SelectHTMLAttributes<HTMLSelectElement> & {
 function Select({ children, value, name, onChange }: Props) {
   return (
     <select
-      className="w-full border-gray-300 rounded-md shadow-sm text-gray-700 bg-white dark:bg-gray-800 dark:text-gray-200 dark:border-gray-500"
+      className="w-full border-gray-300 rounded-md shadow-sm text-gray-700 bg-white dark:bg-surface-00dp dark:text-gray-200 dark:border-gray-800"
       name={name}
       value={value}
       onChange={onChange}

--- a/src/app/components/form/TextField.tsx
+++ b/src/app/components/form/TextField.tsx
@@ -31,7 +31,7 @@ const TextField = ({
   <>
     <label
       htmlFor={id}
-      className="block font-medium text-gray-700 dark:text-white"
+      className="block font-medium text-gray-800 dark:text-white"
     >
       {label}
     </label>

--- a/src/app/components/form/Toggle/index.tsx
+++ b/src/app/components/form/Toggle/index.tsx
@@ -13,7 +13,7 @@ export default function Toggle({ checked, onChange }: Props) {
       checked={checked}
       onChange={onChange}
       className={classNames(
-        checked ? "bg-orange-bitcoin" : "bg-gray-200",
+        checked ? "bg-orange-bitcoin" : "bg-gray-300 dark:bg-surface-00dp",
         "relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-bitcoin"
       )}
     >

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -151,7 +151,7 @@ const Layout = () => {
 
   return (
     <>
-      <div className="px-4 py-2 bg-white flex border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
+      <div className="px-4 py-2 bg-white flex border-b border-gray-200 dark:bg-surface-02dp dark:border-gray-500">
         <AccountMenu
           title={
             typeof auth.account?.name === "string"

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -99,7 +99,7 @@ function AccountsScreen() {
                         <h3 className="font-bold text-gray-900 dark:text-white">
                           {account.name}
                         </h3>
-                        <p className="text-gray-500 dark:text-gray-400">
+                        <p className="text-gray-700 dark:text-gray-400">
                           {account.connector}
                         </p>
                       </div>
@@ -107,7 +107,7 @@ function AccountsScreen() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <Menu as="div" className="relative">
-                      <Menu.Button className="ml-auto flex items-center text-gray-500 hover:text-black transition-color duration-200 dark:hover:text-white">
+                      <Menu.Button className="ml-auto flex items-center text-gray-700 hover:text-black transition-color duration-200 dark:hover:text-white">
                         <EllipsisIcon className="h-6 w-6 rotate-90" />
                       </Menu.Button>
 

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -75,7 +75,7 @@ function AccountsScreen() {
       <h2 className="mt-12 mb-6 text-2xl font-bold dark:text-white">
         Accounts
       </h2>
-      <div className="shadow border-b border-gray-200 dark:border-gray-500 sm:rounded-lg bg-white dark:bg-gray-800">
+      <div className="shadow border-b border-gray-200 dark:border-gray-500 sm:rounded-lg bg-white dark:bg-surface-02dp">
         <div className="p-6">
           <Button
             icon={<PlusIcon className="w-5 h-5 mr-2" />}
@@ -158,7 +158,7 @@ function AccountsScreen() {
           overlayClassName="bg-black bg-opacity-25 fixed inset-0 flex justify-center items-center p-5"
           className="rounded-lg bg-white w-full max-w-lg"
         >
-          <div className="p-5 flex justify-between dark:bg-gray-800">
+          <div className="p-5 flex justify-between dark:bg-surface-02dp">
             <h2 className="text-2xl font-bold dark:text-white">Edit account</h2>
             <button onClick={closeModal}>
               <CrossIcon className="w-6 h-6 dark:text-white" />
@@ -174,7 +174,7 @@ function AccountsScreen() {
               });
             }}
           >
-            <div className="p-5 border-t border-b border-gray-200 dark:bg-gray-800 dark:border-gray-500">
+            <div className="p-5 border-t border-b border-gray-200 dark:bg-surface-02dp dark:border-gray-500">
               <div className="w-60">
                 <TextField
                   autoFocus
@@ -186,7 +186,7 @@ function AccountsScreen() {
               </div>
             </div>
 
-            <div className="flex justify-end p-5 dark:bg-gray-800">
+            <div className="flex justify-end p-5 dark:bg-surface-02dp">
               <Button
                 label="Save"
                 type="submit"

--- a/src/app/screens/ConfirmSignMessage/index.tsx
+++ b/src/app/screens/ConfirmSignMessage/index.tsx
@@ -62,7 +62,7 @@ function ConfirmSignMessage(props: Props) {
       <div className="p-4 max-w-screen-sm mx-auto">
         {!succesMessage ? (
           <>
-            <dl className="shadow bg-white dark:bg-gray-700 p-4 rounded-lg mb-8">
+            <dl className="shadow bg-white dark:bg-surface-02dp p-4 rounded-lg mb-8">
               <dt className="font-semibold text-gray-500">
                 {originRef.current.host} asks you to sign:
               </dt>

--- a/src/app/screens/Keysend/index.tsx
+++ b/src/app/screens/Keysend/index.tsx
@@ -97,7 +97,7 @@ function Keysend(props: Props) {
       <div className="p-4 max-w-screen-sm mx-auto">
         {!successMessage ? (
           <>
-            <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+            <dl className="shadow bg-white dark:bg-surface-02dp pt-4 px-4 rounded-lg mb-6 overflow-hidden">
               {elements().map(([t, d], i) => (
                 <Fragment key={`element-${i}`}>
                   <dt className="text-sm font-semibold text-gray-500">{t}</dt>

--- a/src/app/screens/LNURLAuth.tsx
+++ b/src/app/screens/LNURLAuth.tsx
@@ -31,7 +31,7 @@ function LNURLAuth({ details, origin }: Props) {
     <div>
       <PublisherCard title={origin.name} image={origin.icon} />
       <div className="p-6">
-        <dl className="shadow bg-white dark:bg-gray-700 p-4 rounded-lg mb-8">
+        <dl className="shadow bg-white dark:bg-surface-02dp p-4 rounded-lg mb-8">
           <dt className="font-semibold text-gray-500">
             {origin.name} asks you to login to
           </dt>

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -281,7 +281,7 @@ function LNURLPay(props: Props) {
 
     return (
       <>
-        <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+        <dl className="shadow bg-white dark:bg-surface-02dp pt-4 px-4 rounded-lg mb-6 overflow-hidden">
           {descriptionList.map(([dt, dd]) => (
             <>
               <Dt>{dt}</Dt>
@@ -311,7 +311,7 @@ function LNURLPay(props: Props) {
       <div className="p-4 max-w-screen-sm mx-auto">
         {!successAction ? (
           <>
-            <div className="shadow bg-white dark:bg-gray-700 py-4 px-4 rounded-lg mb-6 overflow-hidden">
+            <div className="shadow bg-white dark:bg-surface-02dp py-4 px-4 rounded-lg mb-6 overflow-hidden">
               <dl>
                 {loading || !details ? (
                   <>

--- a/src/app/screens/LNURLWithdraw.tsx
+++ b/src/app/screens/LNURLWithdraw.tsx
@@ -87,7 +87,7 @@ function LNURLWithdraw(props: Props) {
       <div className="p-4 max-w-screen-sm mx-auto">
         {!successMessage ? (
           <>
-            <dl className="shadow bg-white dark:bg-gray-700 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+            <dl className="shadow bg-white dark:bg-surface-02dp pt-4 px-4 rounded-lg mb-6 overflow-hidden">
               <dt className="text-sm font-semibold text-gray-500">
                 Amount (Satoshi)
               </dt>

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -73,7 +73,7 @@ function MakeInvoice({ invoiceAttributes, origin }: Props) {
 
       <div className="p-4">
         <div className="mb-8">
-          <div className="p-4 shadow bg-white border-gray-200 rounded-lg dark:bg-gray-700 dark:border-gray-600">
+          <div className="p-4 shadow bg-white border-gray-200 rounded-lg dark:bg-surface-02dp dark:border-gray-600">
             <div>
               <TextField
                 id="amount"

--- a/src/app/screens/Onboard/Intro/index.tsx
+++ b/src/app/screens/Onboard/Intro/index.tsx
@@ -39,7 +39,7 @@ export default function Intro() {
 
   return (
     <div>
-      <div className="relative lg:grid lg:grid-cols-3 lg:gap-x-8 mt-14 bg-white dark:bg-gray-800 px-10 py-12 items-center">
+      <div className="relative lg:grid lg:grid-cols-3 lg:gap-x-8 mt-14 bg-white dark:bg-surface-02dp px-10 py-12 items-center">
         <div className="lg:col-span-1">
           <div className="max-w-xs">
             <img src="assets/icons/satsymbol.svg" alt="sat" className="w-64" />

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -64,7 +64,7 @@ export default function SetPassword() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <div className="relative mt-14 lg:flex space-x-8 bg-white dark:bg-gray-800 py-12 px-10">
+      <div className="relative mt-14 lg:flex space-x-8 bg-white dark:bg-surface-02dp py-12 px-10">
         <div className="lg:w-1/2">
           <h1 className="text-2xl font-bold dark:text-white">
             Protect your wallet

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -118,7 +118,7 @@ export default function TestConnection() {
         overlayClassName="bg-black bg-opacity-25 fixed inset-0"
         className="absolute rounded-lg bg-white w-full max-w-lg"
       >
-        <div className="p-5 flex justify-between dark:bg-gray-800">
+        <div className="p-5 flex justify-between dark:bg-surface-02dp">
           <h2 className="text-2xl font-bold dark:text-white">
             Get some Satoshi
           </h2>
@@ -126,7 +126,7 @@ export default function TestConnection() {
             <CrossIcon className="w-6 h-6 dark:text-white" />
           </button>
         </div>
-        <div className="p-5 border-t border-b border-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200">
+        <div className="p-5 border-t border-b border-gray-200 dark:border-gray-600 dark:bg-surface-02dp dark:text-gray-200">
           <p className="mb-2">
             To get started we send {faucetAmount} sat to your wallet.
             <br />
@@ -144,7 +144,7 @@ export default function TestConnection() {
             />
           </div>
         </div>
-        <div className="flex justify-end p-5 dark:bg-gray-800">
+        <div className="flex justify-end p-5 dark:bg-surface-02dp">
           {faucetLoading ? (
             <Loading />
           ) : (
@@ -156,7 +156,7 @@ export default function TestConnection() {
   }
 
   return (
-    <div className="relative lg:mt-14 lg:grid lg:grid-cols-2 lg:gap-8 bg-white dark:bg-gray-800 px-10 py-12">
+    <div className="relative lg:mt-14 lg:grid lg:grid-cols-2 lg:gap-8 bg-white dark:bg-surface-02dp px-10 py-12">
       <div className="relative">
         <div>
           {errorMessage && (

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -67,7 +67,7 @@ export default function TestConnection() {
 
   return (
     <div>
-      <div className="relative lg:mt-14 lg:grid lg:grid-cols-2 lg:gap-8 bg-white dark:bg-gray-800 px-10 py-12">
+      <div className="relative lg:mt-14 lg:grid lg:grid-cols-2 lg:gap-8 bg-white dark:bg-surface-02dp px-10 py-12">
         <div className="relative">
           <div>
             {errorMessage && (

--- a/src/app/screens/Publishers/index.tsx
+++ b/src/app/screens/Publishers/index.tsx
@@ -49,7 +49,7 @@ function Publishers() {
       <h2 className="mt-12 mb-2 text-2xl font-bold dark:text-white">
         Your ⚡️ Websites
       </h2>
-      <p className="mb-6 text-gray-500">
+      <p className="mb-6 text-gray-700 dark:text-gray-500">
         Websites where you have used Alby before
       </p>
       {data.length > 0 ? (
@@ -63,7 +63,9 @@ function Publishers() {
       <h2 className="mt-12 mb-2 text-2xl font-bold dark:text-white">
         Other ⚡️ Websites
       </h2>
-      <p className="mb-6 text-gray-500">Websites where you can use Alby</p>
+      <p className="mb-6 text-gray-700 dark:text-gray-500">
+        Websites where you can use Alby
+      </p>
       <div className="mb-12">
         {websites.map(({ title, items }) => (
           <div className="mb-6" key={title}>
@@ -82,7 +84,7 @@ function Publishers() {
                         <h2 className="font-medium font-serif text-base dark:text-white">
                           {title}
                         </h2>
-                        <p className="font-serif text-sm font-normal text-gray-500 line-clamp-3">
+                        <p className="font-serif text-sm font-normal text-gray-700 dark:text-gray-500 line-clamp-3">
                           {subtitle}
                         </p>
                       </div>

--- a/src/app/screens/Publishers/index.tsx
+++ b/src/app/screens/Publishers/index.tsx
@@ -58,7 +58,7 @@ function Publishers() {
           navigateToPublisher={navigateToPublisher}
         />
       ) : (
-        <p>No websites yet.</p>
+        <p className="dark:text-white">No websites yet.</p>
       )}
       <h2 className="mt-12 mb-2 text-2xl font-bold dark:text-white">
         Other ⚡️ Websites
@@ -71,7 +71,7 @@ function Publishers() {
             <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
               {items.map(({ title, subtitle, logo, url }) => (
                 <a key={url} href={url} target="_blank" rel="noreferrer">
-                  <div className="bg-white shadow-md flex p-4 h-32 rounded-lg hover:bg-gray-50 cursor-pointer w-full">
+                  <div className="bg-white dark:bg-surface-02dp shadow-md flex p-4 h-32 rounded-lg hover:bg-gray-50 cursor-pointer w-full">
                     <div className="flex space-x-3">
                       <img
                         src={logo}
@@ -79,7 +79,7 @@ function Publishers() {
                         className="h-14 w-14 rounded-xl shadow-md object-cover"
                       />
                       <div>
-                        <h2 className="font-medium font-serif text-base">
+                        <h2 className="font-medium font-serif text-base dark:text-white">
                           {title}
                         </h2>
                         <p className="font-serif text-sm font-normal text-gray-500 line-clamp-3">

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -44,7 +44,7 @@ function Settings() {
       <h2 className="mt-12 mb-6 text-2xl font-bold dark:text-white">
         Settings
       </h2>
-      <div className="shadow bg-white sm:rounded-md sm:overflow-hidden px-6 py-2 divide-y dark:bg-gray-800">
+      <div className="shadow bg-white sm:rounded-md sm:overflow-hidden px-6 py-2 divide-y divide-black/10 dark:divide-white/10 dark:bg-surface-02dp">
         <Setting
           title="Website enhancements"
           subtitle="Tipping enhancements for Twitter, YouTube, etc."

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -158,7 +158,7 @@ export default function ConnectLnd() {
         </div>
         <p className="text-center my-4 dark:text-white">OR</p>
         <div
-          className={`cursor-pointer flex flex-col items-center dark:bg-gray-800 p-4 py-3 border-dashed border-2 border-gray-300 bg-gray-50 rounded-md text-center transition duration-200 ${
+          className={`cursor-pointer flex flex-col items-center dark:bg-surface-02dp p-4 py-3 border-dashed border-2 border-gray-300 bg-gray-50 rounded-md text-center transition duration-200 ${
             isDragging ? "border-blue-500 bg-blue-50" : ""
           }`}
           onDrop={dropHandler}

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -177,7 +177,7 @@ export default function NewWallet() {
             />
           </div>
           <div className="mt-6">
-            <p className="mb-2 text-gray-500 dark:text-gray-400">
+            <p className="mb-2 text-gray-700 dark:text-gray-400">
               Your Alby account also comes with an optional{" "}
               <a
                 className="underline"

--- a/static/views/options.html
+++ b/static/views/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="antialiased dark:bg-gray-900">
+<html lang="en" class="antialiased">
 
 <head>
   <meta charset="UTF-8" />
@@ -7,7 +7,7 @@
   <title>Alby</title>
 </head>
 
-<body class="bg-gray-50 dark:bg-gray-900">
+<body class="bg-gray-50 dark:bg-surface-00dp">
   <div id="options-root"></div>
 </body>
 

--- a/static/views/popup.html
+++ b/static/views/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="antialiased dark:bg-gray-900">
+<html lang="en" class="antialiased">
 
 <head>
   <meta charset="UTF-8" />
@@ -9,7 +9,7 @@
   <meta property="og:image:url" content="/assets/icons/alby_icon_yellow_128x128.png" />
 </head>
 
-<body class="w-96 overflow-x-hidden bg-gray-50 dark:bg-gray-900">
+<body class="w-96 overflow-x-hidden bg-gray-50 dark:bg-surface-00dp">
   <div id="popup-root"></div>
 </body>
 

--- a/static/views/prompt.html
+++ b/static/views/prompt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="antialiased dark:bg-gray-900">
+<html lang="en" class="antialiased">
 
 <head>
   <meta charset="UTF-8" />
@@ -7,7 +7,7 @@
   <title>Alby</title>
 </head>
 
-<body class="bg-gray-50 dark:bg-gray-900">
+<body class="bg-gray-50 dark:bg-surface-00dp">
   <div id="prompt-root"></div>
 </body>
 

--- a/static/views/welcome.html
+++ b/static/views/welcome.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="antialiased dark:bg-gray-900">
+<html lang="en" class="antialiased">
 
 <head>
   <meta charset="UTF-8" />
@@ -7,7 +7,7 @@
   <title>Alby</title>
 </head>
 
-<body class="bg-gray-100 dark:bg-gray-900">
+<body class="bg-gray-100 dark:bg-surface-00dp">
   <div id="welcome-root"></div>
 </body>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,16 @@
 const defaultTheme = require("tailwindcss/defaultTheme");
 
+function lighten(color, percent) {
+  var num = parseInt(color.replace("#",""),16),
+  amt = Math.round(2.55 * percent),
+  R = (num >> 16) + amt,
+  B = (num >> 8 & 0x00FF) + amt,
+  G = (num & 0x0000FF) + amt;
+  return "#" + (0x1000000 + (R<255?R<1?0:R:255)*0x10000 + (B<255?B<1?0:B:255)*0x100 + (G<255?G<1?0:G:255)).toString(16).slice(1);
+};
+
+const surfaceColor = '#121212'
+
 module.exports = {
   darkMode: "class",
   content: ["./static/views/**/*.html", "./src/app/**/*.{js,ts,jsx,tsx}"],
@@ -28,6 +39,30 @@ module.exports = {
         "green-bitcoin": "#27ae60",
         "blue-bitcoin": "#2d9cdb",
         "purple-bitcoin": "#bb6bd9",
+
+        // Material Design Gray Palette
+        "gray-50": "#fafafa",
+        "gray-100": "#f5f5f5",
+        "gray-200": "#eeeeee",
+        "gray-300": "#e0e0e0",
+        "gray-400": "#bdbdbd",
+        "gray-500": "#9e9e9e",
+        "gray-600": "#757575",
+        "gray-700": "#616161",
+        "gray-800": "#424242",
+        "gray-900": "#212121",
+
+        // Material Design Surface Colors
+        "surface-00dp": surfaceColor,
+        "surface-01dp": lighten(surfaceColor, 5),
+        "surface-02dp": lighten(surfaceColor, 7),
+        "surface-03dp": lighten(surfaceColor, 8),
+        "surface-04dp": lighten(surfaceColor, 9),
+        "surface-06dp": lighten(surfaceColor, 11),
+        "surface-08dp": lighten(surfaceColor, 12),
+        "surface-12dp": lighten(surfaceColor, 14),
+        "surface-16dp": lighten(surfaceColor, 15),
+        "surface-24dp": lighten(surfaceColor, 16),
       },
     },
   },


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
- Replace the current default Tailwind gray colors by the Material Design gray theme (get's rid of the shades of blue).
- Implement the Material Design Surface Overlay system.
The dark theme can now be composed of 10 available surfaces (`surface-00dp` - `surface-24dp`).
This surfaces are created by having 1 surfaceColor and applying semi-transparent overlays.
This way the overall dark theme can be adjusted by just changing 1 color: the surface color.
https://material.io/design/color/dark-theme.html

#### Screenshots of the changes (If any) -
Before:
<img width="1792" alt="Schermafbeelding 2022-05-01 om 20 35 02" src="https://user-images.githubusercontent.com/12894112/166159677-a74606ab-fbc6-4fec-8517-56df52871349.png">

After:
<img width="1792" alt="Schermafbeelding 2022-05-01 om 20 34 14" src="https://user-images.githubusercontent.com/12894112/166159691-cf0b525b-78a8-403b-baf7-eb9f366273a0.png">

