### PR TITLE
style: make sat buttons text a bit smaller

### DIFF
--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 function SatButtons({ onClick }: Props) {
   return (
-    <div className="flex gap-2 mt-2">
+    <div className="flex gap-2 mt-2 text-sm">
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="100 ⚡"


### PR DESCRIPTION
The text does not fit in one line on windows
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Screenshots of the changes (If any) -
Problem: 
<img width="281" alt="image" src="https://user-images.githubusercontent.com/318/166520488-b1f0b65f-e6cd-45ac-a6bb-f05db582d5ba.png">

needs to be tested on windows. 

#### How Has This Been Tested?

open the LNURL pay screen by sending to "hello@getalby.com" 
