### PR TITLE
chore: update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,7 @@ jobs:
   comment-build-links:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs:
-      [
-        build,
-        release-firefox-nightly,
-        release-chrome-nightly,
-        release-opera-nightly,
-      ]
+    needs: [build]
     name: comment-release-links
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     name: build-prod
+    env:
+      WALLET_CREATE_URL: "https://getalby.com/api/users"
 
     steps:
       - uses: actions/checkout@v3
@@ -43,78 +45,6 @@ jobs:
           name: opera.crx
           path: dist/production/opera.crx
 
-  release-firefox-nightly:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      FILE: "firefox.xpi"
-      AWS_REGION: "eu-central-1"
-      S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_KEY: "alby-firefox-nightly-${{ github.event.pull_request.number || 'master' }}.xpi"
-
-    name: release-firefox-nightly
-    steps:
-      - name: Download firefox.xpi
-        if: ${{ env.S3_BUCKET }}
-        uses: actions/download-artifact@v2
-        with:
-          name: firefox.xpi
-      - name: Upload releases to S3
-        if: ${{ env.S3_BUCKET }}
-        uses: zdurham/s3-upload-github-action@master
-        with:
-          args: --acl public-read --content-type application/x-xpinstall
-
-  release-chrome-nightly:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      FILE: "chrome.zip"
-      AWS_REGION: "eu-central-1"
-      S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_KEY: "alby-chrome-nightly-${{ github.event.pull_request.number || 'master' }}.zip"
-
-    name: release-chrome-nightly
-    steps:
-      - name: Download chrome.zip
-        if: ${{ env.S3_BUCKET }}
-        uses: actions/download-artifact@v2
-        with:
-          name: chrome.zip
-      - name: Upload releases to S3
-        if: ${{ env.S3_BUCKET }}
-        uses: zdurham/s3-upload-github-action@master
-        with:
-          args: --acl public-read
-
-  release-opera-nightly:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      FILE: "opera.crx"
-      AWS_REGION: "eu-central-1"
-      S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_KEY: "alby-opera-nightly-${{ github.event.pull_request.number || 'master' }}.crx"
-
-    name: release-opera-nightly
-    steps:
-      - name: Download opera.crz
-        if: ${{ env.S3_BUCKET }}
-        uses: actions/download-artifact@v2
-        with:
-          name: opera.crx
-      - name: Upload releases to S3
-        if: ${{ env.S3_BUCKET }}
-        uses: zdurham/s3-upload-github-action@master
-        with:
-          args: --acl public-read
-
   comment-build-links:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
@@ -126,12 +56,9 @@ jobs:
         release-opera-nightly,
       ]
     name: comment-release-links
-    env:
-      S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
 
     steps:
       - name: Find Comment
-        if: ${{ env.S3_BUCKET }}
         uses: peter-evans/find-comment@v2
         id: fc
         with:
@@ -140,13 +67,12 @@ jobs:
           body-includes: Build files
 
       - name: Create or update comment
-        if: ${{ env.S3_BUCKET }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Build files:
-            * [Firefox](https://${{ env.S3_BUCKET }}.s3.eu-central-1.amazonaws.com/alby-firefox-nightly-${{ github.event.pull_request.number }}.xpi)
-            * [Chrome](https://${{ env.S3_BUCKET }}.s3.eu-central-1.amazonaws.com/alby-chrome-nightly-${{ github.event.pull_request.number }}.zip)
+            * [Firefox](https://nightly.link/getAlby/lightning-browser-extension/actions/runs/${{ github.run_id }}/firefox.xpi.zip)
+            * [Chrome](https://nightly.link/getAlby/lightning-browser-extension/actions/runs/${{ github.run_id }}/chrome.zip)
           edit-mode: replace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,10 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Build files:
+            Build files for this pull request:
             * [Firefox](https://nightly.link/getAlby/lightning-browser-extension/actions/runs/${{ github.run_id }}/firefox.xpi.zip)
             * [Chrome](https://nightly.link/getAlby/lightning-browser-extension/actions/runs/${{ github.run_id }}/chrome.zip)
+            Use those to install this build. See the [readme](https://github.com/getAlby/lightning-browser-extension#-load-extension-into-browser) for install instructions.
+
+            keep stacking sats!
           edit-mode: replace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,10 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Build files for this pull request:
+            Here are the current build files for this pull request. See the [readme](https://github.com/getAlby/lightning-browser-extension#-load-extension-into-browser) for install instructions.
+
             * [Firefox](https://nightly.link/getAlby/lightning-browser-extension/actions/runs/${{ github.run_id }}/firefox.xpi.zip)
             * [Chrome](https://nightly.link/getAlby/lightning-browser-extension/actions/runs/${{ github.run_id }}/chrome.zip)
-            Use those to install this build. See the [readme](https://github.com/getAlby/lightning-browser-extension#-load-extension-into-browser) for install instructions.
 
             keep stacking sats!
           edit-mode: replace

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Add Alby to your browser
 
 ### Try out the most recent version of Alby (Nightly Releases)
 
-- [Firefox Nightly](https://alby-releases-public.s3.eu-central-1.amazonaws.com/alby-firefox-nightly-master.xpi) - best to install it as a temporary add-on as discussed in the "Load extension into browser" section
-- [Chrome Nightly](https://alby-releases-public.s3.eu-central-1.amazonaws.com/alby-chrome-nightly-master.zip) - go to `chrome://extensions/`, enable "Developer mode" (top right) and drag & drop the file in the browser
+- [Firefox Nightly](https://nightly.link/getAlby/lightning-browser-extension/workflows/build/master/firefox.xpi.zip) - best to install it as a temporary add-on as discussed in the "Load extension into browser" section
+- [Chrome Nightly](https://nightly.link/getAlby/lightning-browser-extension/workflows/build/master/chrome.zip) - go to `chrome://extensions/`, enable "Developer mode" (top right) and drag & drop the file in the browser
 
 (Note: You might need to reconfigure your wallet after installing new versions)
 
@@ -120,7 +120,7 @@ Then run the following
 
 #### Testnet/testing-accounts for development
 
-We set up our own internal testnet, which can be used for your development.  
+We set up our own internal testnet, which can be used for your development.
 If this is not reachable please let us know.
 
 - [Test-setup](https://github.com/getAlby/lightning-browser-extension/wiki/Test-setup) for different connectors (i.e. LND)
@@ -130,7 +130,7 @@ If this is not reachable please let us know.
 
 #### Storybook.js
 
-We have a working [Storybook](https://storybook.js.org)-setup and some components have stories.  
+We have a working [Storybook](https://storybook.js.org)-setup and some components have stories.
 You can find the deployed Storybook here: https://lbe-stories.netlify.app
 
 ### :white_check_mark: Tests
@@ -289,7 +289,7 @@ heavily inspired by the super-amazing work of the [Joule extension](https://ligh
 
 Want to support the work on Alby?
 
-Support the Alby team ⚡️hello@getalby.com  
+Support the Alby team ⚡️hello@getalby.com
 You can also contribute to our [bounty program](https://github.com/getAlby/lightning-browser-extension/wiki/Bounties): ⚡️bounties@getalby.com
 
 ## License


### PR DESCRIPTION
### Describe the changes you have made in this PR

We now use nightly.link to link to the build files and because of that no longer need S3. 
This seems to be much easier as we do not need to upload the files to S3 and this also means the workflow does no longer need any sensitive data and thus we can comment the build link on all PRs

Additionally this also uses the production getalby.com accounts

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

