### PR TITLE
fix: lndconnect workaround for Firefox

### DIFF
--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -20,8 +20,10 @@ export default function ConnectMyNode() {
   function handleLndconnectUrl(event: React.ChangeEvent<HTMLInputElement>) {
     try {
       const lndconnectUrl = event.target.value.trim();
-      const lndconnect = new URL(lndconnectUrl);
-      const url = "https:" + lndconnect.pathname;
+      let lndconnect = new URL(lndconnectUrl);
+      lndconnect.protocol = "http:";
+      lndconnect = new URL(lndconnect.toString());
+      const url = `https://${lndconnect.hostname}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -20,8 +20,10 @@ export default function ConnectStart9() {
   function handleLndconnectUrl(event: React.ChangeEvent<HTMLInputElement>) {
     try {
       const lndconnectUrl = event.target.value.trim();
-      const lndconnect = new URL(lndconnectUrl);
-      const url = "https:" + lndconnect.pathname;
+      let lndconnect = new URL(lndconnectUrl);
+      lndconnect.protocol = "http:";
+      lndconnect = new URL(lndconnect.toString());
+      const url = `https://${lndconnect.hostname}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -20,8 +20,10 @@ export default function ConnectUmbrel() {
   function handleLndconnectUrl(event: React.ChangeEvent<HTMLInputElement>) {
     try {
       const lndconnectUrl = event.target.value.trim();
-      const lndconnect = new URL(lndconnectUrl);
-      const url = "https:" + lndconnect.pathname;
+      let lndconnect = new URL(lndconnectUrl);
+      lndconnect.protocol = "http:";
+      lndconnect = new URL(lndconnect.toString());
+      const url = `https://${lndconnect.hostname}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector


### PR DESCRIPTION


#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -

This fixes the parsing of lndconnect URLs. Firefox recently made a change to comply with the specs (I could not find a changelog entry, but verified locally) of the `URL()` API, breaking Alby.

#### Screenshots of the changes (If any) -

#### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
