### PR TITLE
fix: purgecss ignores max-screen classes

### DIFF
--- a/src/app/components/Container.tsx
+++ b/src/app/components/Container.tsx
@@ -1,11 +1,29 @@
+type MaxWidth = "sm" | "md" | "lg" | "xl" | "2xl";
+
 type Props = {
   children: React.ReactNode;
-  maxWidth?: "sm" | "md" | "lg" | "xl" | "2xl";
+  maxWidth?: MaxWidth;
 };
 
 function Container({ children, maxWidth = "lg" }: Props) {
+  // Avoid dynamically created class strings as PurgeCSS doesn't understand this.
+  const getMaxWidthClass = (maxWidth: MaxWidth) => {
+    switch (maxWidth) {
+      case "sm":
+        return "max-w-screen-sm";
+      case "md":
+        return "max-w-screen-md";
+      case "lg":
+        return "max-w-screen-lg";
+      case "xl":
+        return "max-w-screen-xl";
+      case "2xl":
+        return "max-w-screen-2xl";
+    }
+  };
+
   return (
-    <div className={`container max-w-screen-${maxWidth} mx-auto px-4`}>
+    <div className={`container ${getMaxWidthClass(maxWidth)} mx-auto px-4`}>
       {children}
     </div>
   );


### PR DESCRIPTION
### Describe the changes you have made in this PR

Currently max-screen-width-${maxWidth} classes are ignored, because PurgeCSS doesn't handle dynamically created classes. (unless you explicitly define them in your tailwind setup).
This change makes sure that the classes are fully written and can be found by PurgeCSS

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)
