### PR TITLE
Text update to refect users can now also login to their getalby.com accounts

### DIFF
--- a/src/app/router/connectorRoutes.tsx
+++ b/src/app/router/connectorRoutes.tsx
@@ -31,8 +31,8 @@ export default [
   {
     path: "create-wallet",
     element: <NewWallet />,
-    title: "Alby wallet",
-    description: "We manage a lightning wallet for you",
+    title: "Alby Wallet",
+    description: "Create or login to your Alby account",
     logo: alby,
   },
   {

--- a/src/app/router/connectorRoutes.tsx
+++ b/src/app/router/connectorRoutes.tsx
@@ -31,8 +31,8 @@ export default [
   {
     path: "create-wallet",
     element: <NewWallet />,
-    title: "Create a new wallet",
-    description: "We create and manage a lightning wallet for you",
+    title: "Alby wallet",
+    description: "We manage a lightning wallet for you",
     logo: alby,
   },
   {

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -107,7 +107,7 @@ export default function NewWallet() {
     <ConnectorForm
       title={
         lndHubData.login === ""
-          ? "Your Alby lightning wallet"
+          ? "Your Alby Lightning Wallet"
           : "🎉Your account is ready"
       }
       submitLabel="Continue"
@@ -147,7 +147,9 @@ export default function NewWallet() {
         <>
           <div className="mt-6 dark:text-white">
             <strong>
-              Get your Alby account and we host a lightning wallet for you!
+              Create or login to your Alby account.
+              <br />
+              We host a Lightning wallet for you!
             </strong>
           </div>
 

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -107,10 +107,10 @@ export default function NewWallet() {
     <ConnectorForm
       title={
         lndHubData.login === ""
-          ? "Get a new lightning wallet"
+          ? "Your Alby lightning wallet"
           : "🎉Your account is ready"
       }
-      submitLabel={lndHubData.login ? "Continue" : "Create a wallet"}
+      submitLabel="Continue"
       submitLoading={loading}
       onSubmit={lndHubData.login ? next : signup}
       submitDisabled={password === "" || email === ""}
@@ -146,9 +146,9 @@ export default function NewWallet() {
       ) : (
         <>
           <div className="mt-6 dark:text-white">
-            <strong>Create a getAlby.com account</strong>
-            <br />
-            ...and let us host a lightning wallet for you!
+            <strong>
+              Get your Alby account and we host a lightning wallet for you!
+            </strong>
           </div>
 
           <div className="mt-6">


### PR DESCRIPTION
Change text for the Alby wallet connector to emphansize less on creating a new account. 
Users can now also login to existing accounts via email/password.

#### Type of change (Remove other not matching type)

- non-breaking change which adds functionality)

#### Screenshots of the changes (If any) -
<img width="274" alt="image" src="https://user-images.githubusercontent.com/318/166640561-773ee367-d5b6-417a-8807-dfb5fd7b0c2e.png">

<img width="694" alt="image" src="https://user-images.githubusercontent.com/318/166640516-d7b79bfe-b493-4835-ad9e-90c1e51a9f27.png">


