### PR TITLE
feat: send screen above the fold

### DIFF
--- a/src/app/components/ConfirmOrCancel/index.tsx
+++ b/src/app/components/ConfirmOrCancel/index.tsx
@@ -19,7 +19,7 @@ function ConfirmOrCancel({
 }: Props) {
   return (
     <div className="text-center">
-      <div className="mb-5">
+      <div className="mb-4">
         <Button
           onClick={onConfirm}
           label="Confirm"
@@ -30,12 +30,12 @@ function ConfirmOrCancel({
         />
       </div>
 
-      <p className="mb-3 underline text-sm text-gray-300">
-        Only connect with sites you trust.
+      <p className="mb-2 text-sm text-gray-400">
+        <em>Only connect with sites you trust.</em>
       </p>
 
       <a
-        className="underline text-sm text-gray-500 dark:text-gray-400"
+        className="underline text-sm text-gray-600 dark:text-gray-400"
         href="#"
         onClick={onCancel}
       >

--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -30,7 +30,7 @@ export default function PublisherCard({
     >
       <div className="flex sm:justify-center items-center">
         <img
-          className="mr-3 w-18 h-18 shrink-0 border-solid border-2 border-white object-cover rounded-full shadow-xl"
+          className="mr-3 w-14 h-14 shrink-0 border-solid border-2 border-white object-cover rounded-full shadow-xl"
           src={image}
           alt=""
           onError={(e) => {

--- a/src/app/router/Popup/Popup.tsx
+++ b/src/app/router/Popup/Popup.tsx
@@ -62,9 +62,9 @@ const Layout = () => {
         }
       />
 
-      <div className="overflow-y-auto grow">
+      <main className="overflow-y-auto grow">
         <Outlet />
-      </div>
+      </main>
     </div>
   );
 };

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -32,11 +32,11 @@ type Props = {
 };
 
 const Dt = ({ children }: { children: React.ReactNode }) => (
-  <dt className="font-medium text-gray-500">{children}</dt>
+  <dt className="font-medium text-gray-800 dark:text-white">{children}</dt>
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="mb-4 dark:text-white">{children}</dd>
+  <dd className="mb-4 dark:text-gray-400">{children}</dd>
 );
 
 function LNURLPay(props: Props) {
@@ -311,7 +311,7 @@ function LNURLPay(props: Props) {
       <div className="p-4 max-w-screen-sm mx-auto">
         {!successAction ? (
           <>
-            <div className="shadow bg-white dark:bg-surface-02dp py-4 px-4 rounded-lg mb-6 overflow-hidden">
+            <div className="mb-4">
               <dl>
                 {loading || !details ? (
                   <>

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -36,7 +36,7 @@ const Dt = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="mb-4 dark:text-gray-400">{children}</dd>
+  <dd className="mb-4 text-gray-600 dark:text-gray-500">{children}</dd>
 );
 
 function LNURLPay(props: Props) {

--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -23,6 +23,15 @@ body {
   font-size: 100%;
 }
 
+main::-webkit-scrollbar { 
+  display: none;
+}
+
+main {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
 .ReactModal__Overlay {
   opacity: 0;
   transition: opacity 200ms ease;


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
- Removed the card style from the send screen as it uses a lot of space.
- Smaller avatar.
- Visually hide scrollbar as in most extensions.

#### Screenshots of the changes (If any) -
Before:
<img width="384" alt="Schermafbeelding 2022-05-04 om 11 12 50" src="https://user-images.githubusercontent.com/12894112/166653719-be5cbd1c-ff49-489d-8690-f04d8d8b1f3b.png">

After:
<img width="384" alt="Schermafbeelding 2022-05-04 om 11 12 24" src="https://user-images.githubusercontent.com/12894112/166653764-9d04ce3b-cadf-4c44-afb0-493e69a46f45.png">

