### PR TITLE
fix: return if valid instead of throwing an error

### DIFF
--- a/src/common/utils/signer.ts
+++ b/src/common/utils/signer.ts
@@ -29,7 +29,12 @@ class HashKeySigner {
   }
 
   verify(message: string, signature: string) {
-    return this.sk.verify(message, signature);
+    try {
+      return this.sk.verify(message, signature);
+    } catch (e) {
+      console.error(e);
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #804

#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
VerifyMessage will currently throw an error when using LNBits or LNDHub if a signature is incorrect. The actual behavior should be that it returns a Promise that shows if it was valid or not. 