### PR TITLE
feat: add function to abort polling

### DIFF
--- a/src/app/screens/Receive.tsx
+++ b/src/app/screens/Receive.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   CaretLeftIcon,
@@ -36,6 +36,15 @@ function Receive() {
   const [copyLabel, setCopyLabel] = useState("Copy");
   const [paid, setPaid] = useState(false);
   const [pollingForPayment, setPollingForPayment] = useState(false);
+  const mounted = useRef(false)
+
+  useEffect(() => {
+    mounted.current = true;
+
+    return () => {
+      mounted.current = false
+    }
+  }, [])
 
   function handleChange(
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
@@ -56,6 +65,7 @@ function Receive() {
       validate: (payment) => payment.paid,
       interval: 3000,
       maxAttempts: 20,
+      shouldStopPolling: () => !mounted.current
     })
       .then(() => {
         setPaid(true);

--- a/src/common/utils/helpers.ts
+++ b/src/common/utils/helpers.ts
@@ -58,11 +58,13 @@ export async function poll<T>({
   validate,
   interval,
   maxAttempts,
+  shouldStopPolling,
 }: {
   fn: () => Promise<T>;
   validate: (value: T) => boolean;
   interval: number;
   maxAttempts: number;
+  shouldStopPolling: () => boolean;
 }) {
   let attempts = 0;
 
@@ -70,6 +72,9 @@ export async function poll<T>({
     resolve: (value: unknown) => void,
     reject: (reason?: Error) => void
   ) => {
+    if (shouldStopPolling()) {
+      return reject(new Error("Polling aborted manually"));
+    }
     const result = await fn();
     attempts++;
 


### PR DESCRIPTION
#### Type of change (Remove other not matching type)

- New feature (non-breaking change which adds functionality)

#### Describe the changes you have made in this PR -
The receive screen makes API calls (maxAttempts: 20) to check if an invoice was paid. Currently there is no mechanism to abort those API calls when the receive screen gets closed (unmounted). This PR adds a shouldStopPolling option to the current poll implementation.
