### PR TITLE
chore: add unlocked check to enable call

### DIFF
--- a/src/extension/background-script/actions/allowances/enable.js
+++ b/src/extension/background-script/actions/allowances/enable.js
@@ -1,15 +1,17 @@
+import state from "../../state";
 import db from "../../db";
 import utils from "~/common/lib/utils";
 import setIcon from "../setup/setIcon";
 
 const enable = async (message, sender) => {
+  const isUnlocked = state.getState().isUnlocked();
   const host = message.origin.host || message.args.host;
   const allowance = await db.allowances
     .where("host")
     .equalsIgnoreCase(host)
     .first();
 
-  if (allowance && allowance.enabled) {
+  if (isUnlocked && allowance && allowance.enabled) {
     setIcon({ args: { icon: "active" } }, sender); // highlight the icon when enabled
     return {
       data: { enabled: true },
@@ -45,7 +47,7 @@ const enable = async (message, sender) => {
         },
       };
     } catch (e) {
-      console.log(e);
+      console.error(e);
       return { error: e.message };
     }
   }

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -89,6 +89,9 @@ const state = createState<State>((set, get) => ({
     }
     set({ password: null, connector: null, account: null });
   },
+  isUnlocked: () => {
+    return get().password !== null;
+  },
   init: () => {
     return browser.storage.sync.get(browserStorageKeys).then((result) => {
       // Deep merge to ensure that nested defaults are also merged instead of overwritten.


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
During the enable() call we did not check if Alby is unlocked and ready to use. 
This change now not only checks for an allowance but now also checks if Alby is unlocked.

This means, if a website calls enable() and Alby is locked we now always show the prompt and ask the user to unlock.

If the user has an allowance already set the prompt will close after unlocking
otherwise the user will be asked to confirm the enable() call.

#### How Has This Been Tested?

* Make sure to have an allowance on a website
* Lock Alby
* call webln.enable() - you should be prompted to unlock and the enable() promise resolves afterwards

