### PR TITLE
fix: selected should only be part of accountmenu

### DIFF
--- a/src/app/components/AccountMenu/index.test.tsx
+++ b/src/app/components/AccountMenu/index.test.tsx
@@ -75,10 +75,9 @@ describe("AccountMenu", () => {
     await waitFor(() => screen.getByText("Switch account"));
 
     // As we have set the active account as "LND account above"
-    const item = screen.getByTitle("LND account");
-    // check if there is a selected icon
-    const icon = item.querySelector('[data-testid="selected"]');
-    expect(icon).not.toBe(null);
+    expect(
+      screen.getByTitle("LND account").querySelector('[data-testid="selected"]')
+    ).toBeInTheDocument();
   });
 
   test("displays accounts without options", async () => {

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -3,6 +3,7 @@ import {
   CaretDownIcon,
   PlusIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
+import { CheckIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import { useState, useEffect } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -84,12 +85,19 @@ function AccountMenu({ title, subtitle, showOptions = true }: Props) {
                 }}
                 disabled={loading}
                 title={account.name}
-                selected={accountId === auth.account?.id}
               >
                 <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 shrink-0 opacity-75 text-gray-700 dark:text-neutral-300" />
                 <span className="overflow-hidden text-ellipsis whitespace-nowrap">
                   {account.name}&nbsp;
                 </span>
+                {accountId === auth.account?.id && (
+                  <span
+                    data-testid="selected"
+                    className="ml-auto w-3.5 h-3.5 rounded-full bg-orange-bitcoin flex justify-center items-center"
+                  >
+                    <CheckIcon className="w-3 h-3 text-white" />
+                  </span>
+                )}
               </Menu.ItemButton>
             );
           })}

--- a/src/app/components/Menu/MenuItemButton.tsx
+++ b/src/app/components/Menu/MenuItemButton.tsx
@@ -1,4 +1,3 @@
-import { CheckIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { Menu } from "@headlessui/react";
 import { classNames } from "~/app/utils/index";
 
@@ -8,7 +7,6 @@ type Props = {
   disabled?: boolean;
   onClick: () => void;
   title?: string;
-  selected?: boolean;
 };
 
 function MenuItemButton({
@@ -17,7 +15,6 @@ function MenuItemButton({
   disabled = false,
   onClick,
   title = "",
-  selected = false,
 }: Props) {
   return (
     <Menu.Item>
@@ -34,14 +31,6 @@ function MenuItemButton({
           title={title}
         >
           {children}
-          {selected && (
-            <span className="ml-auto w-3.5 h-3.5 rounded-full bg-orange-bitcoin flex justify-center items-center">
-              <CheckIcon
-                data-testid="selected"
-                className="w-3 h-3 text-white"
-              />
-            </span>
-          )}
         </button>
       )}
     </Menu.Item>


### PR DESCRIPTION
### Describe the changes you have made in this PR

The selected state of accountmenu should just be part of that component, leaving the MenuItemButton a general component.

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)
