### PR TITLE
Support paths on the LND URL

### DIFF
--- a/src/extension/background-script/connectors/lnd.ts
+++ b/src/extension/background-script/connectors/lnd.ts
@@ -236,7 +236,7 @@ class Lnd implements Connector {
     defaultValues?: Record<string, unknown>
   ): Promise<Type> {
     const url = new URL(this.config.url);
-    url.pathname = path;
+    url.pathname = `${url.pathname.replace(/\/$/, "")}${path}`;
     let body = null;
     const headers = new Headers();
     headers.append("Accept", "application/json");


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #884

#### Type of change (Remove other not matching type)
- New feature/bugfix (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
Currently we replace the path - assuming that the REST API runs on the root path.
This change now appends the LND API path

#### How Has This Been Tested?

Tried to add a new account which was mentioned on twitter. 
Or: 

* add an LND account with a path
* check the background script console that the HTTP request is made to the correct URL with path: e.g. `/my/path/v1/getInfo`  (for this check you do not need to have an LND running on that path, the request will fail, but you see if the URL was as expected)