### PR TITLE
refactor: remove connector badge from accounts dropdown

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -12,7 +12,6 @@ import utils from "~/common/lib/utils";
 import { useAuth } from "~/app/context/AuthContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 
-import Badge from "../Badge";
 import Menu from "../Menu";
 
 export type Props = {
@@ -88,12 +87,6 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
               >
                 <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-700 dark:text-gray-300" />
                 {account.name}&nbsp;
-                <Badge
-                  label={account.connector}
-                  color="blue-500"
-                  textColor="white"
-                  small
-                />
               </Menu.ItemButton>
             );
           })}


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #859

#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
I removed the connectors badge from the accounts dropdown menu.

#### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/85003930/169628750-5b1d6ecf-7f41-430f-938d-49c66a9aea2b.png)

#### How Has This Been Tested?
Ran locally and verified that badges no longer appear in UI.

#### Checklist:

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
