### PR TITLE
fix: add descriptive message when method is not supported

### DIFF
--- a/src/extension/background-script/connectors/lndhub.ts
+++ b/src/extension/background-script/connectors/lndhub.ts
@@ -352,6 +352,10 @@ export default class LndHub implements Connector {
 
       if (axios.isAxiosError(e)) {
         const errResponse = e.response as AxiosResponse;
+        if (errResponse?.status === 404) {
+          const method = path.replace("/", "");
+          throw new Error(`${method} not supported by the connected account.`);
+        }
         const errorMessage = `${errResponse?.data.message}\n(${e.message})`;
         throw new Error(errorMessage);
       }


### PR DESCRIPTION
#### Link this PR to an issue
Fixes #961

#### Type of change (Remove other not matching type)

- Bug fix (non-breaking change which fixes an issue)

#### Describe the changes you have made in this PR -
Shows: "keysend not supported by the connected account." when not available. Instead of 404.