### PR TITLE
fix: show allowances without budget

### DIFF
--- a/src/app/screens/Publishers/index.test.tsx
+++ b/src/app/screens/Publishers/index.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { AccountsProvider } from "../../context/AccountsContext";
+import Publishers from "./index";
+
+jest.mock("~/common/lib/utils", () => {
+  return {
+    call: jest.fn(() => ({
+      allowances: [
+        {
+          host: "https://openai.com/dall-e-2/",
+          name: "DALL·E 2",
+          imageURL: "",
+          enabled: true,
+          lastPaymentAt: 1656408772800,
+          totalBudget: 98756,
+          remainingBudget: 98656,
+          id: 1,
+          usedBudget: 100,
+          percentage: "0",
+          paymentsCount: 1,
+          paymentsAmount: "0100",
+        },
+      ],
+    })),
+  };
+});
+
+describe("Publishers", () => {
+  test("renders active allowance", async () => {
+    render(
+      <AccountsProvider>
+        <MemoryRouter>
+          <Publishers />
+        </MemoryRouter>
+      </AccountsProvider>
+    );
+
+    expect(await screen.findByText("Your ⚡️ Websites")).toBeInTheDocument();
+    expect(await screen.findByText("DALL·E 2")).toBeInTheDocument();
+    expect(await screen.findByText("ACTIVE")).toBeInTheDocument();
+  });
+});

--- a/src/app/screens/Publishers/index.tsx
+++ b/src/app/screens/Publishers/index.tsx
@@ -24,12 +24,7 @@ function Publishers() {
       const allowances: Publisher[] = allowanceResponse.allowances.reduce<
         Publisher[]
       >((acc, allowance) => {
-        if (
-          !allowance?.id ||
-          !allowance.enabled ||
-          allowance.remainingBudget <= 0
-        )
-          return acc;
+        if (!allowance?.id || !allowance.enabled) return acc;
 
         const {
           id,
@@ -55,11 +50,13 @@ function Publishers() {
           percentage,
           totalBudget,
           usedBudget,
-          badge: {
-            label: "ACTIVE",
-            color: "green-bitcoin",
-            textColor: "white",
-          },
+          ...(allowance.remainingBudget > 0 && {
+            badge: {
+              label: "ACTIVE",
+              color: "green-bitcoin",
+              textColor: "white",
+            },
+          }),
         });
 
         return acc;


### PR DESCRIPTION
Allowances without budget should be listed but do not have an "active" badge

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)


