### PR TITLE
feat(app): Show and convert fiats if setting is enabled

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -68,14 +68,16 @@ function AccountMenu({ title, balances, showOptions = true }: Props) {
           {title || <Skeleton />}
         </p>
 
-        {balances.satsBalance && balances.fiatBalance ? (
+        {balances.satsBalance ? (
           <p className="flex justify-between">
             <span className="text-xs dark:text-white">
               {balances.satsBalance}
             </span>
-            <span className="text-xs text-gray-600 dark:text-neutral-400">
-              ~{balances.fiatBalance}
-            </span>
+            {!!balances.fiatBalance && (
+              <span className="text-xs text-gray-600 dark:text-neutral-400">
+                ~{balances.fiatBalance}
+              </span>
+            )}
           </p>
         ) : (
           <Skeleton />

--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -1,9 +1,21 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import * as SettingsContext from "~/app/context/SettingsContext";
+import type { SettingsStorage } from "~/types";
 
 import type { Props } from "./index";
 import AllowanceMenu from "./index";
+
+const mockSettings = {
+  showFiat: true,
+} as SettingsStorage;
+
+jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+  settings: mockSettings,
+  isLoading: false,
+  updateSetting: jest.fn(),
+});
 
 jest.mock("~/common/lib/utils");
 

--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -1,15 +1,11 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import * as SettingsContext from "~/app/context/SettingsContext";
-import type { SettingsStorage } from "~/types";
 
 import type { Props } from "./index";
 import AllowanceMenu from "./index";
-
-const mockSettings = {
-  showFiat: true,
-} as SettingsStorage;
 
 jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -2,6 +2,7 @@ import { GearIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { CrossIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import { useState, useEffect } from "react";
 import Modal from "react-modal";
+import { useSettings } from "~/app/context/SettingsContext";
 import utils from "~/common/lib/utils";
 import { getFiatValue } from "~/common/utils/currencyConvert";
 import type { Allowance } from "~/types";
@@ -17,18 +18,21 @@ export type Props = {
 };
 
 function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
+  const { isLoading: isLoadingSettings, settings } = useSettings();
+  const showFiat = !isLoadingSettings && settings.showFiat;
+
   const [modalIsOpen, setIsOpen] = useState(false);
   const [budget, setBudget] = useState("0");
   const [fiatAmount, setFiatAmount] = useState("");
 
   useEffect(() => {
-    if (budget !== "") {
+    if (budget !== "" && showFiat) {
       (async () => {
         const res = await getFiatValue(budget);
         setFiatAmount(res);
       })();
     }
-  }, [budget]);
+  }, [budget, showFiat]);
 
   function openModal() {
     setBudget(allowance.totalBudget.toString());

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -79,9 +79,11 @@ export default function TransactionsTable({ transactions }: Props) {
                             : "+"}
                           {tx.totalAmount} sats
                         </p>
-                        <p className="text-xs text-gray-600 dark:text-neutral-400">
-                          ~{tx.totalAmountFiat}
-                        </p>
+                        {!!tx.totalAmountFiat && (
+                          <p className="text-xs text-gray-600 dark:text-neutral-400">
+                            ~{tx.totalAmountFiat}
+                          </p>
+                        )}
                       </div>
                       {([tx.type && "sent", "sending"].includes(tx.type) ||
                         (tx.type === "received" && tx.boostagram)) && (

--- a/src/app/components/form/DualCurrencyField/index.test.tsx
+++ b/src/app/components/form/DualCurrencyField/index.test.tsx
@@ -5,7 +5,7 @@ import type { Props } from "./index";
 import DualCurrencyField from "./index";
 
 const props: Props = {
-  fiatValue: 1000,
+  fiatValue: "$10.00",
   label: "Amount",
 };
 
@@ -20,6 +20,6 @@ describe("DualCurrencyField", () => {
     const input = screen.getByLabelText("Amount");
 
     expect(input).toBeInTheDocument();
-    expect(await screen.getByText("~1000")).toBeInTheDocument();
+    expect(await screen.getByText("~$10.00")).toBeInTheDocument();
   });
 });

--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -4,7 +4,7 @@ import { classNames } from "~/app/utils";
 export type Props = {
   suffix?: string;
   endAdornment?: React.ReactNode;
-  fiatValue: string | number;
+  fiatValue: string;
   label: string;
   hint?: string;
 };

--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -72,18 +72,20 @@ export default function DualCurrencyField({
 
       <div
         className={classNames(
-          `flex items-stretch overflow-hidden field mt-1 ${
-            !hint && "mb-6"
-          } pb-6 relative`,
+          `flex items-stretch overflow-hidden field mt-1 ${!hint && "mb-6"} ${
+            !!fiatValue && "pb-6"
+          } relative`,
           "focus-within:ring-orange-bitcoin focus-within:border-orange-bitcoin focus-within:dark:border-orange-bitcoin focus-within:ring-1",
           outerStyles
         )}
       >
         {inputNode}
 
-        <p className="helper text-xs text-gray-600 absolute z-1 top-0 left-0 font-semibold pointer-events-none translate-x-4 translate-y-10">
-          ~{fiatValue}
-        </p>
+        {!!fiatValue && (
+          <p className="helper text-xs text-gray-600 absolute z-1 top-0 left-0 font-semibold pointer-events-none translate-x-4 translate-y-10">
+            ~{fiatValue}
+          </p>
+        )}
 
         {suffix && (
           <span

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -1,0 +1,63 @@
+import { useState, useEffect, createContext, useContext } from "react";
+import { toast } from "react-toastify";
+import api from "~/common/lib/api";
+import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
+import type { SettingsStorage } from "~/types";
+
+interface SettingsContextType {
+  settings: SettingsStorage;
+  updateSetting: (setting: Setting) => void;
+  isLoading: boolean;
+}
+
+type Setting = Partial<SettingsStorage>;
+
+const SettingsContext = createContext({} as SettingsContextType);
+
+export const SettingsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [settings, setSettings] =
+    useState<SettingsContextType["settings"]>(DEFAULT_SETTINGS);
+
+  const [isLoading, setIsLoading] = useState(true);
+  // call this to trigger a re-render on all occassions
+  const updateSetting = (setting: Setting) =>
+    setSettings((prevState) => ({
+      ...prevState,
+      ...setting,
+    }));
+
+  // Invoked only on on mount.
+  useEffect(() => {
+    api
+      .getSettings()
+      .then((response) => {
+        setSettings(response);
+      })
+      .catch((e) => {
+        toast.error(
+          `SettingsProvider: An unexpected error occurred (${e.message})`
+        );
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const value = {
+    settings,
+    updateSetting,
+    isLoading,
+  };
+
+  return (
+    <SettingsContext.Provider value={value}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => useContext(SettingsContext);

--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -16,74 +16,77 @@ import { HashRouter, Navigate, Outlet, Routes, Route } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import { AccountProvider, useAccount } from "~/app/context/AccountContext";
 import { AccountsProvider } from "~/app/context/AccountsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import RequireAuth from "~/app/router/RequireAuth";
 import getConnectorRoutes from "~/app/router/connectorRoutes";
 
 function Options() {
   const connectorRoutes = getConnectorRoutes();
   return (
-    <AccountProvider>
-      <AccountsProvider>
-        <HashRouter>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <RequireAuth>
-                  <Layout />
-                </RequireAuth>
-              }
-            >
-              <Route index element={<Navigate to="/publishers" replace />} />
-              <Route path="publishers">
-                <Route path=":id" element={<Publisher />} />
-                <Route index element={<Publishers />} />
-              </Route>
-              <Route path="send" element={<Send />} />
-              <Route path="keysend" element={<Keysend />} />
-              <Route path="receive" element={<Receive />} />
-              <Route path="lnurlPay" element={<LNURLPay />} />
-              <Route path="confirmPayment" element={<ConfirmPayment />} />
-              <Route path="settings" element={<Settings />} />
-              <Route path="accounts">
+    <SettingsProvider>
+      <AccountProvider>
+        <AccountsProvider>
+          <HashRouter>
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <RequireAuth>
+                    <Layout />
+                  </RequireAuth>
+                }
+              >
+                <Route index element={<Navigate to="/publishers" replace />} />
+                <Route path="publishers">
+                  <Route path=":id" element={<Publisher />} />
+                  <Route index element={<Publishers />} />
+                </Route>
+                <Route path="send" element={<Send />} />
+                <Route path="keysend" element={<Keysend />} />
+                <Route path="receive" element={<Receive />} />
+                <Route path="lnurlPay" element={<LNURLPay />} />
+                <Route path="confirmPayment" element={<ConfirmPayment />} />
+                <Route path="settings" element={<Settings />} />
+                <Route path="accounts">
+                  <Route
+                    path="new"
+                    element={
+                      <Container>
+                        <Outlet />
+                      </Container>
+                    }
+                  >
+                    <Route
+                      index
+                      element={
+                        <ChooseConnector title="Add a new lightning account" />
+                      }
+                    />
+                    {connectorRoutes.map((connectorRoute) => (
+                      <Route
+                        key={connectorRoute.path}
+                        path={connectorRoute.path}
+                        element={connectorRoute.element}
+                      />
+                    ))}
+                  </Route>
+                  <Route index element={<Accounts />} />
+                </Route>
                 <Route
-                  path="new"
+                  path="test-connection"
                   element={
                     <Container>
-                      <Outlet />
+                      <TestConnection />
                     </Container>
                   }
-                >
-                  <Route
-                    index
-                    element={
-                      <ChooseConnector title="Add a new lightning account" />
-                    }
-                  />
-                  {connectorRoutes.map((connectorRoute) => (
-                    <Route
-                      key={connectorRoute.path}
-                      path={connectorRoute.path}
-                      element={connectorRoute.element}
-                    />
-                  ))}
-                </Route>
-                <Route index element={<Accounts />} />
+                />
               </Route>
-              <Route
-                path="test-connection"
-                element={
-                  <Container>
-                    <TestConnection />
-                  </Container>
-                }
-              />
-            </Route>
-            <Route path="unlock" element={<Unlock />} />
-          </Routes>
-        </HashRouter>
-      </AccountsProvider>
-    </AccountProvider>
+              <Route path="unlock" element={<Unlock />} />
+            </Routes>
+          </HashRouter>
+        </AccountsProvider>
+      </AccountProvider>
+    </SettingsProvider>
   );
 }
 

--- a/src/app/router/Popup/Popup.tsx
+++ b/src/app/router/Popup/Popup.tsx
@@ -11,35 +11,38 @@ import { ToastContainer } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { AccountProvider } from "~/app/context/AccountContext";
 import { AccountsProvider } from "~/app/context/AccountsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 
 import RequireAuth from "../RequireAuth";
 
 function Popup() {
   return (
-    <AccountProvider>
-      <AccountsProvider>
-        <HashRouter>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <RequireAuth>
-                  <Layout />
-                </RequireAuth>
-              }
-            >
-              <Route index element={<Home />} />
-              <Route path="send" element={<Send />} />
-              <Route path="receive" element={<Receive />} />
-              <Route path="lnurlPay" element={<LNURLPay />} />
-              <Route path="keysend" element={<Keysend />} />
-              <Route path="confirmPayment" element={<ConfirmPayment />} />
-            </Route>
-            <Route path="unlock" element={<Unlock />} />
-          </Routes>
-        </HashRouter>
-      </AccountsProvider>
-    </AccountProvider>
+    <SettingsProvider>
+      <AccountProvider>
+        <AccountsProvider>
+          <HashRouter>
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <RequireAuth>
+                    <Layout />
+                  </RequireAuth>
+                }
+              >
+                <Route index element={<Home />} />
+                <Route path="send" element={<Send />} />
+                <Route path="receive" element={<Receive />} />
+                <Route path="lnurlPay" element={<LNURLPay />} />
+                <Route path="keysend" element={<Keysend />} />
+                <Route path="confirmPayment" element={<ConfirmPayment />} />
+              </Route>
+              <Route path="unlock" element={<Unlock />} />
+            </Routes>
+          </HashRouter>
+        </AccountsProvider>
+      </AccountProvider>
+    </SettingsProvider>
   );
 }
 

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -13,6 +13,7 @@ import { ToastContainer } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { AccountProvider } from "~/app/context/AccountContext";
 import { AccountsProvider } from "~/app/context/AccountsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import RequireAuth from "~/app/router/RequireAuth";
 import type {
   LNURLAuthServiceResponse,
@@ -47,110 +48,121 @@ const routeParams: {
 
 function Prompt() {
   return (
-    <AccountProvider>
-      <AccountsProvider>
-        <HashRouter>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <RequireAuth>
-                  <Layout />
-                </RequireAuth>
-              }
-            >
+    <SettingsProvider>
+      <AccountProvider>
+        <AccountsProvider>
+          <HashRouter>
+            <Routes>
               <Route
-                index
-                element={<Navigate to={`/${routeParams.action}`} replace />}
-              />
-              <Route
-                path="webln/enable"
-                element={<Enable origin={routeParams.origin} />}
-              />
-              <Route
-                path="lnurlAuth"
+                path="/"
                 element={
-                  <LNURLAuth
-                    details={
-                      routeParams.args?.lnurlDetails as LNURLAuthServiceResponse
-                    }
-                    origin={routeParams.origin}
-                  />
+                  <RequireAuth>
+                    <Layout />
+                  </RequireAuth>
                 }
-              />
-              <Route
-                path="lnurlPay"
-                element={
-                  <LNURLPay
-                    details={
-                      routeParams.args?.lnurlDetails as LNURLPayServiceResponse
-                    }
-                    origin={routeParams.origin}
-                  />
-                }
-              />
-              <Route
-                path="lnurlWithdraw"
-                element={
-                  <LNURLWithdraw
-                    details={
-                      routeParams.args
-                        ?.lnurlDetails as LNURLWithdrawServiceResponse
-                    }
-                    origin={routeParams.origin}
-                  />
-                }
-              />
-              <Route
-                path="makeInvoice"
-                element={
-                  <MakeInvoice
-                    amountEditable={routeParams.args.amountEditable as boolean}
-                    memoEditable={routeParams.args.memoEditable as boolean}
-                    invoiceAttributes={
-                      routeParams.args.invoiceAttributes as RequestInvoiceArgs
-                    }
-                    origin={routeParams.origin}
-                  />
-                }
-              />
-              <Route
-                path="confirmPayment"
-                element={
-                  <ConfirmPayment
-                    paymentRequest={routeParams.args?.paymentRequest as string}
-                    origin={routeParams.origin}
-                  />
-                }
-              />
-              <Route
-                path="confirmKeysend"
-                element={
-                  <Keysend
-                    destination={routeParams.args?.destination as string}
-                    valueSat={routeParams.args?.amount as string}
-                    customRecords={
-                      routeParams.args?.customRecords as Record<string, string>
-                    }
-                    origin={routeParams.origin}
-                  />
-                }
-              />
-              <Route
-                path="confirmSignMessage"
-                element={
-                  <ConfirmSignMessage
-                    message={routeParams.args?.message as string}
-                    origin={routeParams.origin}
-                  />
-                }
-              />
-            </Route>
-            <Route path="unlock" element={<Unlock />} />
-          </Routes>
-        </HashRouter>
-      </AccountsProvider>
-    </AccountProvider>
+              >
+                <Route
+                  index
+                  element={<Navigate to={`/${routeParams.action}`} replace />}
+                />
+                <Route
+                  path="webln/enable"
+                  element={<Enable origin={routeParams.origin} />}
+                />
+                <Route
+                  path="lnurlAuth"
+                  element={
+                    <LNURLAuth
+                      details={
+                        routeParams.args
+                          ?.lnurlDetails as LNURLAuthServiceResponse
+                      }
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="lnurlPay"
+                  element={
+                    <LNURLPay
+                      details={
+                        routeParams.args
+                          ?.lnurlDetails as LNURLPayServiceResponse
+                      }
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="lnurlWithdraw"
+                  element={
+                    <LNURLWithdraw
+                      details={
+                        routeParams.args
+                          ?.lnurlDetails as LNURLWithdrawServiceResponse
+                      }
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="makeInvoice"
+                  element={
+                    <MakeInvoice
+                      amountEditable={
+                        routeParams.args.amountEditable as boolean
+                      }
+                      memoEditable={routeParams.args.memoEditable as boolean}
+                      invoiceAttributes={
+                        routeParams.args.invoiceAttributes as RequestInvoiceArgs
+                      }
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="confirmPayment"
+                  element={
+                    <ConfirmPayment
+                      paymentRequest={
+                        routeParams.args?.paymentRequest as string
+                      }
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="confirmKeysend"
+                  element={
+                    <Keysend
+                      destination={routeParams.args?.destination as string}
+                      valueSat={routeParams.args?.amount as string}
+                      customRecords={
+                        routeParams.args?.customRecords as Record<
+                          string,
+                          string
+                        >
+                      }
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+                <Route
+                  path="confirmSignMessage"
+                  element={
+                    <ConfirmSignMessage
+                      message={routeParams.args?.message as string}
+                      origin={routeParams.origin}
+                    />
+                  }
+                />
+              </Route>
+              <Route path="unlock" element={<Unlock />} />
+            </Routes>
+          </HashRouter>
+        </AccountsProvider>
+      </AccountProvider>
+    </SettingsProvider>
   );
 }
 

--- a/src/app/router/Welcome/Welcome.tsx
+++ b/src/app/router/Welcome/Welcome.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { HashRouter as Router, useRoutes, useLocation } from "react-router-dom";
 import { AccountProvider } from "~/app/context/AccountContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import getConnectorRoutes from "~/app/router/connectorRoutes";
 import i18n from "~/i18n/i18nConfig";
 import { translationI18nNamespace } from "~/i18n/namespaces";
@@ -123,28 +124,30 @@ function App() {
   }, [location]);
 
   return (
-    <AccountProvider>
-      <div>
-        {process.env.NODE_ENV === "development" && (
-          <>
-            <DevMenu />
-            <div className="w-32 mr-4 mt-1 pt-3 float-right">
-              <LocaleSwitcher />
+    <SettingsProvider>
+      <AccountProvider>
+        <div>
+          {process.env.NODE_ENV === "development" && (
+            <>
+              <DevMenu />
+              <div className="w-32 mr-4 mt-1 pt-3 float-right">
+                <LocaleSwitcher />
+              </div>
+            </>
+          )}
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center font-serif font-medium text-2xl pt-7 pb-3 dark:text-white">
+              <p>{t("welcome.heading")}</p>
             </div>
-          </>
-        )}
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center font-serif font-medium text-2xl pt-7 pb-3 dark:text-white">
-            <p>{t("welcome.heading")}</p>
-          </div>
 
-          <Steps steps={steps} />
+            <Steps steps={steps} />
+          </div>
+          <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            {routesElement}
+          </div>
         </div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {routesElement}
-        </div>
-      </div>
-    </AccountProvider>
+      </AccountProvider>
+    </SettingsProvider>
   );
 }
 

--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -7,6 +7,7 @@ import SuccessMessage from "@components/SuccessMessage";
 import { useState, MouseEvent, useRef, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
+import { useSettings } from "~/app/context/SettingsContext";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
@@ -22,6 +23,9 @@ type Props = {
 };
 
 function Keysend(props: Props) {
+  const { isLoading: isLoadingSettings, settings } = useSettings();
+  const showFiat = !isLoadingSettings && settings.showFiat;
+
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
@@ -46,11 +50,13 @@ function Keysend(props: Props) {
   const [successMessage, setSuccessMessage] = useState("");
 
   useEffect(() => {
-    (async () => {
-      const res = await getFiatValue(budget);
-      setFiatAmount(res);
-    })();
-  }, [budget]);
+    if (showFiat) {
+      (async () => {
+        const res = await getFiatValue(budget);
+        setFiatAmount(res);
+      })();
+    }
+  }, [budget, showFiat]);
 
   async function confirm() {
     if (rememberMe && budget) {

--- a/src/app/screens/ConfirmPayment/index.test.tsx
+++ b/src/app/screens/ConfirmPayment/index.test.tsx
@@ -2,9 +2,21 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import lightningPayReq from "bolt11";
 import { MemoryRouter } from "react-router-dom";
+import * as SettingsContext from "~/app/context/SettingsContext";
+import type { SettingsStorage } from "~/types";
 
 import type { Props } from "./index";
 import ConfirmPayment from "./index";
+
+const mockSettings = {
+  showFiat: true,
+} as SettingsStorage;
+
+jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+  settings: mockSettings,
+  isLoading: false,
+  updateSetting: jest.fn(),
+});
 
 jest.mock("~/common/utils/currencyConvert", () => {
   return {

--- a/src/app/screens/ConfirmPayment/index.test.tsx
+++ b/src/app/screens/ConfirmPayment/index.test.tsx
@@ -2,15 +2,11 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import lightningPayReq from "bolt11";
 import { MemoryRouter } from "react-router-dom";
+import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import * as SettingsContext from "~/app/context/SettingsContext";
-import type { SettingsStorage } from "~/types";
 
 import type { Props } from "./index";
 import ConfirmPayment from "./index";
-
-const mockSettings = {
-  showFiat: true,
-} as SettingsStorage;
 
 jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
+import { useSettings } from "~/app/context/SettingsContext";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
@@ -22,6 +23,9 @@ export type Props = {
 };
 
 function ConfirmPayment(props: Props) {
+  const { isLoading: isLoadingSettings, settings } = useSettings();
+  const showFiat = !isLoadingSettings && settings.showFiat;
+
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const auth = useAccount();
@@ -41,11 +45,13 @@ function ConfirmPayment(props: Props) {
   const [fiatAmount, setFiatAmount] = useState("");
 
   useEffect(() => {
-    (async () => {
-      const res = await getFiatValue(budget);
-      setFiatAmount(res);
-    })();
-  }, [budget]);
+    if (showFiat) {
+      (async () => {
+        const res = await getFiatValue(budget);
+        setFiatAmount(res);
+      })();
+    }
+  }, [budget, showFiat]);
 
   const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -14,11 +14,12 @@ import TransactionsTable from "@components/TransactionsTable";
 import { Tab } from "@headlessui/react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import browser from "webextension-polyfill";
+import { useSettings } from "~/app/context/SettingsContext";
 import { classNames } from "~/app/utils/index";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
@@ -28,6 +29,8 @@ import type { Allowance, Battery, Transaction } from "~/types";
 dayjs.extend(relativeTime);
 
 function Home() {
+  const { isLoading: isLoadingSettings, settings } = useSettings();
+
   const [allowance, setAllowance] = useState<Allowance | null>(null);
   const [isBlocked, setIsBlocked] = useState<boolean>(false);
   const [currentUrl, setCurrentUrl] = useState<URL | null>(null);
@@ -81,15 +84,21 @@ function Home() {
     }
   }
 
-  async function loadPayments() {
-    const result = await api.getPayments({ limit: 10 });
-    for await (const payment of result.payments) {
-      const totalAmountFiat = await getFiatValue(payment.totalAmount);
-      payment.totalAmountFiat = totalAmountFiat;
+  const loadPayments = useCallback(async () => {
+    try {
+      const result = await api.getPayments({ limit: 10 });
+      for await (const payment of result.payments) {
+        const totalAmountFiat = settings.showFiat
+          ? await getFiatValue(payment.totalAmount)
+          : "";
+        payment.totalAmountFiat = totalAmountFiat;
+      }
+      setPayments(result?.payments);
+      setLoadingPayments(false);
+    } catch (e) {
+      console.error(e);
     }
-    setPayments(result?.payments);
-    setLoadingPayments(false);
-  }
+  }, [settings.showFiat]);
 
   function handleLightningDataMessage(response: {
     action: string;
@@ -129,7 +138,12 @@ function Home() {
   }
 
   useEffect(() => {
-    loadPayments();
+    if (!isLoadingSettings) {
+      loadPayments();
+    }
+  }, [isLoadingSettings, loadPayments]);
+
+  useEffect(() => {
     loadAllowance();
 
     // Enhancement data is loaded asynchronously (for example because we need to fetch additional data).

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -129,7 +129,9 @@ function Home() {
     }));
 
     for (const invoice of invoices) {
-      const totalAmountFiat = await getFiatValue(invoice.totalAmount);
+      const totalAmountFiat = settings.showFiat
+        ? await getFiatValue(invoice.totalAmount)
+        : "";
       invoice.totalAmountFiat = totalAmountFiat;
     }
 

--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -9,6 +9,7 @@ import React, { useState, useEffect, MouseEvent } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
+import { useSettings } from "~/app/context/SettingsContext";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import api from "~/common/lib/api";
 import lnurl from "~/common/lib/lnurl";
@@ -43,6 +44,9 @@ const Dd = ({ children }: { children: React.ReactNode }) => (
 );
 
 function LNURLPay(props: Props) {
+  const { isLoading: isLoadingSettings, settings } = useSettings();
+  const showFiat = !isLoadingSettings && settings.showFiat;
+
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const auth = useAccount();
@@ -69,11 +73,13 @@ function LNURLPay(props: Props) {
   const [payment, setPayment] = useState<PaymentResponse | undefined>();
 
   useEffect(() => {
-    (async () => {
-      const res = await getFiatValue(valueSat);
-      setFiatValue(res);
-    })();
-  }, [valueSat]);
+    if (showFiat) {
+      (async () => {
+        const res = await getFiatValue(valueSat);
+        setFiatValue(res);
+      })();
+    }
+  }, [valueSat, showFiat]);
 
   useEffect(() => {
     if (searchParams) {

--- a/src/app/screens/Receive.tsx
+++ b/src/app/screens/Receive.tsx
@@ -16,6 +16,7 @@ import QRCode from "react-qr-code";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
+import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
 import { getFiatValue } from "~/common/utils/currencyConvert";
@@ -25,6 +26,9 @@ import DualCurrencyField from "../components/form/DualCurrencyField";
 
 function Receive() {
   const auth = useAccount();
+  const { isLoading: isLoadingSettings, settings } = useSettings();
+  const showFiat = !isLoadingSettings && settings.showFiat;
+
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     amount: "0",
@@ -52,13 +56,13 @@ function Receive() {
   const [fiatAmount, setFiatAmount] = useState("");
 
   useEffect(() => {
-    if (formData.amount !== "") {
+    if (formData.amount !== "" && showFiat) {
       (async () => {
         const res = await getFiatValue(formData.amount);
         setFiatAmount(res);
       })();
     }
-  }, [formData]);
+  }, [formData, showFiat]);
 
   function handleChange(
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -145,23 +145,22 @@ function Settings() {
           )}
         </Setting>
 
-        {process.env.NODE_ENV === "development" && (
-          <Setting
-            title={t("show_fiat.title")}
-            subtitle={t("show_fiat.subtitle")}
-          >
-            {!isLoading && (
-              <Toggle
-                checked={settings.showFiat}
-                onChange={() => {
-                  saveSetting({
-                    showFiat: !settings.showFiat,
-                  });
-                }}
-              />
-            )}
-          </Setting>
-        )}
+        <Setting
+          title={t("show_fiat.title")}
+          subtitle={t("show_fiat.subtitle")}
+        >
+          {!isLoading && (
+            <Toggle
+              checked={settings.showFiat}
+              onChange={() => {
+                saveSetting({
+                  showFiat: !settings.showFiat,
+                });
+              }}
+            />
+          )}
+        </Setting>
+
         {settings.showFiat && (
           <>
             <Setting

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -9,16 +9,16 @@ import Select from "@components/form/Select";
 import Toggle from "@components/form/Toggle";
 import { Html5Qrcode } from "html5-qrcode";
 import type { FormEvent } from "react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import Modal from "react-modal";
 import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
+import { useSettings } from "~/app/context/SettingsContext";
 import { getTheme } from "~/app/utils";
 import { CURRENCIES } from "~/common/constants";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { SettingsStorage } from "~/types";
 
 const initialFormData = {
   password: "",
@@ -27,26 +27,11 @@ const initialFormData = {
 
 function Settings() {
   const { t } = useTranslation("translation", { keyPrefix: "settings" });
-
+  const { isLoading, settings, updateSetting } = useSettings();
   const { fetchAccountInfo } = useAccount();
-
-  const [loading, setLoading] = useState(true);
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [formData, setFormData] = useState(initialFormData);
-  const [settings, setSettings] = useState<SettingsStorage>({
-    websiteEnhancements: false,
-    legacyLnurlAuth: false,
-    isUsingLegacyLnurlAuthKey: false,
-    userName: "",
-    userEmail: "",
-    locale: "",
-    theme: "system",
-    showFiat: true,
-    currency: CURRENCIES.USD,
-    exchange: "coindesk",
-    debug: false,
-  });
 
   const [cameraPermissionsGranted, setCameraPermissionsGranted] =
     useState(false);
@@ -66,16 +51,10 @@ function Settings() {
   async function saveSetting(
     setting: Record<string, string | number | boolean>
   ) {
-    const response = await api.setSetting(setting);
-    setSettings(response);
+    // ensure to update SettingsContext
+    updateSetting(setting);
+    await api.setSetting(setting);
   }
-
-  useEffect(() => {
-    api.getSettings().then((response) => {
-      setSettings(response);
-      setLoading(false);
-    });
-  }, []);
 
   return (
     <Container>
@@ -87,7 +66,7 @@ function Settings() {
           title={t("website_enhancements.title")}
           subtitle={t("website_enhancements.subtitle")}
         >
-          {!loading && (
+          {!isLoading && (
             <Toggle
               checked={settings.websiteEnhancements}
               onChange={() => {
@@ -129,7 +108,7 @@ function Settings() {
         </Setting>
 
         <Setting title={t("theme.title")} subtitle={t("theme.subtitle")}>
-          {!loading && (
+          {!isLoading && (
             <div className="w-64">
               <Select
                 name="theme"
@@ -149,55 +128,82 @@ function Settings() {
           )}
         </Setting>
 
-        <Setting title={t("currency.title")} subtitle={t("currency.subtitle")}>
-          {!loading && (
-            <div className="w-64">
-              <Select
-                name="currency"
-                value={settings.currency}
-                onChange={async (event) => {
-                  fetchAccountInfo({ isLatestRate: true });
-                  await saveSetting({
-                    currency: event.target.value,
+        {process.env.NODE_ENV === "development" && (
+          <Setting
+            title={t("show_fiat.title")}
+            subtitle={t("show_fiat.subtitle")}
+          >
+            {!isLoading && (
+              <Toggle
+                checked={settings.showFiat}
+                onChange={() => {
+                  saveSetting({
+                    showFiat: !settings.showFiat,
                   });
                 }}
-              >
-                {Object.keys(CURRENCIES).map((currency) => (
-                  <option key={currency} value={currency}>
-                    {currency}
-                  </option>
-                ))}
-              </Select>
-            </div>
-          )}
-        </Setting>
+              />
+            )}
+          </Setting>
+        )}
+        {settings.showFiat && (
+          <>
+            <Setting
+              title={t("currency.title")}
+              subtitle={t("currency.subtitle")}
+            >
+              {!isLoading && (
+                <div className="w-64">
+                  <Select
+                    name="currency"
+                    value={settings.currency}
+                    onChange={async (event) => {
+                      fetchAccountInfo({ isLatestRate: true });
+                      await saveSetting({
+                        currency: event.target.value,
+                      });
+                    }}
+                  >
+                    {Object.keys(CURRENCIES).map((currency) => (
+                      <option key={currency} value={currency}>
+                        {currency}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              )}
+            </Setting>
 
-        <Setting title={t("exchange.title")} subtitle={t("exchange.subtitle")}>
-          {!loading && (
-            <div className="w-64">
-              <Select
-                name="exchange"
-                value={settings.exchange}
-                onChange={async (event) => {
-                  // exchange/value change should be reflected in the upper account-menu after select?
-                  await saveSetting({
-                    exchange: event.target.value,
-                  });
-                }}
-              >
-                <option value="alby">Alby</option>
-                <option value="coindesk">Coindesk</option>
-                <option value="yadio">yadio</option>
-              </Select>
-            </div>
-          )}
-        </Setting>
+            <Setting
+              title={t("exchange.title")}
+              subtitle={t("exchange.subtitle")}
+            >
+              {!isLoading && (
+                <div className="w-64">
+                  <Select
+                    name="exchange"
+                    value={settings.exchange}
+                    onChange={async (event) => {
+                      // exchange/value change should be reflected in the upper account-menu after select?
+                      await saveSetting({
+                        exchange: event.target.value,
+                      });
+                    }}
+                  >
+                    <option value="alby">Alby</option>
+                    <option value="coindesk">Coindesk</option>
+                    <option value="yadio">yadio</option>
+                  </Select>
+                </div>
+              )}
+            </Setting>
+          </>
+        )}
 
         <Setting
           title={t("change_password.title")}
           subtitle={t("change_password.subtitle")}
         >
-          {!loading && (
+          {!isLoading && (
             <div className="w-64">
               <Button
                 onClick={() => {
@@ -206,8 +212,8 @@ function Settings() {
                 label={t("change_password.title")}
                 primary
                 fullWidth
-                loading={loading}
-                disabled={loading}
+                loading={isLoading}
+                disabled={isLoading}
               />
             </div>
           )}
@@ -224,7 +230,7 @@ function Settings() {
 
       <div className="mb-12 shadow bg-white sm:rounded-md sm:overflow-hidden px-6 py-2 divide-y divide-black/10 dark:divide-white/10 dark:bg-surface-02dp">
         <Setting title={t("name.title")} subtitle={t("name.subtitle")}>
-          {!loading && (
+          {!isLoading && (
             <div className="w-64">
               <Input
                 placeholder={t("name.placeholder")}
@@ -241,7 +247,7 @@ function Settings() {
         </Setting>
 
         <Setting title={t("email.title")} subtitle={t("email.subtitle")}>
-          {!loading && (
+          {!isLoading && (
             <div className="w-64">
               <Input
                 placeholder={t("email.placeholder")}
@@ -324,7 +330,7 @@ function Settings() {
           title={t("lnurl_auth.legacy_lnurl_auth_202207.title")}
           subtitle={t("lnurl_auth.legacy_lnurl_auth_202207.subtitle")}
         >
-          {!loading && (
+          {!isLoading && (
             <Toggle
               checked={settings.isUsingLegacyLnurlAuthKey}
               onChange={() => {
@@ -341,7 +347,7 @@ function Settings() {
           title={t("lnurl_auth.legacy_lnurl_auth.title")}
           subtitle={t("lnurl_auth.legacy_lnurl_auth.subtitle")}
         >
-          {!loading && (
+          {!isLoading && (
             <Toggle
               checked={settings.legacyLnurlAuth}
               onChange={() => {

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -42,6 +42,7 @@ function Settings() {
     userEmail: "",
     locale: "",
     theme: "system",
+    showFiat: true,
     currency: CURRENCIES.USD,
     exchange: "coindesk",
     debug: false,

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -125,6 +125,26 @@ function Settings() {
           )}
         </Setting>
 
+        <Setting
+          title={t("change_password.title")}
+          subtitle={t("change_password.subtitle")}
+        >
+          {!isLoading && (
+            <div className="w-64">
+              <Button
+                onClick={() => {
+                  setModalIsOpen(true);
+                }}
+                label={t("change_password.title")}
+                primary
+                fullWidth
+                loading={isLoading}
+                disabled={isLoading}
+              />
+            </div>
+          )}
+        </Setting>
+
         {process.env.NODE_ENV === "development" && (
           <Setting
             title={t("show_fiat.title")}
@@ -195,26 +215,6 @@ function Settings() {
             </Setting>
           </>
         )}
-
-        <Setting
-          title={t("change_password.title")}
-          subtitle={t("change_password.subtitle")}
-        >
-          {!isLoading && (
-            <div className="w-64">
-              <Button
-                onClick={() => {
-                  setModalIsOpen(true);
-                }}
-                label={t("change_password.title")}
-                primary
-                fullWidth
-                loading={isLoading}
-                disabled={isLoading}
-              />
-            </div>
-          )}
-        </Setting>
       </div>
 
       <h2 className="mt-12 text-2xl font-bold dark:text-white">

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -77,7 +77,6 @@ function Settings() {
             />
           )}
         </Setting>
-
         <Setting
           title={t("camera_access.title")}
           subtitle={t("camera_access.subtitle")}
@@ -100,13 +99,11 @@ function Settings() {
             </p>
           )}
         </Setting>
-
         <Setting title={t("language.title")} subtitle={t("language.subtitle")}>
           <div className="w-32">
             <LocaleSwitcher />
           </div>
         </Setting>
-
         <Setting title={t("theme.title")} subtitle={t("theme.subtitle")}>
           {!isLoading && (
             <div className="w-64">

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -5,7 +5,7 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 
-import { getFiatValue, getBalances } from "../currencyConvert";
+import { getFiatValue, getBalances, getSatValue } from "../currencyConvert";
 
 const server = setupServer(
   rest.get(
@@ -73,5 +73,11 @@ describe("Currency coversion utils", () => {
       fiatBalance: "$37,026.96",
       satsBalance: "123456789 sats",
     });
+  });
+
+  test("getSatValue", async () => {
+    const result = getSatValue(123456789);
+
+    expect(result).toBe("123456789 sats");
   });
 });

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -5,7 +5,7 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 
-import { getFiatValue, getBalances, getSatValue } from "../currencyConvert";
+import { getFiatValue, getSatValue } from "../currencyConvert";
 
 const server = setupServer(
   rest.get(
@@ -64,15 +64,6 @@ describe("Currency coversion utils", () => {
     const result = await getFiatValue(123456789);
 
     expect(result).toBe("$37,026.96");
-  });
-
-  test("getBalances", async () => {
-    const result = await getBalances(123456789);
-
-    expect(result).toMatchObject({
-      fiatBalance: "$37,026.96",
-      satsBalance: "123456789 sats",
-    });
   });
 
   test("getSatValue", async () => {

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -93,11 +93,15 @@ const satoshisToFiat = async ({
   return fiat;
 };
 
-export const getFiatValue = async (amount: number | string) => {
+export const getFiatValue = async (
+  amount: number | string,
+  isLatestRate?: boolean
+) => {
   const { currency } = await getCurrencySettings();
   const fiatValue = await satoshisToFiat({
     amountInSats: amount,
     convertTo: currency,
+    isLatestRate,
   });
   const localeFiatValue = fiatValue.toLocaleString("en", {
     style: "currency",

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -124,3 +124,5 @@ export const getBalances = async (balance: number, isLatestRate?: boolean) => {
     fiatBalance: localeFiatValue,
   };
 };
+
+export const getSatValue = (balance: number) => `${balance} sats`;

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -6,7 +6,7 @@ import debounce from "lodash/debounce";
 import { CURRENCIES } from "~/common/constants";
 import { getSettings } from "~/common/lib/api";
 
-const settings = async () => {
+const getCurrencySettings = async () => {
   const { currency, exchange } = await getSettings();
 
   return {
@@ -18,7 +18,7 @@ const settings = async () => {
 const numSatsInBtc = 100_000_000;
 
 const getFiatBtcRate = async (currency: CURRENCIES): Promise<string> => {
-  const { exchange } = await settings();
+  const { exchange } = await getCurrencySettings();
 
   let response;
 
@@ -94,7 +94,7 @@ const satoshisToFiat = async ({
 };
 
 export const getFiatValue = async (amount: number | string) => {
-  const { currency } = await settings();
+  const { currency } = await getCurrencySettings();
   const fiatValue = await satoshisToFiat({
     amountInSats: amount,
     convertTo: currency,
@@ -108,7 +108,7 @@ export const getFiatValue = async (amount: number | string) => {
 };
 
 export const getBalances = async (balance: number, isLatestRate?: boolean) => {
-  const { currency } = await settings();
+  const { currency } = await getCurrencySettings();
   const fiatValue = await satoshisToFiat({
     amountInSats: balance,
     convertTo: currency,

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -111,22 +111,4 @@ export const getFiatValue = async (
   return localeFiatValue;
 };
 
-export const getBalances = async (balance: number, isLatestRate?: boolean) => {
-  const { currency } = await getCurrencySettings();
-  const fiatValue = await satoshisToFiat({
-    amountInSats: balance,
-    convertTo: currency,
-    isLatestRate,
-  });
-  const localeFiatValue = fiatValue.toLocaleString("en", {
-    style: "currency",
-    currency: currency,
-  });
-
-  return {
-    satsBalance: `${balance} sats`,
-    fiatBalance: localeFiatValue,
-  };
-};
-
 export const getSatValue = (balance: number) => `${balance} sats`;

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -43,6 +43,7 @@ export const DEFAULT_SETTINGS: SettingsStorage = {
   userEmail: "",
   locale: i18n.resolvedLanguage,
   theme: "system",
+  showFiat: true,
   currency: CURRENCIES.USD,
   exchange: "alby",
   debug: false,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -223,6 +223,10 @@
           "system": "System"
         }
       },
+      "show_fiat": {
+        "title": "Sats to Fiat",
+        "subtitle": "Always convert into selected currency from selected exchange"
+      },
       "currency": {
         "title": "Currency",
         "subtitle": "Show the amounts additionally in this currency"

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,7 @@ export interface SettingsStorage {
   userEmail: string;
   locale: string;
   theme: string;
+  showFiat: boolean;
   currency: CURRENCIES;
   exchange: SupportedExchanges;
   debug: boolean;

--- a/tests/fixtures/settings.ts
+++ b/tests/fixtures/settings.ts
@@ -1,0 +1,4 @@
+import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
+import type { SettingsStorage } from "~/types";
+
+export const settingsFixture: SettingsStorage = { ...DEFAULT_SETTINGS };


### PR DESCRIPTION
### Describe the changes you have made in this PR

This is the main integration of the new settings feature.

This PR does:
- add a new boolean to the DEFAULT_SETTINGs => `showFiat`
- `showFiat` is `true` by default
- ~Settings: If in development mode show a "Show Fiat" toggle~ => Toggle is shown in production
- Settings: If `showFiat` is `false` => hide settings for "currency"  and "exchange" 
- Add new SettingsContext and Provider which gets the current settings from `api.getSettings` 
- Wrap all screens with this Provider
- Settings: get settings now via SettingsContext and not directly from `api.getSettings` no more
- Settings: ensure to update the SettingsContext state too when saving new settings
- Acounts: Divide `getSats` and `getFiatValues`
- Acounts: get `showFiat`  from SettingsContext
- Accounts: do not fetch fiats if `showFiat` is `false` => fiatValue remains or becomes an empty string
- Do the same for all other places where `getFiatValue` is used (Receive, Pay, Payment, KeySend, Home, Publisher)
- Ensure to not render any data if `fiatValues` is an empty string (AccountMenu, DualCurrency, Transactions)
- addes settings fixtures for tests
- and some minor refactorings

Please checkout this branch and toggle the Setting by yourself to check if something is missing 🙏 


### Next steps:
- [x] talk with Design about the Toggle in Settings view => waiting for update in ticket
- [x] show the Toggle in production mode => **FEEDBACK REQUIRED** if this PR should already render the toggle for production users
- [x] more usages of the hook `useSettings` on component level, see [comment](https://github.com/getAlby/lightning-browser-extension/pull/1177#discussion_r929754374) => new ticket https://github.com/getAlby/lightning-browser-extension/issues/1210

### Link this PR to an issue

Part of https://github.com/getAlby/lightning-browser-extension/issues/1141

### How has this been tested?

I added addiitonal tests where a Test File existed already.

| Setting enabled  | Setting disabled  |
|---|---|
|<img src="https://user-images.githubusercontent.com/11243967/180760429-09f03585-d5c3-42b3-bd80-d0b57b589ddd.png" width="300" />   |  <img src="https://user-images.githubusercontent.com/11243967/180760432-3da38487-7af9-4e0f-b31e-6c6ec3cea992.png" width="300" />  |
|<img src="https://user-images.githubusercontent.com/11243967/180765956-a94f31d5-6328-427c-849b-fdc0e523c124.png" width="300" />    |  <img src="https://user-images.githubusercontent.com/11243967/180765961-5ec97819-3b2f-4535-a5b6-c1c1343b6be4.png" width="300" />     |
|<img src="https://user-images.githubusercontent.com/11243967/180768822-59767884-7bca-4449-ba5d-8233cea5e5c1.png" width="300" />    |  <img src="https://user-images.githubusercontent.com/11243967/180768828-9f0f50e8-7216-4b1e-8bb3-d0faeb1a35d3.png" width="300" />     |
|<img width="370" alt="incoming_with" src="https://user-images.githubusercontent.com/11243967/181722611-82ceb402-9323-4ebb-9872-8afd00cdcca5.png">  |  <img width="369" alt="incoming_without" src="https://user-images.githubusercontent.com/11243967/181722616-5960338c-c0ac-4ea1-9f22-b90f727a7123.png">  |





### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
