### PR TITLE
feat: intial configuration to render metadata in PaymentSummary

### DIFF
--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -2,9 +2,10 @@ type Props = {
   amount: string | React.ReactNode;
   amountAlt?: string;
   description?: string | React.ReactNode;
+  metadata?: string;
 };
 
-function PaymentSummary({ amount, amountAlt, description }: Props) {
+function PaymentSummary({ amount, amountAlt, description, metadata }: Props) {
   return (
     <dl className="mb-0">
       <dt className="font-medium text-gray-800 dark:text-white">Amount</dt>

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -120,6 +120,7 @@ function Prompt() {
                   <ConfirmPayment
                     paymentRequest={routeParams.args?.paymentRequest as string}
                     origin={routeParams.origin}
+                    metadata={routeParams.args?.metadata as string}
                   />
                 }
               />

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -19,6 +19,7 @@ import type { OriginData } from "~/types";
 export type Props = {
   origin?: OriginData;
   paymentRequest?: string;
+  metadata?: string;
 };
 
 function ConfirmPayment(props: Props) {
@@ -32,6 +33,7 @@ function ConfirmPayment(props: Props) {
     )
   );
   const originRef = useRef(props.origin || getOriginData());
+  const metadataRef = useRef(props.metadata);
   const paymentRequestRef = useRef(
     props.paymentRequest || searchParams.get("paymentRequest")
   );
@@ -61,7 +63,7 @@ function ConfirmPayment(props: Props) {
       const response = await utils.call(
         "sendPayment",
         { paymentRequest: paymentRequestRef.current },
-        { origin: originRef.current }
+        { origin: originRef.current, metadata: metadataRef.current }
       );
       auth.fetchAccountInfo(); // Update balance.
       msg.reply(response);
@@ -108,6 +110,7 @@ function ConfirmPayment(props: Props) {
                 <PaymentSummary
                   amount={invoiceRef.current?.satoshis}
                   description={invoiceRef.current?.tagsObject.description}
+                  metadata={props.metadata}
                 />
               </div>
 


### PR DESCRIPTION
The initial configuration to render metadata in paymentsSummary Dialogue

### Describe the changes you have made in this PR
1. structuring metadata on the client-side according to the schema.org specifications
2. extract metadata passed via sendPayment method
3.  return metadata in the payment response
4. add metadata to PaymentSummary to render it


### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes (If any)

_Add screenshots to help explain your problem_


```RouteParams```

![image](https://user-images.githubusercontent.com/55848322/176018971-6d115f0d-4c88-4649-adef-9eb9cfc8924f.png)



```ConfirmPayment.tsx  -- ```
```props.metadata```
![image](https://user-images.githubusercontent.com/55848322/176019476-e3a0e2d2-8ce8-4545-8e76-9a3dc5e34f6b.png)

```
metadataRef
```
![image](https://user-images.githubusercontent.com/55848322/176020429-fda8c457-1953-4c59-91bb-7cf4e6822ee9.png)


### How has this been tested?

Tested by making payments with and without passing metadata from the client-side using prototype

![image](https://user-images.githubusercontent.com/55848322/175254736-7ae59199-416e-47bd-9750-0728eb56ad41.png)


### Checklist

- [X] My code follows the style guidelines of this project and performed a self-review of my own code
- [X] New and existing tests pass locally with my changes
- [X] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
