### PR TITLE
refactor: input label should be inline

### DIFF
--- a/src/app/components/form/TextField.tsx
+++ b/src/app/components/form/TextField.tsx
@@ -29,10 +29,7 @@ const TextField = ({
   endAdornment,
 }: React.InputHTMLAttributes<HTMLInputElement> & Props) => (
   <>
-    <label
-      htmlFor={id}
-      className="block font-medium text-gray-800 dark:text-white"
-    >
+    <label htmlFor={id} className="font-medium text-gray-800 dark:text-white">
       {label}
     </label>
     <div className="mt-1">


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
Currently when hovering above an amount field, will already show stepper arrows because the label's take up all width.
- Removed making the label a block element (keeping it the default inline)