### PR TITLE
chore(lnurl): bech32 parsing eerror is just an info, not a real error

### DIFF
--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -28,7 +28,7 @@ const normalizeLnurl = (lnurlString: string) => {
     const url = bech32Decode(lnurlString);
     return new URL(url);
   } catch (e) {
-    console.error("ignoring bech32 parsing error", e);
+    console.info("ignoring bech32 parsing error", e);
   }
 
   // maybe it's a lightning address?


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adjusting the output of this _error_.  
It's confusing because you can think that this is an actual error while this is just an info that's bech32 decoding did not work on this which is ok.

Code is doing this:
1. // maybe it's bech32 encoded?
2. // maybe it's a lightning address?
3. //maybe it's already a URL?


### Type of change (Remove other not matching type)

- chore

### Screenshots of the changes

Before:
![image](https://user-images.githubusercontent.com/1016218/182345809-85508bb1-8641-4cc5-bcae-a450054378cf.png)

After:
![image](https://user-images.githubusercontent.com/1016218/182345690-1c18a46d-4229-488e-8372-4defe5a45cfe.png)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
