### PR TITLE
fix: handle stored payment amounts in strings

### DIFF
--- a/src/extension/background-script/actions/allowances/__tests__/list.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/list.test.ts
@@ -1,6 +1,88 @@
-import type { MessageAllowanceList } from "~/types";
+import db from "~/extension/background-script/db";
+import type { Allowance, Payment, MessageAllowanceList } from "~/types";
 
 import listAllowances from "../list";
+
+const mockPayments: Payment[] = [
+  {
+    allowanceId: "3",
+    createdAt: "123456",
+    description: "A blue bird?!",
+    destination: "Space",
+    host: "pro.kollider.xyz",
+    id: 4,
+    location: "kollider",
+    name: "Kollider",
+    paymentHash: "123",
+    paymentRequest: "123",
+    preimage: "123",
+    totalAmount: 1000,
+    totalFees: 111,
+  },
+  {
+    allowanceId: "3",
+    createdAt: "123456",
+    description: "A yllow bird?!",
+    destination: "Space",
+    host: "pro.kollider.xyz",
+    id: 5,
+    location: "kollider",
+    name: "Kollider",
+    paymentHash: "123",
+    paymentRequest: "123",
+    preimage: "123",
+    totalAmount: "2000",
+    totalFees: "222",
+  },
+];
+
+const mockAllowances: Allowance[] = [
+  {
+    enabled: true,
+    host: "pro.kollider.xyz",
+    id: 3,
+    imageURL: "https://pro.kollider.xyz/favicon.ico",
+    lastPaymentAt: "0",
+    lnurlAuth: "true",
+    name: "pro kollider",
+    remainingBudget: 500,
+    totalBudget: 500,
+    createdAt: "123456",
+    payments: [],
+    paymentsAmount: 0,
+    paymentsCount: 0,
+    percentage: "0",
+    usedBudget: 0,
+    tag: "",
+  },
+  {
+    enabled: true,
+    host: "lnmarkets.com",
+    id: 4,
+    imageURL: "https://lnmarkets.com/apple-touch-icon.png",
+    lastPaymentAt: "0",
+    lnurlAuth: "false",
+    name: "LN Markets",
+    remainingBudget: 200,
+    totalBudget: 200,
+    createdAt: "1487076708000",
+    payments: [],
+    paymentsAmount: 0,
+    paymentsCount: 0,
+    percentage: "0",
+    usedBudget: 0,
+    tag: "",
+  },
+];
+
+const resultAllowances: Allowance[] = [
+  mockAllowances[1],
+  {
+    ...mockAllowances[0],
+    paymentsAmount: 3000,
+    paymentsCount: 2,
+  },
+];
 
 describe("account all", () => {
   afterEach(() => {
@@ -17,9 +99,12 @@ describe("account all", () => {
       },
     };
 
+    await db.payments.bulkAdd(mockPayments);
+    await db.allowances.bulkAdd(mockAllowances);
+
     expect(await listAllowances(message)).toStrictEqual({
       data: {
-        allowances: [],
+        allowances: resultAllowances,
       },
     });
   });

--- a/src/extension/background-script/actions/allowances/list.ts
+++ b/src/extension/background-script/actions/allowances/list.ts
@@ -27,7 +27,12 @@ const list = async (message: MessageAllowanceList) => {
       .toArray();
 
     allowance.paymentsAmount = payments
-      .map((payment) => payment.totalAmount)
+      .map((payment) => {
+        if (typeof payment.totalAmount === "string") {
+          return parseInt(payment.totalAmount);
+        }
+        return payment.totalAmount;
+      })
       .reduce((previous, current) => previous + current, 0);
 
     return allowance;

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,19 +270,19 @@ export type Transaction = {
 };
 
 export interface Payment {
-  id?: number;
   allowanceId: string;
+  createdAt: string;
+  description: string;
+  destination: string;
   host: string;
+  id?: number;
   location: string;
   name: string;
-  description: string;
+  paymentHash: string;
+  paymentRequest: string;
+  preimage: string;
   totalAmount: number | string;
   totalFees: number | string;
-  preimage: string;
-  paymentRequest: string;
-  paymentHash: string;
-  destination: string;
-  createdAt: string;
 }
 
 export interface PaymentResponse

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,8 +276,8 @@ export interface Payment {
   location: string;
   name: string;
   description: string;
-  totalAmount: number;
-  totalFees: number;
+  totalAmount: number | string;
+  totalFees: number | string;
   preimage: string;
   paymentRequest: string;
   paymentHash: string;


### PR DESCRIPTION
we seem to still store payment amounts in strings.
This causes that numbers are concatenated instead of summed up.

### Describe the changes you have made in this PR
<img width="1253" alt="image" src="https://user-images.githubusercontent.com/318/178610237-f81318f3-2543-4911-abce-ee6c621479c9.png">


### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

