### PR TITLE
style: change sats icon to alby logo on onboard success screen

### DIFF
--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -54,11 +54,18 @@ function ConnectorForm({
                 </video>
               </div>
             ) : (
-              <img
-                src="assets/icons/satsymbol.svg"
-                alt="sats"
-                className="w-64"
-              />
+              <>
+                <img
+                  src="assets/icons/alby_logo.svg"
+                  alt="Alby"
+                  className="block dark:hidden w-64"
+                />
+                <img
+                  src="assets/icons/alby_logo_dark.svg"
+                  alt="Alby"
+                  className="hidden dark:block w-64"
+                />
+              </>
             )}
           </div>
         </div>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -68,7 +68,7 @@
           }
         },
         "post_connect": {
-          "title": "🎉Success!",
+          "title": "🎉 Success!",
           "account_ready": "Your Alby account is ready.",
           "lightning_address": "Your lightning address:",
           "wallet_mobile_title": "Want to use your wallet on your mobile?",


### PR DESCRIPTION
### Describe the changes you have made in this PR

Updated the sats icon to the Alby logo on the onboard success screen.

### Link this PR to an issue

https://github.com/getAlby/lightning-browser-extension/pull/1153#issuecomment-1186837656

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes (If any)

![image](https://user-images.githubusercontent.com/85003930/179627585-953b2e7d-9da8-4b5e-8b12-638d81e19c35.png)

### How has this been tested?

Tested locally on light and dark modes.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
