### PR TITLE
feat: add view password using endAdornment

### DIFF
--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -1,3 +1,7 @@
+import {
+  HiddenIcon,
+  VisibleIcon,
+} from "@bitcoin-design/bitcoin-icons-react/outline";
 import Button from "@components/Button";
 import TextField from "@components/form/TextField";
 import React, { useState } from "react";
@@ -19,6 +23,9 @@ export default function SetPassword() {
   const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormData);
   const [errors, setErrors] = useState(initialErrors);
+  const [passwordView, setPasswordView] = useState(false);
+  const [passwordConfirmationView, setPasswordConfirmationView] =
+    useState(false);
   const { t } = useTranslation("translation", {
     keyPrefix: "welcome.set_password",
   });
@@ -80,10 +87,23 @@ export default function SetPassword() {
               <TextField
                 id="password"
                 label={t("choose_password_label")}
-                type="password"
+                type={passwordView ? "text" : "password"}
                 autoFocus
                 required
                 onChange={handleChange}
+                endAdornment={
+                  <button
+                    type="button"
+                    className="flex justify-center items-center w-10 h-8"
+                    onClick={() => setPasswordView(!passwordView)}
+                  >
+                    {passwordView ? (
+                      <HiddenIcon className="h-6 w-6" />
+                    ) : (
+                      <VisibleIcon className="h-6 w-6" />
+                    )}
+                  </button>
+                }
               />
               {errors.password && (
                 <div className="mt-1 text-red-500">{errors.password}</div>
@@ -93,10 +113,25 @@ export default function SetPassword() {
               <TextField
                 id="passwordConfirmation"
                 label={t("confirm_password_label")}
-                type="password"
+                type={passwordConfirmationView ? "text" : "password"}
                 required
                 onChange={handleChange}
                 onBlur={validate}
+                endAdornment={
+                  <button
+                    type="button"
+                    className="flex justify-center items-center w-10 h-8"
+                    onClick={() =>
+                      setPasswordConfirmationView(!passwordConfirmationView)
+                    }
+                  >
+                    {passwordConfirmationView ? (
+                      <HiddenIcon className="h-6 w-6" />
+                    ) : (
+                      <VisibleIcon className="h-6 w-6" />
+                    )}
+                  </button>
+                }
               />
               {errors.passwordConfirmation && (
                 <div className="mt-1 text-red-500">

--- a/src/app/screens/Unlock/index.tsx
+++ b/src/app/screens/Unlock/index.tsx
@@ -1,3 +1,7 @@
+import {
+  HiddenIcon,
+  VisibleIcon,
+} from "@bitcoin-design/bitcoin-icons-react/outline";
 import AlbyLogo from "@components/AlbyLogo";
 import Button from "@components/Button";
 import Input from "@components/form/Input";
@@ -9,6 +13,7 @@ import utils from "~/common/lib/utils";
 
 function Unlock() {
   const [password, setPassword] = useState("");
+  const [passwordView, setPasswordView] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
   const location = useLocation() as {
@@ -57,10 +62,25 @@ function Unlock() {
         <div className="mb-5">
           <Input
             placeholder="Password"
-            type="password"
+            type={passwordView ? "text" : "password"}
             autoFocus
             value={password}
             onChange={handlePasswordChange}
+            endAdornment={
+              <button
+                type="button"
+                className="flex justify-center items-center w-10 h-8"
+                onClick={() => {
+                  setPasswordView(!passwordView);
+                }}
+              >
+                {passwordView ? (
+                  <HiddenIcon className="h-6 w-6" />
+                ) : (
+                  <VisibleIcon className="h-6 w-6" />
+                )}
+              </button>
+            }
           />
           {error && (
             <p className="mt-1 text-red-500">

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -1,3 +1,7 @@
+import {
+  HiddenIcon,
+  VisibleIcon,
+} from "@bitcoin-design/bitcoin-icons-react/outline";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import { useState } from "react";
@@ -7,6 +11,7 @@ import utils from "~/common/lib/utils";
 
 export default function ConnectCitadel() {
   const navigate = useNavigate();
+  const [passwordView, setPasswordView] = useState(false);
   const [formData, setFormData] = useState({
     password: "",
     url: "http://citadel.local",
@@ -88,9 +93,22 @@ export default function ConnectCitadel() {
         <TextField
           label="Password"
           id="password"
-          type="password"
+          type={passwordView ? "text" : "password"}
           required
           onChange={handleChange}
+          endAdornment={
+            <button
+              type="button"
+              className="flex justify-center items-center w-10 h-8"
+              onClick={() => setPasswordView(!passwordView)}
+            >
+              {passwordView ? (
+                <HiddenIcon className="h-6 w-6" />
+              ) : (
+                <VisibleIcon className="h-6 w-6" />
+              )}
+            </button>
+          }
         />
       </div>
       <TextField

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -1,3 +1,7 @@
+import {
+  HiddenIcon,
+  VisibleIcon,
+} from "@bitcoin-design/bitcoin-icons-react/outline";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import { useState } from "react";
@@ -12,6 +16,7 @@ export default function ConnectEclair() {
     url: "",
   });
   const [loading, setLoading] = useState(false);
+  const [passwordView, setPasswordView] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -72,9 +77,22 @@ export default function ConnectEclair() {
         <TextField
           id="password"
           label="Eclair Password"
-          type="text"
+          type={passwordView ? "text" : "password"}
           required
           onChange={handleChange}
+          endAdornment={
+            <button
+              type="button"
+              className="flex justify-center items-center w-10 h-8"
+              onClick={() => setPasswordView(!passwordView)}
+            >
+              {passwordView ? (
+                <HiddenIcon className="h-6 w-6" />
+              ) : (
+                <VisibleIcon className="h-6 w-6" />
+              )}
+            </button>
+          }
         />
       </div>
       <TextField

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -1,3 +1,7 @@
+import {
+  HiddenIcon,
+  VisibleIcon,
+} from "@bitcoin-design/bitcoin-icons-react/outline";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import { useState } from "react";
@@ -19,6 +23,7 @@ export default function NewWallet() {
   });
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [passwordView, setPasswordView] = useState(false);
   const [lnAddress, setLnAddress] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
@@ -182,7 +187,7 @@ export default function NewWallet() {
             <TextField
               id="password"
               label={tCommon("password")}
-              type="password"
+              type={passwordView ? "text" : "password"}
               minLength={6}
               pattern=".{6,}"
               title="at least 6 characters"
@@ -190,6 +195,19 @@ export default function NewWallet() {
               onChange={(e) => {
                 setPassword(e.target.value.trim());
               }}
+              endAdornment={
+                <button
+                  type="button"
+                  className="flex justify-center items-center w-10 h-8"
+                  onClick={() => setPasswordView(!passwordView)}
+                >
+                  {passwordView ? (
+                    <HiddenIcon className="h-6 w-6" />
+                  ) : (
+                    <VisibleIcon className="h-6 w-6" />
+                  )}
+                </button>
+              }
             />
           </div>
           <div className="mt-6">


### PR DESCRIPTION
### Describe the changes you have made in this PR

Follow up to #739. Uses endAdornment prop to add icon to view and hide password.

### Link this PR to an issue

#679

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes (If any)

<p>
<img width="300" src="https://user-images.githubusercontent.com/64399555/159925854-b1e557a4-a1a7-4476-a884-174b4e204f60.png"/>
<img width="300" src="https://user-images.githubusercontent.com/64399555/159925858-9e134a06-6679-4cd4-8a86-75fa8c6e8a4d.png"/>
</p>

## [...and other places where the password field is used]

### How has this been tested?

Checked manually.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
