### PR TITLE
Update success message for Alby wallet login/creation

### DIFF
--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -106,9 +106,7 @@ export default function NewWallet() {
   return (
     <ConnectorForm
       title={
-        lndHubData.login === ""
-          ? "Your Alby Lightning Wallet"
-          : "🎉Your account is ready"
+        lndHubData.login === "" ? "Your Alby Lightning Wallet" : "🎉Success!"
       }
       submitLabel="Continue"
       submitLoading={loading}
@@ -120,7 +118,7 @@ export default function NewWallet() {
           <div className="mt-6 dark:text-white">
             <p>
               <strong>
-                We have created a new wallet for you. <br />
+                Your Alby account is ready. <br />
               </strong>
             </p>
             {lndHubData.lnAddress && (
@@ -131,7 +129,7 @@ export default function NewWallet() {
             <div className="flex-1">
               <strong>Want to use your wallet on your mobile?</strong>
               <br />
-              Import the wallet into your BlueWallet mobile app using the QR
+              Import the wallet into Zeus or BlueWallet mobile app using the QR
               Code.
             </div>
             <div className="float-right">


### PR DESCRIPTION
Change Alby success text to be more universal for login and wallet creation

#### Link this PR to an issue
Fixes #860

#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

<img width="472" alt="image" src="https://user-images.githubusercontent.com/318/166936908-748f90e1-ac48-44c5-99cc-0aa7ff250902.png">

