### PR TITLE
Add support to load the exchange rate from the Alby server

### DIFF
--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -176,6 +176,7 @@ function Settings() {
                   });
                 }}
               >
+                <option value="alby">Alby</option>
                 <option value="coindesk">Coindesk</option>
                 <option value="yadio">yadio</option>
               </Select>

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -6,7 +6,7 @@
 export const ABORT_PROMPT_ERROR = "Prompt was closed";
 export const USER_REJECTED_ERROR = "User rejected";
 
-// Supported currencies by Coindesk and yadio
+// Supported currencies by Alby API, Coindesk and yadio
 // FYI: yadio is i.e. not supporting "ISK", maybe more?
 // https://github.com/AryanJ-NYC/bitcoin-conversion/blob/master/src/index.ts#L143
 export enum CURRENCIES {

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -26,19 +26,26 @@ const getFiatBtcRate = async (currency: CURRENCIES): Promise<string> => {
     response = await axios.get(
       `https://api.yadio.io/exrates/${currency.toLowerCase()}`
     );
-
     const data = await response?.data;
 
     return data.BTC;
   }
 
-  response = await axios.get(
-    `https://api.coindesk.com/v1/bpi/currentprice/${currency.toLowerCase()}.json`
-  );
+  if (exchange === "coindesk") {
+    response = await axios.get(
+      `https://api.coindesk.com/v1/bpi/currentprice/${currency.toLowerCase()}.json`
+    );
+    const data = await response?.data;
 
+    return data.bpi[currency].rate_float;
+  }
+
+  response = await axios.get(
+    `https://getalby.com/api/rates/${currency.toLowerCase()}.json`
+  );
   const data = await response?.data;
 
-  return data.bpi[currency].rate_float;
+  return data[currency].rate_float;
 };
 
 // @TODO: https://github.com/getAlby/lightning-browser-extension/issues/1021

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -39,7 +39,7 @@ export const DEFAULT_SETTINGS: SettingsStorage = {
   locale: i18n.resolvedLanguage,
   theme: "system",
   currency: CURRENCIES.USD,
-  exchange: "coindesk",
+  exchange: "alby",
   debug: false,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,4 +379,4 @@ export interface Publisher
   };
 }
 
-export type SupportedExchanges = "coindesk" | "yadio";
+export type SupportedExchanges = "alby" | "coindesk" | "yadio";


### PR DESCRIPTION
### Describe the changes you have made in this PR

This add support to load the fiat exchange rates from the Alby server.
This means we no longer by default request data from third-party services (which has privacy implications for the user)

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### How has this been tested?

This is a manually tested additional settings option.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
