### PR TITLE
fix: refactor DB loading of allowances/payments

### DIFF
--- a/src/extension/background-script/db.ts
+++ b/src/extension/background-script/db.ts
@@ -100,7 +100,7 @@ class DB extends Dexie {
       })
       .catch((e) => {
         console.log("Failed to load DB data from storage");
-        console.log(e);
+        console.error(e);
       });
   }
 }

--- a/src/extension/background-script/index.js
+++ b/src/extension/background-script/index.js
@@ -107,16 +107,17 @@ async function init() {
   //await browser.storage.sync.set({ settings: { debug: true }, allowances: [] });
   await state.getState().init();
   console.log("State loaded");
+
   await db.open();
+  console.log("DB opened");
 
   events.subscribe();
+  console.log("Events subscribed");
 
-  // initialize a connector for the current account
   browser.runtime.onMessage.addListener(debugLogger);
   // this is the only handler that may and must return a Promise which resolve with the response to the content script
   browser.runtime.onMessage.addListener(routeCalls);
 
-  // TODO: make optional
   browser.tabs.onUpdated.addListener(updateIcon); // update Icon when there is an allowance
 
   // Notify the content script that the tab has been updated.
@@ -131,12 +132,14 @@ async function init() {
       router,
     };
   }
+  console.log("Loading completed");
 }
 
 // The onInstalled event is fired directly after the code is loaded.
 // When we subscribe to that event asynchronously in the init() function it is too late and we miss the event.
 browser.runtime.onInstalled.addListener(handleInstalled);
 
+console.log("Welcome to Alby");
 init().then(() => {
   if (isFirstInstalled) {
     utils.openUrl("welcome.html");


### PR DESCRIPTION
For some reason it seemed that the opening of the DB got blocked. This could be because of an error in adding the data from the extension storage.
Sadly it is not clear what can cause this.
I hope this change makes it a bit more resilient.


We have heard reports about errors that say "Could not establish connection. Receiving end does not exist."
It seems this is because the `db.open()` call never resolves (https://github.com/getAlby/lightning-browser-extension/blob/master/src/extension/background-script/index.js#L110) 
this means the message listeners are not added. 

It is not fully clear why`db.open()` does not resolve, but it seems there are issues with loading data from the extension storage into the IndexedDB. This PR optimizes loading the data. We now only add data when there is no data in the indexeddb and only if we have data in the storage. 
Before we always tried to add the data - this might cause some problem. (but we don't see an error) 
