### PR TITLE
chore(jest): avoid babel loose warning

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -16,13 +16,16 @@
         "loose": true
       }
     ],
-    ["@babel/preset-react", {
-      "runtime": "automatic"
-    }],
+    [
+      "@babel/preset-react",
+      {
+        "runtime": "automatic"
+      }
+    ],
     "@babel/preset-typescript"
   ],
   "plugins": [
-    ["@babel/plugin-proposal-class-properties", {"loose": true}],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }],
     [
       // Polyfills the runtime needed for async/await and generators
       "@babel/plugin-transform-runtime",
@@ -34,9 +37,7 @@
   ],
   "env": {
     "test": {
-      "presets": [
-        ["@babel/preset-env", { "modules": "auto" }]
-      ]
+      "presets": [["@babel/preset-env", { "modules": "auto", "loose": true }]]
     }
   }
 }


### PR DESCRIPTION
Get rid of distracting message when running jest tests in watch-mode:

```sh
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```