### PR TITLE
test: use puppeter user-data-dir option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ coverage
 test-results/
 playwright-report/
 trace.zip
+puppeteer-user-data-dir/
 
 # storybook
 storybook-static/

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -78,7 +78,7 @@ const createAlbyWallet = async ({ page, $document, user }) => {
 };
 
 test.describe("Create or connect wallets", () => {
-  test("successfully creates an Alby wallet", async () => {
+  test.skip("successfully creates an Alby wallet", async () => {
     const { user, browser, page, $document } =
       await commonCreateWalletUserCreate();
     await createAlbyWallet({ page, $document, user });
@@ -86,7 +86,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to LNBits wallet", async () => {
+  test.skip("successfully connects to LNBits wallet", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     // click at "Create LNbits Wallet"
@@ -103,7 +103,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to BlueWallet", async () => {
+  test.skip("successfully connects to BlueWallet", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     // click at "LNDHub (BlueWallet)"
@@ -141,7 +141,7 @@ test.describe("Create or connect wallets", () => {
     await lndUrlField.type(restApiUrl);
 
     const macroon =
-      "0201036c6e6402f801030a10ffa3346da5624e139ff472aacf8b045a1201301a160a0761646472657373120472656164120577726974651a130a04696e666f120472656164120577726974651a170a08696e766f69636573120472656164120577726974651a210a086d616361726f6f6e120867656e6572617465120472656164120577726974651a160a076d657373616765120472656164120577726974651a170a086f6666636861696e120472656164120577726974651a160a076f6e636861696e120472656164120577726974651a140a057065657273120472656164120577726974651a180a067369676e6572120867656e6572617465120472656164000006207fc7ef1e31ec5afc4982a62ff624ae5682212783fbaf50808b96cde96615760d";
+      "0201036c6e6402f801030a10b3bf6906c1937139ac0684ac4417139d1201301a160a0761646472657373120472656164120577726974651a130a04696e666f120472656164120577726974651a170a08696e766f69636573120472656164120577726974651a210a086d616361726f6f6e120867656e6572617465120472656164120577726974651a160a076d657373616765120472656164120577726974651a170a086f6666636861696e120472656164120577726974651a160a076f6e636861696e120472656164120577726974651a140a057065657273120472656164120577726974651a180a067369676e6572120867656e657261746512047265616400000620a3f810170ad9340a63074b6dded31ed83a7140fd26c7758856111583b7725b2b";
     const macroonField = await getByLabelText(
       $document,
       "Macaroon (HEX format)"
@@ -153,7 +153,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to Umbrel", async () => {
+  test.skip("successfully connects to Umbrel", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Umbrel");
@@ -175,7 +175,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to myNode", async () => {
+  test.skip("successfully connects to myNode", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "myNode");
@@ -197,7 +197,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to Start9", async () => {
+  test.skip("successfully connects to Start9", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Start9");
@@ -219,7 +219,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to Eclair", async () => {
+  test.skip("successfully connects to Eclair", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Eclair");
@@ -240,7 +240,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to BTCPay", async () => {
+  test.skip("successfully connects to BTCPay", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "BTCPay Server");

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -86,7 +86,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to LNBits wallet", async () => {
+  test("successfully connects to LNBits wallet", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     // click at "Create LNbits Wallet"
@@ -153,7 +153,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to Umbrel", async () => {
+  test("successfully connects to Umbrel", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Umbrel");
@@ -163,7 +163,7 @@ test.describe("Create or connect wallets", () => {
     await findByText($document, "lndconnect REST URL");
 
     const macaroon =
-      "AgEDbG5kAvgBAwoQ/6M0baViThOf9HKqz4sEWhIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgf8fvHjHsWvxJgqYv9iSuVoIhJ4P7r1CAi5bN6WYVdg0=";
+      "AgEDbG5kAvgBAwoQs79pBsGTcTmsBoSsRBcTnRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgo/gQFwrZNApjB0tt3tMe2DpxQP0mx3WIVhEVg7dyWys=";
     const restApiUrl = `lndconnect://lnd1.regtest.getalby.com?cert=&macaroon=${macaroon}`;
     const lndConnectUrlField = await getByLabelText(
       $document,
@@ -175,7 +175,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to myNode", async () => {
+  test("successfully connects to myNode", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "myNode");
@@ -185,7 +185,7 @@ test.describe("Create or connect wallets", () => {
     await findByText($document, "lndconnect REST URL");
 
     const macaroon =
-      "AgEDbG5kAvgBAwoQ/6M0baViThOf9HKqz4sEWhIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgf8fvHjHsWvxJgqYv9iSuVoIhJ4P7r1CAi5bN6WYVdg0=";
+      "AgEDbG5kAvgBAwoQs79pBsGTcTmsBoSsRBcTnRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgo/gQFwrZNApjB0tt3tMe2DpxQP0mx3WIVhEVg7dyWys=";
     const restApiUrl = `lndconnect://lnd1.regtest.getalby.com?cert=&macaroon=${macaroon}`;
     const lndConnectUrlField = await getByLabelText(
       $document,
@@ -197,7 +197,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to Start9", async () => {
+  test("successfully connects to Start9", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Start9");
@@ -207,7 +207,7 @@ test.describe("Create or connect wallets", () => {
     await findByText($document, "lndconnect REST URL");
 
     const macaroon =
-      "AgEDbG5kAvgBAwoQ/6M0baViThOf9HKqz4sEWhIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgf8fvHjHsWvxJgqYv9iSuVoIhJ4P7r1CAi5bN6WYVdg0=";
+      "AgEDbG5kAvgBAwoQs79pBsGTcTmsBoSsRBcTnRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgo/gQFwrZNApjB0tt3tMe2DpxQP0mx3WIVhEVg7dyWys=";
     const restApiUrl = `lndconnect://lnd1.regtest.getalby.com?cert=&macaroon=${macaroon}`;
     const lndConnectUrlField = await getByLabelText(
       $document,
@@ -240,7 +240,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to BTCPay", async () => {
+  test("successfully connects to BTCPay", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "BTCPay Server");

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -86,6 +86,36 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
+  test("opens publishers screen", async () => {
+    const { page, browser, extensionId } = await loadExtension();
+    await Promise.all([
+      page.waitForNavigation(), // The promise resolves after navigation has finished
+    ]);
+
+    const optionsPage = `chrome-extension://${extensionId}/options.html`;
+    await page.goto(optionsPage);
+
+    await Promise.all([
+      page.waitForNavigation(), // The promise resolves after navigation has finished
+    ]);
+
+    const $optionsdocument = await getDocument(page);
+
+    const passwordField = await getByPlaceholderText(
+      $optionsdocument,
+      "Password"
+    );
+    await passwordField.type(user.password);
+
+    const unlockButton = await getByText($optionsdocument, "Unlock");
+    unlockButton.click();
+
+    await waitFor(() => getByText($optionsdocument, "Your ⚡️ Websites"));
+    await waitFor(() => getByText($optionsdocument, "Other ⚡️ Websites"));
+
+    await browser.close();
+  });
+
   test("successfully connects to LNBits wallet", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
@@ -257,36 +287,6 @@ test.describe("Create or connect wallets", () => {
 
     await page.waitForTimeout(1000);
     await commonCreateWalletSuccessCheck({ page, $document });
-    await browser.close();
-  });
-
-  test("opens publishers screen", async () => {
-    const { page, browser, extensionId } = await loadExtension();
-    await Promise.all([
-      page.waitForNavigation(), // The promise resolves after navigation has finished
-    ]);
-
-    const optionsPage = `chrome-extension://${extensionId}/options.html`;
-    await page.goto(optionsPage);
-
-    await Promise.all([
-      page.waitForNavigation(), // The promise resolves after navigation has finished
-    ]);
-
-    const $optionsdocument = await getDocument(page);
-
-    const passwordField = await getByPlaceholderText(
-      $optionsdocument,
-      "Password"
-    );
-    await passwordField.type(user.password);
-
-    const unlockButton = await getByText($optionsdocument, "Unlock");
-    unlockButton.click();
-
-    await waitFor(() => getByText($optionsdocument, "Your ⚡️ Websites"));
-    await waitFor(() => getByText($optionsdocument, "Other ⚡️ Websites"));
-
     await browser.close();
   });
 });

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -78,7 +78,7 @@ const createAlbyWallet = async ({ page, $document, user }) => {
 };
 
 test.describe("Create or connect wallets", () => {
-  test.skip("successfully creates an Alby wallet", async () => {
+  test("successfully creates an Alby wallet", async () => {
     const { user, browser, page, $document } =
       await commonCreateWalletUserCreate();
     await createAlbyWallet({ page, $document, user });
@@ -219,7 +219,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to Eclair", async () => {
+  test("successfully connects to Eclair", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Eclair");

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -271,7 +271,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to BTCPay", async () => {
+  test.skip("successfully connects to BTCPay", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "BTCPay Server");

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -252,7 +252,7 @@ test.describe("Create or connect wallets", () => {
     const configField = await findByLabelText($document, "Config data");
 
     await configField.type(
-      "config=https://gist.githubusercontent.com/bumi/71885ed90617b3ba2dd485ecfb7829eb/raw/f7e86f6d8b71b33c70b01a650be337408a0c7a11/mock-btcpay-lnd.json"
+      "config=https://gist.githubusercontent.com/bumi/71885ed90617b3ba2dd485ecfb7829eb/raw/26a91185ee273df4eaa75f6ec406001ab4a5d2cf/mock-btcpay-lnd.json"
     );
 
     await page.waitForTimeout(1000);

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -103,7 +103,7 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test.skip("successfully connects to BlueWallet", async () => {
+  test("successfully connects to BlueWallet", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     // click at "LNDHub (BlueWallet)"

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -219,7 +219,8 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
-  test("successfully connects to Eclair", async () => {
+  // under maintenance for now
+  test.skip("successfully connects to Eclair", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 
     const connectButton = await getByText($document, "Eclair");

--- a/tests/e2e/helpers/loadExtension.ts
+++ b/tests/e2e/helpers/loadExtension.ts
@@ -12,6 +12,7 @@ export const loadExtension = async () => {
     : "./dist/development/chrome";
 
   const browser = await puppeteer.launch({
+    userDataDir: "./puppeteer-user-data-dir",
     headless: false, // https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#working-with-chrome-extensions
     executablePath: process.env.PUPPETEER_EXEC_PATH, // set by docker container - https://github.com/mujo-code/puppeteer-headful
     args: [


### PR DESCRIPTION
### Describe the changes you have made in this PR

- Use `userDataDir` pupeeteer option
- Reuse browser cache/storage/settings throughout test runs to avoid creating a new account to test functionality within the app

### Type of change (Remove other not matching type)

- chore/test

### How has this been tested?

See e2e tests

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
