### PR TITLE
feat: Render metadata in transaction list

### DIFF
--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -4,6 +4,7 @@ import {
   CaretDownIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { Disclosure } from "@headlessui/react";
+import { Fragment } from "react";
 import { Transaction } from "~/types";
 
 import Badge from "../Badge";
@@ -32,6 +33,31 @@ export default function TransactionsTable({ transactions }: Props) {
     );
   }
 
+  function RenderMetadata(metadata: { [key: string]: string }) {
+    const metadataElements: JSX.Element[] = [];
+    if (metadata != undefined) {
+      for (const key in metadata) {
+        metadataElements.push(
+          <>
+            <dt className="mt-4 font-medium text-gray-800 dark:text-white">
+              {key}
+            </dt>
+            <dd className="mb-0 text-gray-600 dark:text-neutral-500 break-all">
+              {key == "image" ? (
+                <img src={`data:image/png;base64, ${metadata[key]}`} />
+              ) : (
+                metadata[key]
+              )}
+            </dd>
+          </>
+        );
+      }
+    } else {
+      metadataElements.push(<p>&quot;No Metadata Present&quot;</p>);
+    }
+
+    return metadataElements;
+  }
   return (
     <div className="shadow overflow-hidden rounded-lg">
       <div className="bg-white divide-y divide-gray-200 dark:divide-white/10 dark:bg-surface-02dp">
@@ -97,6 +123,14 @@ export default function TransactionsTable({ transactions }: Props) {
                       ) : (
                         ""
                       )}
+                      <p>
+                        Metadata:
+                        {RenderMetadata(
+                          tx.metadata as unknown as { [key: string]: string }
+                        ).map((metadata, key) => (
+                          <Fragment key={key}>{metadata}</Fragment>
+                        ))}
+                      </p>
                     </div>
                   </Disclosure.Panel>
                 </>

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,7 @@ export type Transaction = {
   description: string;
   location: string;
   totalAmountFiat: string;
+  metadata?: string;
 };
 
 export interface Payment {


### PR DESCRIPTION
fetch metadata from db use double assertions to convert it to valid type before rendering
render metadata in transaction list
signed-off-by: pavanj914@gmail.com


### Type of change (Remove other not matching type)


- `feat`: New feature (non-breaking change which adds functionality)


### Screenshots of the changes (If any)

_Add screenshots to help explain your problem_
![image](https://user-images.githubusercontent.com/55848322/180075894-f2b7a6f6-a4d4-44c2-9cc1-fb895886002d.png)



### Checklist

- [X] My code follows the style guidelines of this project and performed a self-review of my own code
- [X] New and existing tests pass locally with my changes
- [X] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
