### PR TITLE
chore: removing state subscription to persist to browser storage

### DIFF
--- a/src/extension/background-script/actions/accounts/__tests__/select.test.ts
+++ b/src/extension/background-script/actions/accounts/__tests__/select.test.ts
@@ -8,6 +8,7 @@ jest.mock("~/extension/background-script/state");
 const mockState = {
   currentAccountId: "8b7f1dc6-ab87-4c6c-bca5-19fa8632731e",
   getConnector: jest.fn,
+  saveToStorage: jest.fn,
   accounts: {
     "8b7f1dc6-ab87-4c6c-bca5-19fa8632731e": {
       config:
@@ -42,12 +43,14 @@ describe("select account", () => {
   test("select", async () => {
     state.getState = jest.fn().mockReturnValue(mockState);
 
-    const spy = jest.spyOn(mockState, "getConnector");
+    const connectorSpy = jest.spyOn(mockState, "getConnector");
+    const saveSpy = jest.spyOn(mockState, "saveToStorage");
 
     expect(await select(message)).toStrictEqual({
       data: { unlocked: true },
     });
 
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(connectorSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/extension/background-script/actions/accounts/select.ts
+++ b/src/extension/background-script/actions/accounts/select.ts
@@ -17,6 +17,7 @@ const select = async (message: MessageAccountSelect) => {
       connector: null, // reset memoized connector
       currentAccountId: accountId,
     });
+    await state.getState().saveToStorage();
 
     // init connector this also memoizes the connector in the state object
     await state.getState().getConnector();

--- a/src/extension/background-script/actions/setup/reset.js
+++ b/src/extension/background-script/actions/setup/reset.js
@@ -9,6 +9,7 @@ const reset = async (message, sender) => {
     password: null,
     currentAccountId: null,
   });
+  await state.getState().saveToStorage();
 
   return { data: { reset: true } };
 };

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -114,22 +114,4 @@ const state = createState<State>((set, get) => ({
   },
 }));
 
-browserStorageKeys.forEach((key) => {
-  console.info(`Adding state subscription for ${key}`);
-  state.subscribe(
-    (newValue, previousValue) => {
-      //if (previous && Object.keys(previous) > 0) {
-      const data = { [key]: newValue };
-      return browser.storage.sync.set(data);
-      //}
-      //return Promise.resolve();
-    },
-    (state) => state[key],
-    (newValue, previousValue) => {
-      // NOTE: using JSON.stringify to compare objects
-      return JSON.stringify(newValue) === JSON.stringify(previousValue);
-    }
-  );
-});
-
 export default state;


### PR DESCRIPTION
we now manually call the saveToStorage() method whenever needed.
That means we should not need the complexity of these state subscriptions
