### PR TITLE
fix: youtube battery

### DIFF
--- a/src/extension/content-script/batteries/YouTubeVideo.ts
+++ b/src/extension/content-script/batteries/YouTubeVideo.ts
@@ -4,16 +4,20 @@ import setLightningData from "../setLightningData";
 const urlMatcher = /^https:\/\/www\.youtube.com\/watch.*/;
 
 const battery = (): void => {
-  const videoDescription = document.querySelector(
-    "#columns #primary #primary-inner #meta-contents #description .content"
-  );
+  let text = "";
+  document
+    .querySelectorAll(
+      "#columns #primary #primary-inner #meta-contents #description .content"
+    )
+    .forEach((e) => {
+      text += ` ${e.textContent}`;
+    });
   const channelLink = document.querySelector(
     "#columns #primary #primary-inner #meta-contents .ytd-channel-name a"
   );
-  if (!videoDescription || !channelLink) {
+  if (!text || !channelLink) {
     return;
   }
-  const text = videoDescription.textContent || "";
   let match;
   let recipient;
   // check for an lnurl


### PR DESCRIPTION
### Describe the changes you have made in this PR
This query selector no longer seems to be unique and now matches
two elements. To fix it we simply use the textcontent of all matching elements.

### Type of change (Remove other not matching type)
- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Send some sats to: https://www.youtube.com/watch?v=-WAZ2UCabZs

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
