### PR TITLE
feat: highlight selected account in menu

### DIFF
--- a/src/app/components/AccountMenu/index.test.tsx
+++ b/src/app/components/AccountMenu/index.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { BrowserRouter } from "react-router-dom";
 import * as AccountsContext from "~/app/context/AccountsContext";
+import * as AuthContext from "~/app/context/AuthContext";
 import type { Accounts } from "~/types";
 
 import AccountMenu from ".";
@@ -20,6 +21,15 @@ const mockAccounts: Accounts = {
 jest.spyOn(AccountsContext, "useAccounts").mockReturnValue({
   accounts: mockAccounts,
   getAccounts: jest.fn(),
+});
+
+jest.spyOn(AuthContext, "useAuth").mockReturnValue({
+  account: { id: "1", name: "LND account" },
+  loading: false,
+  unlock: jest.fn(),
+  lock: jest.fn(),
+  setAccountId: jest.fn(),
+  fetchAccountInfo: jest.fn(),
 });
 
 describe("AccountMenu", () => {
@@ -50,6 +60,21 @@ describe("AccountMenu", () => {
     expect(screen.getByText("Galoy account")).toBeInTheDocument();
     expect(screen.getByText("Add a new account")).toBeInTheDocument();
     expect(screen.getByText("Accounts")).toBeInTheDocument();
+  });
+
+  test("highlights current account", async () => {
+    render(
+      <BrowserRouter>
+        <AccountMenu {...defaultProps} />
+      </BrowserRouter>
+    );
+
+    await userEvent.click(screen.getByText("Toggle Dropdown"));
+
+    // As we have set the active account as "LND account above"
+    expect(
+      screen.getByText("LND account").classList.contains("font-bold")
+    ).toBe(true);
   });
 
   test("displays accounts without options", async () => {

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -83,6 +83,7 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                   selectAccount(accountId);
                 }}
                 disabled={loading}
+                selected={accountId === auth.account?.id}
               >
                 <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 opacity-75 text-gray-700 dark:text-neutral-300" />
                 {account.name}&nbsp;

--- a/src/app/components/Menu/MenuItemButton.tsx
+++ b/src/app/components/Menu/MenuItemButton.tsx
@@ -6,6 +6,7 @@ type Props = {
   danger?: boolean;
   disabled?: boolean;
   onClick: () => void;
+  selected?: boolean;
 };
 
 function MenuItemButton({
@@ -13,6 +14,7 @@ function MenuItemButton({
   danger = false,
   disabled = false,
   onClick,
+  selected = false,
 }: Props) {
   return (
     <Menu.Item>
@@ -22,6 +24,7 @@ function MenuItemButton({
             active ? "bg-gray-100 dark:bg-white/10" : "",
             danger ? "text-red-700" : "text-gray-700",
             disabled ? "cursor-not-allowed" : "cursor-pointer",
+            selected ? "font-bold" : "",
             "flex items-center block w-full text-left px-4 py-2 text-sm dark:text-white"
           )}
           disabled={disabled}


### PR DESCRIPTION
### Describe the changes you have made in this PR

I have added a `selected` prop (as active is already in use because of Headless UI) to highlight the selected button in menu.

### Link this PR to an issue


### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)
![Screenshot from 2022-06-03 23-07-14](https://user-images.githubusercontent.com/64399555/171917223-6530bda4-0301-4eac-a904-dcb0cd906203.png)



### Note

Do we have to update the stories to include the new selected prop? 
(`/src/app/components/Menu/Menu.stories.tsx`)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
