### PR TITLE
fix: prevent multiple parallel webln calls

### DIFF
--- a/src/extension/content-script/index.js
+++ b/src/extension/content-script/index.js
@@ -21,6 +21,7 @@ const weblnCalls = [
 const disabledCalls = ["enable"];
 
 let isEnabled = false; // store if webln is enabled for this content page
+let callActive = false; // store if a webln is currently active. Used to prevent multiple calls in parallel
 
 if (shouldInject()) {
   injectScript();
@@ -41,6 +42,11 @@ if (shouldInject()) {
       return;
     }
     if (ev.data && ev.data.application === "LBE" && !ev.data.response) {
+      // if a call is active we ignore the request
+      if (callActive) {
+        console.error("WebLN call already executing");
+        return;
+      }
       // limit the calls that can be made from webln
       // only listed calls can be executed
       // if not enabled only enable can be called.
@@ -59,6 +65,7 @@ if (shouldInject()) {
         origin: getOriginData(),
       };
       const replyFunction = (response) => {
+        callActive = false; // reset call is active
         // if it is the enable call we store if webln is enabled for this content script
         if (ev.data.type == "enable") {
           isEnabled = response.data?.enabled;
@@ -72,6 +79,7 @@ if (shouldInject()) {
           "*" // TODO use origin
         );
       };
+      callActive = true;
       return browser.runtime
         .sendMessage(messageWithOrigin)
         .then(replyFunction)


### PR DESCRIPTION
### Describe the changes you have made in this PR

Currently webln calls can be called multiple times and can lead to multiple prompts
This change checks that only one call at the time can be made. All parallel calls get ignored.

### Link this PR to an issue

issue #601 

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Open [boltz](https://boltz.exchange/)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
