### PR TITLE
fix: error alert after closing prompt

### DIFF
--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -5,6 +5,7 @@ import PaymentSummary from "@components/PaymentSummary";
 import utils from "~/common/lib/utils";
 import getOriginData from "~/extension/content-script/originData";
 import msg from "~/common/lib/msg";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 import BudgetControl from "@components/BudgetControl";
 import PublisherCard from "@components/PublisherCard";
@@ -74,7 +75,7 @@ function Keysend(props: Props) {
   function reject(e: MouseEvent) {
     e.preventDefault();
     if (props.origin) {
-      msg.error("User rejected");
+      msg.error(USER_REJECTED_ERROR);
     } else {
       navigate(-1);
     }

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -6,6 +6,7 @@ import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 import getOriginData from "~/extension/content-script/originData";
 import type { OriginData } from "~/types";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 import PaymentSummary from "@components/PaymentSummary";
 import PublisherCard from "@components/PublisherCard";
@@ -65,7 +66,7 @@ function ConfirmPayment(props: Props) {
   function reject(e: React.MouseEvent<HTMLAnchorElement>) {
     e.preventDefault();
     if (props.paymentRequest && props.origin) {
-      msg.error("User rejected");
+      msg.error(USER_REJECTED_ERROR);
     } else {
       navigate(-1);
     }

--- a/src/app/screens/ConfirmSignMessage/index.tsx
+++ b/src/app/screens/ConfirmSignMessage/index.tsx
@@ -8,6 +8,7 @@ import utils from "~/common/lib/utils";
 import getOriginData from "~/extension/content-script/originData";
 import type { OriginData } from "~/types";
 import SuccessMessage from "@components/SuccessMessage";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 type Props = {
   origin: OriginData;
@@ -49,7 +50,7 @@ function ConfirmSignMessage(props: Props) {
 
   function reject(e: React.MouseEvent<HTMLAnchorElement>) {
     e.preventDefault();
-    msg.error("User rejected");
+    msg.error(USER_REJECTED_ERROR);
   }
 
   return (

--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -4,6 +4,7 @@ import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import PublisherCard from "@components/PublisherCard";
 import msg from "~/common/lib/msg";
 import type { OriginData } from "~/types";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 type Props = {
   origin: OriginData;
@@ -26,7 +27,7 @@ function Enable(props: Props) {
   }, [budget, remember]);
 
   function reject(event: React.MouseEvent<HTMLAnchorElement>) {
-    msg.error("User rejected");
+    msg.error(USER_REJECTED_ERROR);
     event.preventDefault();
   }
 

--- a/src/app/screens/LNURLAuth.tsx
+++ b/src/app/screens/LNURLAuth.tsx
@@ -2,6 +2,7 @@ import { MouseEvent } from "react";
 
 import type { LNURLAuthServiceResponse } from "~/types";
 import msg from "~/common/lib/msg";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import PublisherCard from "@components/PublisherCard";
@@ -24,7 +25,7 @@ function LNURLAuth({ details, origin }: Props) {
 
   function reject(e: MouseEvent) {
     e.preventDefault();
-    msg.error("User rejected");
+    msg.error(USER_REJECTED_ERROR);
   }
 
   return (

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -16,6 +16,7 @@ import utils from "~/common/lib/utils";
 import lnurl from "~/common/lib/lnurl";
 import getOriginData from "~/extension/content-script/originData";
 import { useAuth } from "~/app/context/AuthContext";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 import Button from "@components/Button";
 import TextField from "@components/form/TextField";
@@ -222,7 +223,7 @@ function LNURLPay(props: Props) {
   function reject(e: MouseEvent) {
     e.preventDefault();
     if (props.details && props.origin) {
-      msg.error("User rejected");
+      msg.error(USER_REJECTED_ERROR);
     } else {
       navigate(-1);
     }

--- a/src/app/screens/LNURLWithdraw.tsx
+++ b/src/app/screens/LNURLWithdraw.tsx
@@ -5,6 +5,7 @@ import type { LNURLWithdrawServiceResponse } from "~/types";
 import getOriginData from "~/extension/content-script/originData";
 import msg from "~/common/lib/msg";
 import api from "~/common/lib/api";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import Input from "@components/form/Input";
@@ -77,7 +78,7 @@ function LNURLWithdraw(props: Props) {
 
   function reject(e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault();
-    msg.error("User rejected");
+    msg.error(USER_REJECTED_ERROR);
   }
 
   return (

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -7,6 +7,7 @@ import msg from "~/common/lib/msg";
 import type { RequestInvoiceArgs } from "~/types";
 import api from "~/common/lib/api";
 import SatButtons from "@components/SatButtons";
+import { USER_REJECTED_ERROR } from "~/common/constants";
 
 type Origin = {
   name: string;
@@ -78,7 +79,7 @@ function MakeInvoice({
 
   function reject(e: React.MouseEvent) {
     e.preventDefault();
-    msg.error("User rejected");
+    msg.error(USER_REJECTED_ERROR);
   }
 
   return (

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,2 @@
+export const ABORT_PROMPT_ERROR = "Prompt was closed";
+export const USER_REJECTED_ERROR = "User rejected";

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -3,6 +3,7 @@ import PubSub from "pubsub-js";
 import browser, { Runtime } from "webextension-polyfill";
 import { SendPaymentResponse } from "~/extension/background-script/connectors/connector.interface";
 import { Message, OriginData, OriginDataInternal } from "~/types";
+import { ABORT_PROMPT_ERROR } from "~/common/constants";
 
 const utils = {
   call: <T = Record<string, unknown>>(
@@ -157,7 +158,7 @@ const utils = {
           const onRemovedListener = (tid: number) => {
             if (tabId === tid) {
               browser.runtime.onMessage.removeListener(onMessageListener);
-              reject(new Error("Prompt was closed"));
+              reject(new Error(ABORT_PROMPT_ERROR));
             }
           };
 

--- a/src/extension/inpage-script/index.js
+++ b/src/extension/inpage-script/index.js
@@ -1,4 +1,5 @@
 import WebLNProvider from "../ln/webln";
+import { ABORT_PROMPT_ERROR, USER_REJECTED_ERROR } from "~/common/constants";
 
 if (document) {
   window.webln = new WebLNProvider();
@@ -66,7 +67,9 @@ if (document) {
         })
         .catch((e) => {
           console.log(e);
-          alert(`Error: ${e.message}`);
+          if (![ABORT_PROMPT_ERROR, USER_REJECTED_ERROR].includes(e.message)) {
+            alert(`Error: ${e.message}`);
+          }
         });
     });
   });


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #866

#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
When the user closes a prompt or clicks "cancel", an alert will pop up with error: ${message}.
To handle types of errors differently I started to introduce constants so we can identify errors and handle them accordingly.
In this case preventing to show an alert to the user.