### PR TITLE
fix: url should include port number

### DIFF
--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -22,7 +22,7 @@ export default function ConnectMyNode() {
       let lndconnect = new URL(lndconnectUrl);
       lndconnect.protocol = "http:";
       lndconnect = new URL(lndconnect.toString());
-      const url = `https://${lndconnect.hostname}${lndconnect.pathname}`;
+      const url = `https://${lndconnect.host}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -22,7 +22,7 @@ export default function ConnectStart9() {
       let lndconnect = new URL(lndconnectUrl);
       lndconnect.protocol = "http:";
       lndconnect = new URL(lndconnect.toString());
-      const url = `https://${lndconnect.hostname}${lndconnect.pathname}`;
+      const url = `https://${lndconnect.host}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -22,7 +22,7 @@ export default function ConnectUmbrel() {
       let lndconnect = new URL(lndconnectUrl);
       lndconnect.protocol = "http:";
       lndconnect = new URL(lndconnect.toString());
-      const url = `https://${lndconnect.hostname}${lndconnect.pathname}`;
+      const url = `https://${lndconnect.host}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -171,6 +171,50 @@ test.describe("Create or connect wallets", () => {
     await commonCreateWalletSuccessCheck({ browser, welcomePage, $document });
   });
 
+  test("successfully connects to myNode", async () => {
+    const { browser, welcomePage, $document } =
+      await commonCreateWalletUserCreate();
+
+    const connectButton = await getByText($document, "myNode");
+    connectButton.click();
+
+    // wait for the field label instead of headline (headline text already exists on the page before)
+    await waitFor(() => getByText($document, "lndconnect REST URL"));
+
+    const macaroon =
+      "AgEDbG5kAvgBAwoQ4hM6HKwsW01W5E4y3GTIVRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgxPl4Pghz-lCiCRgG9eu5GcXcQy4zgAtAFGOtpkhd8O0";
+    const restApiUrl = `lndconnect://lnd1.regtest.getalby.com?cert=&macaroon=${macaroon}`;
+    const lndConnectUrlField = await getByLabelText(
+      $document,
+      "lndconnect REST URL"
+    );
+    await lndConnectUrlField.type(restApiUrl);
+
+    await commonCreateWalletSuccessCheck({ browser, welcomePage, $document });
+  });
+
+  test("successfully connects to Start9", async () => {
+    const { browser, welcomePage, $document } =
+      await commonCreateWalletUserCreate();
+
+    const connectButton = await getByText($document, "Start9");
+    connectButton.click();
+
+    // wait for the field label instead of headline (headline text already exists on the page before)
+    await waitFor(() => getByText($document, "lndconnect REST URL"));
+
+    const macaroon =
+      "AgEDbG5kAvgBAwoQ4hM6HKwsW01W5E4y3GTIVRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgxPl4Pghz-lCiCRgG9eu5GcXcQy4zgAtAFGOtpkhd8O0";
+    const restApiUrl = `lndconnect://lnd1.regtest.getalby.com?cert=&macaroon=${macaroon}`;
+    const lndConnectUrlField = await getByLabelText(
+      $document,
+      "lndconnect REST URL"
+    );
+    await lndConnectUrlField.type(restApiUrl);
+
+    await commonCreateWalletSuccessCheck({ browser, welcomePage, $document });
+  });
+
   test("successfully connects to Eclair", async () => {
     const { browser, welcomePage, $document } =
       await commonCreateWalletUserCreate();

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -1,9 +1,10 @@
 import { test } from "@playwright/test";
 import { USER } from "complete-randomer";
 import { getDocument, queries, waitFor } from "pptr-testing-library";
-const { getByText, getByLabelText } = queries;
 
 import { loadExtension } from "./helpers/loadExtension";
+
+const { getByText, getByLabelText } = queries;
 
 const commonCreateWalletUserCreate = async () => {
   const user = USER.SINGLE();
@@ -144,6 +145,28 @@ test.describe("Create or connect wallets", () => {
       "Macaroon (HEX format)"
     );
     await macroonField.type(macroon);
+
+    await commonCreateWalletSuccessCheck({ browser, welcomePage, $document });
+  });
+
+  test("successfully connects to Umbrel", async () => {
+    const { browser, welcomePage, $document } =
+      await commonCreateWalletUserCreate();
+
+    const connectButton = await getByText($document, "Umbrel");
+    connectButton.click();
+
+    // wait for the field label instead of headline (headline text already exists on the page before)
+    await waitFor(() => getByText($document, "lndconnect REST URL"));
+
+    const macaroon =
+      "AgEDbG5kAvgBAwoQ4hM6HKwsW01W5E4y3GTIVRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgxPl4Pghz-lCiCRgG9eu5GcXcQy4zgAtAFGOtpkhd8O0";
+    const restApiUrl = `lndconnect://lnd1.regtest.getalby.com?cert=&macaroon=${macaroon}`;
+    const lndConnectUrlField = await getByLabelText(
+      $document,
+      "lndconnect REST URL"
+    );
+    await lndConnectUrlField.type(restApiUrl);
 
     await commonCreateWalletSuccessCheck({ browser, welcomePage, $document });
   });


### PR DESCRIPTION
### Describe the changes you have made in this PR

Use host instead of hostname to include the port number.
This prevents `GET https://umbrel.local/v1/getinfo net::ERR_CONNECTION_REFUSED` errors

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)
