### PR TITLE
feat: show it when there is no budget set

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -136,26 +136,21 @@ function Home() {
       <>
         <div className="px-4 pb-5">
           <div className="flex justify-between items-center py-3">
-            {+allowance.totalBudget > 0 ? (
-              <>
-                <dl className="mb-0">
-                  <dt className="text-xs text-gray-500 dark:tex-gray-400">
-                    Allowance
-                  </dt>
-                  <dd className="mb-0 text-sm font-medium dark:text-gray-400">
-                    {allowance.usedBudget} / {allowance.totalBudget} sat used
-                  </dd>
-                </dl>
-              </>
-            ) : (
-              <div />
-            )}
-            <div className="flex items-center">
-              {+allowance.totalBudget > 0 && (
-                <div className="w-24 mr-4">
+            <dl className="mb-0">
+              <dt className="text-xs text-gray-500 dark:tex-gray-400">
+                Allowance
+              </dt>
+              <dd className="flex items-center mb-0 text-sm font-medium dark:text-gray-400">
+                {+allowance.totalBudget > 0
+                  ? `${allowance.usedBudget} / ${allowance.totalBudget} `
+                  : "0 / 0 "}
+                sats used
+                <div className="ml-3 w-24">
                   <Progressbar percentage={allowance.percentage} />
                 </div>
-              )}
+              </dd>
+            </dl>
+            <div className="flex items-center">
               <AllowanceMenu
                 allowance={allowance}
                 onEdit={loadAllowance}


### PR DESCRIPTION
### Describe the changes you have made in this PR
- Currently the allowance menu sits empty on the right and doesn't indicate what it can do.
This change shows there is no budget "0 / 0" just like on the Publisher screen and gives you a hint what you could do with the menu.

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes (If any)

Before:
<img width="384" alt="Schermafbeelding 2022-05-31 om 12 06 51" src="https://user-images.githubusercontent.com/12894112/171149723-ddc5c845-cb20-4955-a379-ae81cb5053ec.png">

After:
<img width="384" alt="Schermafbeelding 2022-05-31 om 12 04 12" src="https://user-images.githubusercontent.com/12894112/171149737-7e09aa23-d0ab-48c2-abbe-c2b5017ce2ce.png">

