### PR TITLE
feat: special Alby meta tags

### DIFF
--- a/src/extension/content-script/originData.ts
+++ b/src/extension/content-script/originData.ts
@@ -194,7 +194,7 @@ const metaDataRules: Record<string, RuleSet> = {
   provider: {
     rules: [
       [
-        'meta[property="alby:site_name"][content]',
+        'meta[property="alby:name"][content]',
         (element) => element.getAttribute("content"),
       ],
       [

--- a/src/extension/content-script/originData.ts
+++ b/src/extension/content-script/originData.ts
@@ -75,6 +75,10 @@ const metaDataRules: Record<string, RuleSet> = {
   description: {
     rules: [
       [
+        'meta[property="alby:description"][content]',
+        (element) => element.getAttribute("content"),
+      ],
+      [
         'meta[property="og:description"][content]',
         (element) => element.getAttribute("content"),
       ],
@@ -189,6 +193,10 @@ const metaDataRules: Record<string, RuleSet> = {
   },
   provider: {
     rules: [
+      [
+        'meta[property="alby:site_name"][content]',
+        (element) => element.getAttribute("content"),
+      ],
       [
         'meta[property="og:site_name"][content]',
         (element) => element.getAttribute("content"),
@@ -491,6 +499,10 @@ const metaDataRules: Record<string, RuleSet> = {
   image: {
     rules: [
       [
+        'meta[property="alby:image"][content]',
+        (element) => element.getAttribute("content"),
+      ],
+      [
         'meta[property="og:image:secure_url"][content]',
         (element) => element.getAttribute("content"),
       ],
@@ -578,6 +590,10 @@ const metaDataRules: Record<string, RuleSet> = {
   },
   icon: {
     rules: [
+      [
+        'meta[property="alby:image"][content]',
+        (element) => element.getAttribute("content"),
+      ],
       [
         'link[rel="apple-touch-icon"][href]',
         (element) => element.getAttribute("href"),


### PR DESCRIPTION
### Describe the changes you have made in this PR

This allows website owners to specifically set the title, description and image for Alby.

The following meta tags will be be preferred within Alby
- `alby:site_name`
- `alby:description`
- `alby:image`

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
