### PR TITLE
fix: infinite loop upon refreshing the choose connector screen

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -66,7 +66,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           utils.openPage("welcome.html");
           window.close();
         } else if (response.unlocked) {
-          if (onWelcomePage) {
+          if (response.configured && onWelcomePage) {
             utils.redirectPage("options.html");
           }
           setAccountId(response.currentAccountId);


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #874

#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
After setting a password during the onboarding, the status becomes "unlocked". Upon refreshing a screen during the onboarding, this will result in an infinite loop (welcome redirecting to options and vice versa) 
This bug seems to have been introduced by: https://github.com/getAlby/lightning-browser-extension/commit/7d17db559c2a85b943d4554ff161adb815fba606

Thanks to @secondl1ght for catching this!