### PR TITLE
fix: revert browser targets

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -7,7 +7,12 @@
         "useBuiltIns": false,
         // Do not transform modules to CJS
         "modules": false,
-        "targets": "last 5 Chrome versions, last 5 Edge versions, last 5 Opera versions, last 5 Firefox versions",
+        "targets": {
+          "chrome": "49",
+          "firefox": "52",
+          "opera": "36",
+          "edge": "79"
+        },
         "loose": true
       }
     ],


### PR DESCRIPTION
for some reason this causes an issue and the extension does not work.
error: Could not establish connection. Receiving end does not exist.

this was introduced in: https://github.com/getAlby/lightning-browser-extension/pull/911/

<img width="332" alt="image" src="https://user-images.githubusercontent.com/318/170511237-9bf93552-19bd-49c0-a0b0-73579d76b88d.png">
<img width="1379" alt="image" src="https://user-images.githubusercontent.com/318/170511316-5a8d49fa-0ae6-4488-8f69-44d94ba78432.png">
