### PR TITLE
feat: change metadata type to string

### DIFF
--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -5,16 +5,17 @@ type Props = {
   amount: string | React.ReactNode;
   amountAlt?: string;
   description?: string | React.ReactNode;
-  metadata?: { [key: string]: string };
+  metadata?: string;
 };
 
 function PaymentSummary({ amount, amountAlt, description, metadata }: Props) {
   const metadataElements: JSX.Element[] = [];
   if (metadata != undefined) {
-    const isMetadataValid = MetadataValidator(metadata);
+    const metadataObject: object = JSON.parse(metadata);
+    const isMetadataValid: boolean = MetadataValidator(metadataObject);
 
     if (isMetadataValid) {
-      for (const key in metadata) {
+      for (const [key, value] of Object.entries(metadataObject)) {
         metadataElements.push(
           <>
             <dt className="mt-4 font-medium text-gray-800 dark:text-white">
@@ -22,9 +23,9 @@ function PaymentSummary({ amount, amountAlt, description, metadata }: Props) {
             </dt>
             <dd className="mb-0 text-gray-600 dark:text-neutral-500 break-all">
               {key == "image" ? (
-                <img src={`data:image/png;base64, ${metadata[key]}`} />
+                <img src={`data:image/png;base64, ${value}`} />
               ) : (
-                metadata[key]
+                value
               )}
             </dd>
           </>

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -120,9 +120,7 @@ function Prompt() {
                   <ConfirmPayment
                     paymentRequest={routeParams.args?.paymentRequest as string}
                     origin={routeParams.origin}
-                    metadata={
-                      routeParams.args?.metadata as { [key: string]: string }
-                    }
+                    metadata={routeParams.args?.metadata as string}
                   />
                 }
               />

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -19,7 +19,7 @@ import type { OriginData } from "~/types";
 export type Props = {
   origin?: OriginData;
   paymentRequest?: string;
-  metadata?: { [key: string]: string };
+  metadata?: string;
 };
 
 function ConfirmPayment(props: Props) {

--- a/src/schema/metadataValidator.ts
+++ b/src/schema/metadataValidator.ts
@@ -11,12 +11,12 @@ export function isBase64(str: string) {
   }
 }
 
-export function MetadataValidator(metadata: { [key: string]: string }) {
+export function MetadataValidator(metadata: object) {
   let hasValidType = false;
   let hasValidImage = true;
-  for (const key in metadata) {
+  for (const [key, value] of Object.entries(metadata)) {
     if (key == "type") {
-      if (metadata[key] == "AudioObject") {
+      if (value == "AudioObject") {
         const parsed = audioObjectSchema.safeParse(metadata);
         if (parsed.success) {
           hasValidType = true;
@@ -24,7 +24,7 @@ export function MetadataValidator(metadata: { [key: string]: string }) {
       }
     }
     if (key == "image") {
-      hasValidImage = isBase64(metadata[key]);
+      hasValidImage = isBase64(value);
     }
   }
 


### PR DESCRIPTION

_A clear and concise description of what you want to happen_
change metadata type to string
change rendering mechasim by parsing stringified change and rendering it as javascript object
pass it as as string will help it to store metadata as JSON in db

