### PR TITLE
docs: align Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,39 +1,48 @@
 ---
 name: "🐞 Bug report"
 about: Create a report to help us improve (use this to report bugs only)
-title: ''
+title: ""
 labels: "🐞 bug"
-assignees: ''
-
+assignees: ""
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
 
-**To Reproduce**
+_A clear and concise description of what the bug is_
+
+### Screenshots (If Any)
+
+_Add screenshots to help explain your problem_
+
+### To Reproduce
+
 Steps to reproduce the behavior:
+
 1. Visit to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Click on '....'
+1. Scroll down to '....'
+1. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
 
-**Information About Alby**
+_A clear and concise description of what you expected to happen_
+
+### Alby information
+
 - Alby Version: [e.g. 1.5.0]
 - Alby installed through [e.g. installed through the browser stores, installed manually]
 - Wallet connected with Alby [e.g. LND, BlueWallet LNDhub]
 
-**Screenshots (If Any)**
-Add screenshots to help explain your problem.
+### Device information [optional]:
 
-**Device Information [optional]:**
- - OS: [e.g. Windows]
- - Browser [e.g. chrome, safari, firefox]
- - Browser Version [e.g. 22]
+- OS: [e.g. Windows]
+- Browser [e.g. chrome, safari, firefox]
+- Browser Version [e.g. 22]
 
-**Additional context**
-Add any other additional context about the problem here.
+### Additional context
 
-**Are you working on this issue? (Yes/No)**
+_Add any other additional context about the problem here_
+
+### Are you working on this issue?
+
+_(Yes/No)_

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,22 +1,27 @@
 ---
 name: "✨ Feature request"
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: "✨ feature"
-assignees: ''
-
+assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is.
+### Is your feature request related to a problem? Please describe
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+_A clear and concise description of what the problem is_
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Describe the solution you'd like
 
-**Additional context**
-Add any other additional context or screenshots about the feature request here.
+_A clear and concise description of what you want to happen_
 
-**Are you working on this? (Yes/No)**
+### Describe alternatives you've considered
+
+_A clear and concise description of any alternative solutions or features you've considered_
+
+### Additional context
+
+_Add any other additional context or screenshots about the feature request here_
+
+### Are you working on this?
+
+_(Yes/No)_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,27 @@
-#### Link this PR to an issue
-Fixes #ISSUE-NUMBER
+### Describe the changes you have made in this PR
 
-#### Type of change (Remove other not matching type)
+_A clear and concise description of what you want to happen_
 
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- Documentation update
+### Link this PR to an issue
 
-#### Describe the changes you have made in this PR -
+_#ISSUE-NUMBER_
 
-#### Screenshots of the changes (If any) -
+### Type of change (Remove other not matching type)
 
-#### How Has This Been Tested?
+- `fix`: Bug fix (non-breaking change which fixes an issue)
+- `feat`: New feature (non-breaking change which adds functionality)
+- `feat!`: Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- `docs`: Documentation update
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+### Screenshots of the changes (If any)
 
-#### Checklist:
+_Add screenshots to help explain your problem_
+
+### How has this been tested?
+
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_
+
+### Checklist
 
 - [ ] My code follows the style guidelines of this project and performed a self-review of my own code
 - [ ] New and existing tests pass locally with my changes


### PR DESCRIPTION
Adjusted all templates:

- Use headlines instead of just bold to create automatic margin
- All entries have _descriptions_ to indicate what this means and that these can be removed
- Add further info

What do you think? Anything else we should add or improve?