### PR TITLE
Refactor/652 account remove delete

### DIFF
--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -28,11 +28,6 @@ export default function TestConnection() {
     setLoading(true);
     try {
       const response = await api.getAccountInfo();
-
-      if ("error" in response) {
-        throw new Error(response.error);
-      }
-
       const name = response.name;
       const { alias } = response.info;
       const { balance: resBalance } = response.balance;

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -36,13 +36,9 @@ export default function TestConnection() {
 
       setAccountInfo({ alias, balance, name });
     } catch (e) {
-      if (typeof e === "string") {
-        console.error(e);
-        setErrorMessage(e);
-      } else if (e instanceof Error) {
-        console.error(e.message);
-        setErrorMessage(e.message);
-      }
+      const message = e instanceof Error ? `(${e.message})` : "";
+      console.error(message);
+      setErrorMessage(message);
     } finally {
       setLoading(false);
     }

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -21,10 +21,9 @@ export default function TestConnection() {
 
   const navigate = useNavigate();
 
-  function handleEdit(event: React.MouseEvent<HTMLButtonElement>) {
-    utils.call("deleteAccount").then(() => {
-      navigate(-1);
-    });
+  async function handleEdit(event: React.MouseEvent<HTMLButtonElement>) {
+    await utils.call("deleteAccount");
+    navigate(-1);
   }
 
   async function loadAccountInfo() {

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -34,8 +34,7 @@ interface UnlockRes {
   currentAccountId: string;
 }
 
-export const getAccountInfo = () =>
-  utils.call<AccountInfoRes | { error: string }>("accountInfo");
+export const getAccountInfo = () => utils.call<AccountInfoRes>("accountInfo");
 
 /**
  * stale-while-revalidate get account info
@@ -57,9 +56,6 @@ export const swrGetAccountInfo = async (
     // Update account info with most recent data, save to cache.
     getAccountInfo()
       .then((response) => {
-        if ("error" in response) {
-          throw new Error(response.error);
-        }
         const { alias } = response.info;
         const { balance: resBalance } = response.balance;
         const name = response.name;

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -18,6 +18,7 @@ import {
 import utils from "./utils";
 
 export interface AccountInfoRes {
+  balance: { balance: string | number };
   currentAccountId: string;
   info: { alias: string };
   name: string;
@@ -55,7 +56,6 @@ export const swrGetAccountInfo = async (
     // Update account info with most recent data, save to cache.
     getAccountInfo()
       .then((response) => {
-        console.log("getAccountInfo - response", response);
         const { alias } = response.info;
         const { balance: resBalance } = response.balance;
         const name = response.name;

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -18,7 +18,6 @@ import {
 import utils from "./utils";
 
 export interface AccountInfoRes {
-  balance: { balance: string | number };
   currentAccountId: string;
   info: { alias: string };
   name: string;
@@ -56,6 +55,7 @@ export const swrGetAccountInfo = async (
     // Update account info with most recent data, save to cache.
     getAccountInfo()
       .then((response) => {
+        console.log("getAccountInfo - response", response);
         const { alias } = response.info;
         const { balance: resBalance } = response.balance;
         const name = response.name;

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -34,7 +34,8 @@ interface UnlockRes {
   currentAccountId: string;
 }
 
-export const getAccountInfo = () => utils.call<AccountInfoRes>("accountInfo");
+export const getAccountInfo = () =>
+  utils.call<AccountInfoRes | { error: string }>("accountInfo");
 
 /**
  * stale-while-revalidate get account info
@@ -56,6 +57,9 @@ export const swrGetAccountInfo = async (
     // Update account info with most recent data, save to cache.
     getAccountInfo()
       .then((response) => {
+        if ("error" in response) {
+          throw new Error(response.error);
+        }
         const { alias } = response.info;
         const { balance: resBalance } = response.balance;
         const name = response.name;

--- a/src/extension/background-script/actions/accounts/delete.ts
+++ b/src/extension/background-script/actions/accounts/delete.ts
@@ -3,25 +3,23 @@ import type { MessageAccountDelete } from "~/types";
 
 const deleteAccount = async (message: MessageAccountDelete) => {
   const accounts = state.getState().accounts;
-
   let currentAccountId = state.getState().currentAccountId;
-  let accountId = message.args.id;
+  let accountId = message?.args?.id;
 
   // if no account is specified, delete the current account
-  if (accountId === undefined && currentAccountId !== null) {
+  if (!accountId && currentAccountId !== null) {
     accountId = currentAccountId;
   }
 
   if (typeof accountId === "string" || typeof accountId === "number") {
     delete accounts[accountId];
     state.setState({ accounts });
+    const accountsUpdated = state.getState().accounts;
+    const accountIds = Object.keys(accountsUpdated);
 
     // if the current account gets deleted we select a new "current account"
-    if (accountId === currentAccountId) {
-      const accountIds = Object.keys(accounts);
-      if (accountIds.length > 0) {
-        currentAccountId = accountIds[0];
-      }
+    if (accountId === currentAccountId && accountIds.length > 0) {
+      currentAccountId = accountIds[0];
       state.setState({ currentAccountId });
     }
 

--- a/src/extension/background-script/actions/accounts/index.ts
+++ b/src/extension/background-script/actions/accounts/index.ts
@@ -4,8 +4,7 @@ import deleteAccount from "./delete";
 import edit from "./edit";
 import info from "./info";
 import lock from "./lock";
-import remove from "./remove";
 import select from "./select";
 import unlock from "./unlock";
 
-export { all, unlock, lock, add, edit, select, info, remove, deleteAccount };
+export { all, unlock, lock, add, edit, select, info, deleteAccount };

--- a/src/extension/background-script/router.ts
+++ b/src/extension/background-script/router.ts
@@ -39,7 +39,6 @@ const routes = {
   addAccount: accounts.add,
   editAccount: accounts.edit,
   getAccounts: accounts.all,
-  removeAccount: accounts.remove,
   deleteAccount: accounts.deleteAccount,
   selectAccount: accounts.select,
   setPassword: setup.setPassword,

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface MessageDefault {
 }
 
 export interface MessageAccountDelete extends MessageDefault {
-  args: { id: Account["id"] };
+  args?: { id: Account["id"] };
   action: "deleteAccount";
 }
 export interface MessageAccountAdd extends MessageDefault {


### PR DESCRIPTION
- Switch `remove` account to `delete` account because it was the same code
- `delete` has more functionality but can handle this as well. Extended the tests
- Switched some code from Promise/then to async/await