### PR TITLE
added default shortcut command

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -51,6 +51,14 @@
     "__firefox__browser_style": false
   },
 
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+A"
+      }
+    }
+  },
+
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true,

--- a/src/manifest.json.development.sample
+++ b/src/manifest.json.development.sample
@@ -56,6 +56,14 @@
     "__firefox__browser_style": false
   },
 
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+A"
+      }
+    }
+  },
+
   "__chrome|opera__options_page": "options.html",
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
#### Adds default keyboard shortcut of Alt+Shift+A to open Alby extension's popup

#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
added default shortcut command. super simple, just executes the browser action of opening Alby's popup with the command Alt+Shift+A by default on install.

#### Screenshots of the changes (If any) -

#### How Has This Been Tested?
Uninstalled, reinstalled in chrome and firefox, installs with keyboard shortcut by default. 

#### Checklist:

- [ x ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ x ] New and existing tests pass locally with my changes
- [ x ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
