### PR TITLE
chore: add check to not run tests against the production user API

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,10 @@ import { devices } from "@playwright/test";
  */
 // require('dotenv').config();
 
+if (process.env.WALLET_CREATE_URL === "https://getalby.com/api/users") {
+  console.log("----\nDo not run tests against production");
+  process.exit(1);
+}
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,15 @@ import { devices } from "@playwright/test";
 // require('dotenv').config();
 
 if (process.env.WALLET_CREATE_URL === "https://getalby.com/api/users") {
-  console.log("----\nDo not run tests against production");
+  console.error(
+    `
+    ----
+    🚧 🚧 🚧
+    Careful! Do not run tests against production!
+    🚧 🚧 🚧
+    ----
+    `
+  );
   process.exit(1);
 }
 /**


### PR DESCRIPTION
This tries to add a simple check to not accidentally run the end to end tests against the production app.