### PR TITLE
fix: add dark mode styling for adornment

### DIFF
--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -93,7 +93,7 @@ export default function DualCurrencyField({
         )}
 
         {endAdornment && (
-          <span className="flex items-center bg-white dark:bg-black">
+          <span className="flex items-center bg-white dark:bg-black dark:text-neutral-400">
             {endAdornment}
           </span>
         )}

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -81,7 +81,7 @@ export default function Input({
         </span>
       )}
       {endAdornment && (
-        <span className="flex items-center bg-white dark:bg-black">
+        <span className="flex items-center bg-white dark:bg-black dark:text-neutral-400">
           {endAdornment}
         </span>
       )}


### PR DESCRIPTION
### Describe the changes you have made in this PR

The dark mode style is not added to the adornment and hence the icon/element is not visible in dark mode.

### Link this PR to an issue

#1093

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)
### How has this been tested?

![Screenshot from 2022-06-28 14-33-47](https://user-images.githubusercontent.com/64399555/176139775-281683d4-4a08-4c9e-8cf7-992f2214c7a0.png)


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
