### PR TITLE
fix: pressing enter in send screen opens qr code scanner

### DIFF
--- a/src/app/screens/Send.tsx
+++ b/src/app/screens/Send.tsx
@@ -114,6 +114,7 @@ function Send() {
           }
           endAdornment={
             <button
+              type="button"
               className="flex justify-center items-center w-10 h-8"
               onClick={() => setQrIsOpen(true)}
             >


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
If you currently press "enter" after typing something into the invoice field, the QR Code scanner opens.
(While it should submit the form)
