### PR TITLE
fix: catch boostagram parsing errors

### DIFF
--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -176,11 +176,16 @@ const utils = {
   getBoostagramFromInvoiceCustomRecords: (
     custom_records: Invoice["custom_records"] | undefined
   ) => {
-    const hasBoostagram = custom_records && 7629169 in custom_records;
-    const boostagramDecoded = hasBoostagram
-      ? atob(custom_records[7629169])
-      : undefined;
-    return boostagramDecoded ? JSON.parse(boostagramDecoded) : undefined;
+    try {
+      const hasBoostagram = custom_records && 7629169 in custom_records;
+      const boostagramDecoded = hasBoostagram
+        ? atob(custom_records[7629169])
+        : undefined;
+      return boostagramDecoded ? JSON.parse(boostagramDecoded) : undefined;
+    } catch (e) {
+      console.error(e);
+      return;
+    }
   },
 };
 


### PR DESCRIPTION
We don't know what's in the custom records anything can fail.
With invalid data the `atob` or the `JSON.parse` can fail.

We now just catch and ignore all errors here
