### PR TITLE
refactor: remove custom gray, use new Tailwind's neutral theme

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -60,7 +60,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
       <div
         className={`flex-auto mx-2 py-1 ${!title && !subtitle ? "w-28" : ""}`}
       >
-        <div className="text-xs text-gray-700 dark:text-gray-400">
+        <div className="text-xs text-gray-700 dark:text-neutral-400">
           {title || <Skeleton />}
         </div>
         <div className="text-xs dark:text-white">
@@ -85,7 +85,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                 }}
                 disabled={loading}
               >
-                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-700 dark:text-gray-300" />
+                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-700 dark:text-neutral-300" />
                 {account.name}&nbsp;
               </Menu.ItemButton>
             );
@@ -98,7 +98,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                   openOptions("accounts/new");
                 }}
               >
-                <PlusIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
+                <PlusIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-neutral-300" />
                 Add a new account
               </Menu.ItemButton>
               <Menu.ItemButton
@@ -106,7 +106,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                   openOptions("accounts");
                 }}
               >
-                <AddressBookIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
+                <AddressBookIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-neutral-300" />
                 Accounts
               </Menu.ItemButton>
             </>

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -91,7 +91,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
             <CrossIcon className="w-6 h-6 dark:text-white" />
           </button>
         </div>
-        <div className="p-5 border-t border-b border-gray-200 dark:bg-surface-02dp dark:border-gray-500">
+        <div className="p-5 border-t border-b border-gray-200 dark:bg-surface-02dp dark:border-neutral-500">
           <div className="w-60">
             <TextField
               id="budget"

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -31,7 +31,7 @@ export default function Button({
         fullWidth ? "px-0 py-2" : "px-7 py-2",
         primary
           ? "bg-orange-bitcoin text-white border border-transparent"
-          : `bg-white text-gray-700 border border-gray-300 dark:bg-surface-02dp dark:text-gray-200 dark:border-gray-800`,
+          : `bg-white text-gray-700 border border-gray-300 dark:bg-surface-02dp dark:text-neutral-200 dark:border-neutral-800`,
         primary && !disabled && "hover:bg-orange-bitcoin-700",
         !primary && !disabled && "hover:bg-gray-100 dark:hover:bg-surface-16dp",
         disabled ? "cursor-default opacity-60" : "cursor-pointer",

--- a/src/app/components/ConfirmOrCancel/index.tsx
+++ b/src/app/components/ConfirmOrCancel/index.tsx
@@ -35,7 +35,7 @@ function ConfirmOrCancel({
       </p>
 
       <a
-        className="underline text-sm text-gray-600 dark:text-gray-400"
+        className="underline text-sm text-gray-600 dark:text-neutral-400"
         href="#"
         onClick={onCancel}
       >

--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -32,7 +32,7 @@ function ConnectorForm({
         <div className="lg:w-1/2">
           <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
           {description && (
-            <div className="mb-6 text-gray-500 dark:text-gray-400">
+            <div className="mb-6 text-gray-500 dark:text-neutral-400">
               {typeof description === "string" ? (
                 <p>{description}</p>
               ) : (

--- a/src/app/components/LinkButton/index.tsx
+++ b/src/app/components/LinkButton/index.tsx
@@ -10,14 +10,14 @@ type Props = {
 export default function LinkButton({ to, title, description, logo }: Props) {
   return (
     <Link to={to} className="block">
-      <div className="p-4 bg-white dark:bg-surface-02dp h-96 text-center shadow-lg overflow-hidden border-b border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition duration-200">
+      <div className="p-4 bg-white dark:bg-surface-02dp h-96 text-center shadow-lg overflow-hidden border-b border-gray-300 dark:border-neutral-700 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-800 transition duration-200">
         <div className="my-12">
           <img src={logo} alt="logo" className="inline rounded-3xl w-32" />
         </div>
         <div>
           <span className="block dark:text-white text-lg">{title}</span>
           {description && (
-            <span className="text-sm text-gray-700 dark:text-gray-300">
+            <span className="text-sm text-gray-500 dark:text-neutral-300">
               {description}
             </span>
           )}

--- a/src/app/components/Navbar/NavbarLink.tsx
+++ b/src/app/components/Navbar/NavbarLink.tsx
@@ -15,7 +15,7 @@ function NavbarLink({ children, end = false, href }: Props) {
         "block px-1 font-semibold transition-colors duration-200" +
         (isActive
           ? " text-orange-bitcoin hover:text-orange-bitcoin dark:text-orange-bitcoin"
-          : " text-gray-600 dark:text-gray-400 hover:text-gray-700")
+          : " text-gray-500 dark:text-neutral-400 hover:text-gray-700")
       }
     >
       {children}

--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -8,12 +8,12 @@ function PaymentSummary({ amount, amountAlt, description }: Props) {
   return (
     <dl className="mb-0">
       <dt className="font-medium text-gray-800 dark:text-white">Amount</dt>
-      <dd className="mb-0 text-gray-600 dark:text-gray-500">{amount}</dd>
+      <dd className="mb-0 text-gray-600 dark:text-neutral-500">{amount}</dd>
       {amountAlt && <dd className="text-gray-500">{amountAlt}</dd>}
       <dt className="mt-4 font-medium text-gray-800 dark:text-white">
         Description
       </dt>
-      <dd className="mb-0 text-gray-600 dark:text-gray-500 break-all">
+      <dd className="mb-0 text-gray-600 dark:text-neutral-500 break-all">
         {description}
       </dd>
     </dl>

--- a/src/app/components/PublishersTable/index.tsx
+++ b/src/app/components/PublishersTable/index.tsx
@@ -39,7 +39,7 @@ export default function PublishersTable({
           {publishers.map((publisher) => (
             <tr
               key={publisher.id}
-              className="cursor-pointer hover:bg-gray-50 transition duration-200 dark:hover:bg-gray-800"
+              className="cursor-pointer hover:bg-gray-50 transition duration-200 dark:hover:bg-neutral-800"
               onClick={() => navigateToPublisher(publisher.id)}
             >
               <td className="px-4 py-6 whitespace-nowrap">
@@ -69,7 +69,7 @@ export default function PublishersTable({
                         />
                       )}
                     </div>
-                    <div className="text-sm text-gray-700 dark:text-gray-400">
+                    <div className="text-sm text-gray-500 dark:text-neutral-400">
                       {publisher.host} • {publisher.paymentsCount} payments{" "}
                       {publisher.paymentsAmount > 0 && (
                         <span>({publisher.paymentsAmount} sats)</span>
@@ -81,7 +81,7 @@ export default function PublishersTable({
               <td className="px-6 py-6 whitespace-nowrap text-right">
                 {publisher.totalBudget > 0 && (
                   <div className="ml-40">
-                    <p className="text-lg text-gray-700 mb-0 dark:text-gray-400">
+                    <p className="text-lg text-gray-500 mb-0 dark:text-neutral-400">
                       {publisher.usedBudget} / {publisher.totalBudget} sat used
                     </p>
                     <div className="relative mt-2 ml-auto">

--- a/src/app/components/Setting/index.tsx
+++ b/src/app/components/Setting/index.tsx
@@ -11,7 +11,9 @@ function Setting({ title, subtitle, children }: Props) {
         <span className="text-gray-900 dark:text-white font-medium">
           {title}
         </span>
-        <p className="text-gray-700 dark:text-gray-500 text-sm">{subtitle}</p>
+        <p className="text-gray-500 dark:text-neutral-500 text-sm">
+          {subtitle}
+        </p>
       </div>
       {children}
     </div>

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -49,7 +49,7 @@ export default function TransactionsTable({ transactions }: Props) {
                       <div className="text-sm font-medium text-gray-900 truncate dark:text-white">
                         {tx.title}
                       </div>
-                      <p className="text-xs text-gray-600 capitalize dark:text-gray-400">
+                      <p className="text-xs text-gray-600 capitalize dark:text-neutral-400">
                         {tx.type}
                       </p>
                     </div>
@@ -83,7 +83,7 @@ export default function TransactionsTable({ transactions }: Props) {
                     </div>
                   </div>
                   <Disclosure.Panel>
-                    <div className="mt-1 ml-9 text-xs text-gray-600 dark:text-gray-400">
+                    <div className="mt-1 ml-9 text-xs text-gray-600 dark:text-neutral-400">
                       {tx.description}
                       <p>Fee: {tx.totalFees} sat</p>
                       {tx.preimage && (

--- a/src/app/components/UserMenu/index.tsx
+++ b/src/app/components/UserMenu/index.tsx
@@ -40,7 +40,7 @@ export default function UserMenu() {
 
   return (
     <Menu as="div" className="relative">
-      <Menu.Button className="flex items-center text-gray-700 hover:text-black dark:hover:text-white transition-colors duration-200">
+      <Menu.Button className="flex items-center text-gray-700 dark:text-white hover:text-black dark:hover:text-white transition-colors duration-200">
         <MenuIcon className="h-6 w-6" />
       </Menu.Button>
       <Menu.List position="right">
@@ -49,7 +49,7 @@ export default function UserMenu() {
             openOptions("publishers");
           }}
         >
-          <TransactionsIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
+          <TransactionsIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-neutral-300" />
           Websites
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -57,7 +57,7 @@ export default function UserMenu() {
             navigate("/send");
           }}
         >
-          <SendIcon className="w-6 h-6 -ml-0.5 mr-2 text-gray-700 dark:text-gray-300" />
+          <SendIcon className="w-6 h-6 -ml-0.5 mr-2 text-gray-700 dark:text-neutral-300" />
           Send
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -65,7 +65,7 @@ export default function UserMenu() {
             navigate("/receive");
           }}
         >
-          <ReceiveIcon className="w-6 h-6 -ml-0.5 mr-2 text-gray-700 dark:text-gray-300" />
+          <ReceiveIcon className="w-6 h-6 -ml-0.5 mr-2 text-gray-700 dark:text-neutral-300" />
           Receive
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -73,7 +73,7 @@ export default function UserMenu() {
             openOptions("settings");
           }}
         >
-          <GearIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
+          <GearIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-neutral-300" />
           Settings
         </Menu.ItemButton>
         <Menu.ItemButton
@@ -81,12 +81,12 @@ export default function UserMenu() {
             utils.openUrl("https://feedback.getalby.com");
           }}
         >
-          <QuestionIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
+          <QuestionIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-neutral-300" />
           Feedback
         </Menu.ItemButton>
         <Menu.Divider />
         <Menu.ItemButton onClick={lock}>
-          <LockIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-gray-300" />
+          <LockIcon className="h-5 w-5 mr-2 text-gray-700 dark:text-neutral-300" />
           Lock
         </Menu.ItemButton>
       </Menu.List>

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -29,7 +29,7 @@ export default function Input({
 }: React.InputHTMLAttributes<HTMLInputElement> & Props) {
   const inputEl = useRef<HTMLInputElement>(null);
   const outerStyles =
-    "shadow-sm rounded-md border border-gray-300 dark:border-gray-800 bg-white dark:bg-black transition duration-300";
+    "shadow-sm rounded-md border border-gray-300 dark:border-neutral-800 bg-white dark:bg-black transition duration-300";
 
   const inputNode = (
     <input
@@ -38,7 +38,7 @@ export default function Input({
       name={name}
       id={id}
       className={classNames(
-        "block w-full placeholder-gray-500 dark:placeholder-gray-600 dark:text-white",
+        "block w-full placeholder-gray-500 dark:placeholder-neutral-600 dark:text-white",
         !suffix && !endAdornment
           ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
           : "pr-0 border-0 focus:ring-0 bg-transparent"

--- a/src/app/components/form/Select/index.tsx
+++ b/src/app/components/form/Select/index.tsx
@@ -5,7 +5,7 @@ type Props = React.SelectHTMLAttributes<HTMLSelectElement> & {
 function Select({ children, value, name, onChange }: Props) {
   return (
     <select
-      className="w-full border-gray-300 rounded-md shadow-sm text-gray-700 bg-white dark:bg-surface-00dp dark:text-gray-200 dark:border-gray-800"
+      className="w-full border-gray-300 rounded-md shadow-sm text-gray-700 bg-white dark:bg-surface-00dp dark:text-neutral-200 dark:border-neutral-800"
       name={name}
       value={value}
       onChange={onChange}

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -155,7 +155,7 @@ const Layout = () => {
   return (
     <>
       <ToastContainer />
-      <div className="px-4 py-2 bg-white flex border-b border-gray-200 dark:bg-surface-02dp dark:border-gray-500">
+      <div className="px-4 py-2 bg-white flex border-b border-gray-200 dark:bg-surface-02dp dark:border-neutral-500">
         <AccountMenu
           title={
             typeof auth.account?.name === "string"

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -75,7 +75,7 @@ function AccountsScreen() {
       <h2 className="mt-12 mb-6 text-2xl font-bold dark:text-white">
         Accounts
       </h2>
-      <div className="shadow border-b border-gray-200 dark:border-gray-500 sm:rounded-lg bg-white dark:bg-surface-02dp">
+      <div className="shadow border-b border-gray-200 dark:border-neutral-500 sm:rounded-lg bg-white dark:bg-surface-02dp">
         <div className="p-6">
           <Button
             icon={<PlusIcon className="w-5 h-5 mr-2" />}
@@ -99,7 +99,7 @@ function AccountsScreen() {
                         <h3 className="font-bold text-gray-900 dark:text-white">
                           {account.name}
                         </h3>
-                        <p className="text-gray-700 dark:text-gray-400">
+                        <p className="text-gray-700 dark:text-neutral-400">
                           {account.connector}
                         </p>
                       </div>
@@ -174,7 +174,7 @@ function AccountsScreen() {
               });
             }}
           >
-            <div className="p-5 border-t border-b border-gray-200 dark:bg-surface-02dp dark:border-gray-500">
+            <div className="p-5 border-t border-b border-gray-200 dark:bg-surface-02dp dark:border-neutral-500">
               <div className="w-60">
                 <TextField
                   autoFocus

--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -63,11 +63,11 @@ function Enable(props: Props) {
           Connect with <i>{props.origin.host}</i>
         </h3>
 
-        <p className="text-gray-500 mb-4 dark:text-gray-400">
+        <p className="text-gray-500 mb-4 dark:text-neutral-400">
           <strong>{props.origin.name}</strong> does not have access to your
           account.
         </p>
-        <p className="mb-8 text-gray-500 mb-4 dark:text-gray-400">
+        <p className="mb-8 text-gray-500 mb-4 dark:text-neutral-400">
           Do you want to grant them access?
         </p>
 

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -137,10 +137,10 @@ function Home() {
         <div className="px-4 pb-5">
           <div className="flex justify-between items-center py-3">
             <dl className="mb-0">
-              <dt className="text-xs text-gray-500 dark:tex-gray-400">
+              <dt className="text-xs text-gray-500 dark:text-neutral-400">
                 Allowance
               </dt>
-              <dd className="flex items-center mb-0 text-sm font-medium dark:text-gray-400">
+              <dd className="flex items-center mb-0 text-sm font-medium dark:text-neutral-400">
                 {+allowance.totalBudget > 0
                   ? `${allowance.usedBudget} / ${allowance.totalBudget} `
                   : "0 / 0 "}
@@ -197,7 +197,7 @@ function Home() {
               }))}
             />
           ) : (
-            <p className="text-gray-500 dark:text-gray-400">
+            <p className="text-gray-500 dark:text-neutral-400">
               No transactions on <strong>{allowance.name}</strong> yet.
             </p>
           )}
@@ -272,7 +272,7 @@ function Home() {
                 }))}
               />
             ) : (
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-gray-500 dark:text-neutral-400">
                 No transactions yet.
               </p>
             )}

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -41,7 +41,7 @@ const Dt = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="mb-4 text-gray-600 dark:text-gray-500">{children}</dd>
+  <dd className="mb-4 text-gray-600 dark:text-neutral-500">{children}</dd>
 );
 
 function LNURLPay(props: Props) {

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -28,7 +28,7 @@ const Dt = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="mb-4 text-gray-600 dark:text-gray-500">{children}</dd>
+  <dd className="mb-4 text-gray-600 dark:text-neutral-500">{children}</dd>
 );
 
 function MakeInvoice({

--- a/src/app/screens/Onboard/Intro/features.tsx
+++ b/src/app/screens/Onboard/Intro/features.tsx
@@ -21,7 +21,7 @@ export default function Features({ features }: Props) {
               {feature.name}
             </p>
           </dt>
-          <dd className="mt-2 text-gray-500 dark:text-gray-400">
+          <dd className="mt-2 text-gray-500 dark:text-neutral-400">
             {feature.description}
           </dd>
         </div>

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -80,7 +80,7 @@ export default function SetPassword() {
           <h1 className="text-2xl font-bold dark:text-white">
             {t("set_password.title")}
           </h1>
-          <p className="text-gray-500 mt-6 dark:text-gray-400">
+          <p className="text-gray-500 mt-6 dark:text-neutral-400">
             {t("set_password.description")}
           </p>
           <div className="w-4/5">

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -56,7 +56,7 @@ export default function TestConnection() {
               <h1 className="text-3xl font-bold dark:text-white">
                 {t("test_connection.connection_error")}
               </h1>
-              <p className="dark:text-gray-500">{errorMessage}</p>
+              <p className="dark:text-neutral-500">{errorMessage}</p>
               <Button
                 label={t("test_connection.edit")}
                 onClick={handleEdit}

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -107,7 +107,7 @@ export default function TestConnection() {
                   />
                 </div>
 
-                <p className="mt-6 dark:text-gray-400">
+                <p className="mt-6 dark:text-neutral-400">
                   Awesome, you&apos;re ready to go!
                 </p>
 

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -52,7 +52,7 @@ function Publisher() {
           <div className="flex justify-between items-center pt-8 pb-4">
             <dl>
               <dt className="text-sm font-medium text-gray-500">Allowance</dt>
-              <dd className="flex items-center font-bold text-xl dark:text-gray-400">
+              <dd className="flex items-center font-bold text-xl dark:text-neutral-400">
                 {allowance.usedBudget} / {allowance.totalBudget} sat used
                 <div className="ml-3 w-24">
                   <Progressbar percentage={allowance.percentage} />

--- a/src/app/screens/Publishers/index.tsx
+++ b/src/app/screens/Publishers/index.tsx
@@ -49,7 +49,7 @@ function Publishers() {
       <h2 className="mt-12 mb-2 text-2xl font-bold dark:text-white">
         Your ⚡️ Websites
       </h2>
-      <p className="mb-6 text-gray-700 dark:text-gray-500">
+      <p className="mb-6 text-gray-500 dark:text-neutral-500">
         Websites where you have used Alby before
       </p>
       {data.length > 0 ? (
@@ -63,7 +63,7 @@ function Publishers() {
       <h2 className="mt-12 mb-2 text-2xl font-bold dark:text-white">
         Other ⚡️ Websites
       </h2>
-      <p className="mb-6 text-gray-700 dark:text-gray-500">
+      <p className="mb-6 text-gray-500 dark:text-neutral-500">
         Websites where you can use Alby
       </p>
       <div className="mb-12">
@@ -84,7 +84,7 @@ function Publishers() {
                         <h2 className="font-medium font-serif text-base dark:text-white">
                           {title}
                         </h2>
-                        <p className="font-serif text-sm font-normal text-gray-700 dark:text-gray-500 line-clamp-3">
+                        <p className="font-serif text-sm font-normal text-gray-500 dark:text-neutral-500 line-clamp-3">
                           {subtitle}
                         </p>
                       </div>

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -129,7 +129,7 @@ function Settings() {
       <h2 className="mt-12 text-2xl font-bold dark:text-white">
         Personal data
       </h2>
-      <div className="mb-6 text-gray-700 dark:text-gray-300 text-sm">
+      <div className="mb-6 text-gray-500 dark:text-neutral-500 text-sm">
         Payees can request for additional data to be sent with a payment. This
         data is not shared with anyone without your consent, you will always be
         prompted before this data is sent along with a payment.

--- a/src/app/screens/connectors/ChooseConnector/index.tsx
+++ b/src/app/screens/connectors/ChooseConnector/index.tsx
@@ -13,7 +13,7 @@ export default function ChooseConnector({ title, description }: Props) {
         <div className="mb-6">
           <h1 className="text-3xl font-bold dark:text-white">{title}</h1>
           {description && (
-            <p className="text-gray-500 mt-6 dark:text-gray-400">
+            <p className="text-gray-500 mt-6 dark:text-neutral-400">
               {description}
             </p>
           )}

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -123,7 +123,7 @@ export default function ConnectRaspiBlitz() {
       </div>
       {formData.url.match(/\.onion/i) && <CompanionDownloadInfo />}
       <div className="mt-6">
-        <p className="mb-6 text-gray-500 mt-6 dark:text-gray-400">
+        <p className="mb-6 text-gray-500 mt-6 dark:text-neutral-400">
           Select <b>CONNECT</b>.<br />
           Select <b>EXPORT</b>.<br />
           Select <b>HEX</b>.<br />

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -178,7 +178,7 @@ export default function NewWallet() {
             />
           </div>
           <div className="mt-6">
-            <p className="mb-2 text-gray-700 dark:text-gray-400">
+            <p className="mb-2 text-gray-700 dark:text-neutral-400">
               Your Alby account also comes with an optional{" "}
               <a
                 className="underline"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,15 +1,26 @@
 const defaultTheme = require("tailwindcss/defaultTheme");
+const colors = require("tailwindcss/colors");
 
 function lighten(color, percent) {
-  var num = parseInt(color.replace("#",""),16),
-  amt = Math.round(2.55 * percent),
-  R = (num >> 16) + amt,
-  B = (num >> 8 & 0x00FF) + amt,
-  G = (num & 0x0000FF) + amt;
-  return "#" + (0x1000000 + (R<255?R<1?0:R:255)*0x10000 + (B<255?B<1?0:B:255)*0x100 + (G<255?G<1?0:G:255)).toString(16).slice(1);
-};
+  var num = parseInt(color.replace("#", ""), 16),
+    amt = Math.round(2.55 * percent),
+    R = (num >> 16) + amt,
+    B = ((num >> 8) & 0x00ff) + amt,
+    G = (num & 0x0000ff) + amt;
+  return (
+    "#" +
+    (
+      0x1000000 +
+      (R < 255 ? (R < 1 ? 0 : R) : 255) * 0x10000 +
+      (B < 255 ? (B < 1 ? 0 : B) : 255) * 0x100 +
+      (G < 255 ? (G < 1 ? 0 : G) : 255)
+    )
+      .toString(16)
+      .slice(1)
+  );
+}
 
-const surfaceColor = '#121212'
+const surfaceColor = "#121212";
 
 module.exports = {
   darkMode: "class",
@@ -39,18 +50,6 @@ module.exports = {
         "green-bitcoin": "#27ae60",
         "blue-bitcoin": "#2d9cdb",
         "purple-bitcoin": "#bb6bd9",
-
-        // Material Design Gray Palette
-        "gray-50": "#fafafa",
-        "gray-100": "#f5f5f5",
-        "gray-200": "#eeeeee",
-        "gray-300": "#e0e0e0",
-        "gray-400": "#bdbdbd",
-        "gray-500": "#9e9e9e",
-        "gray-600": "#757575",
-        "gray-700": "#616161",
-        "gray-800": "#424242",
-        "gray-900": "#212121",
 
         // Material Design Surface Colors
         "surface-00dp": surfaceColor,


### PR DESCRIPTION
### Describe the changes you have made in this PR
- Remove custom gray theme. Since Tailwind 3 there are 5 tones of gray: **slate**, **gray** (slightly blue), **neutral**, **zinc** and **stone**. (https://tailwindcss.com/docs/upgrade-guide#renamed-gray-scales)
- Replaces all uses of "gray" in dark mode by "neutral". (hence many file changes which are just replacements)

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)
