### PR TITLE
refactor: use settings context in LNURLPay

### DIFF
--- a/src/app/screens/LNURLPay.tsx
+++ b/src/app/screens/LNURLPay.tsx
@@ -11,7 +11,6 @@ import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import { USER_REJECTED_ERROR } from "~/common/constants";
-import api from "~/common/lib/api";
 import lnurl from "~/common/lib/lnurl";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
@@ -104,15 +103,9 @@ function LNURLPay(props: Props) {
   }, [searchParams]);
 
   useEffect(() => {
-    api.getSettings().then((response) => {
-      if (response.userName) {
-        setUserName(response.userName);
-      }
-      if (response.userEmail) {
-        setUserEmail(response.userEmail);
-      }
-    });
-  }, []);
+    !!settings.userName && setUserName(settings.userName);
+    !!settings.userEmail && setUserEmail(settings.userEmail);
+  }, [settings.userName, settings.userEmail]);
 
   const getPayerData = (details: LNURLPayServiceResponse) => {
     if (


### PR DESCRIPTION
### Describe the changes you have made in this PR

The new SettingsContext provides a hook `useSettings` which can be used on component level for reading the current settings.

### Link this PR to an issue

closes https://github.com/getAlby/lightning-browser-extension/issues/1210


### How has this been tested?

Added a userName and userEmail in Settings => input fields in LNURLPay screen are pre-filled


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
