### PR TITLE
fix: request.type being used instead of request.action

### DIFF
--- a/src/extension/content-script/index.js
+++ b/src/extension/content-script/index.js
@@ -28,7 +28,7 @@ if (shouldInject()) {
 
   // extract LN data from websites
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.type === "extractLightningData") {
+    if (request.action === "extractLightningData") {
       extractLightningData();
     }
   });


### PR DESCRIPTION
This typo prevents extractLightningData() from being called. 

