### PR TITLE
feat: add feedback form on uninstall

### DIFF
--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -157,4 +157,4 @@ init().then(() => {
   }
 });
 
-browser.runtime.setUninstallURL("https://form.jotform.com/221745756722057");
+browser.runtime.setUninstallURL("https://getalby.com/thanks");

--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -157,4 +157,4 @@ init().then(() => {
   }
 });
 
-browser.runtime.setUninstallURL("https://getalby.com/thanks");
+browser.runtime.setUninstallURL("https://getalby.com/goodbye");

--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -156,3 +156,5 @@ init().then(() => {
     utils.openUrl("welcome.html");
   }
 });
+
+browser.runtime.setUninstallURL("https://form.jotform.com/221745756722057");


### PR DESCRIPTION
### Describe the changes you have made in this PR

When a user uninstalls Alby they will now be directed to this URL: https://form.jotform.com/221745756722057

### Link this PR to an issue

#210 

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes (If any)

![image](https://user-images.githubusercontent.com/85003930/179890343-ac3387f9-5321-4434-8880-22c53502bf49.png)

### How has this been tested?

Uninstalled the app and was taken to the feedback form.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
