### PR TITLE
chore: fix react-modal warning

### DIFF
--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -77,6 +77,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
         </Menu.List>
       </Menu>
       <Modal
+        ariaHideApp={false}
         closeTimeoutMS={200}
         isOpen={modalIsOpen}
         onRequestClose={closeModal}

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -201,6 +201,7 @@ function AccountsScreen() {
         </table>
 
         <Modal
+          ariaHideApp={false}
           closeTimeoutMS={200}
           isOpen={editModalIsOpen}
           onRequestClose={closeEditModal}
@@ -248,6 +249,7 @@ function AccountsScreen() {
         </Modal>
 
         <Modal
+          ariaHideApp={false}
           closeTimeoutMS={200}
           isOpen={exportModalIsOpen}
           onRequestClose={closeExportModal}


### PR DESCRIPTION
### Describe the changes you have made in this PR

We don't support screen readers so might as well turn off the`ariaHideApp` prop functionality of the react-modal which hides the background content from being accessed by screen readers when the modal is open.

### Link this PR to an issue

--

### Type of change (Remove other not matching type)

- `chore`

### Screenshots of the changes (If any)

--

### How has this been tested?

Ran all tests

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
