### PR TITLE
fix: remove decodeURI from boostagram message

### DIFF
--- a/src/app/components/TransactionsTable/index.test.tsx
+++ b/src/app/components/TransactionsTable/index.test.tsx
@@ -80,7 +80,7 @@ const invoicesWithBoostagram: Props = {
         episode: undefined,
         itemID: undefined,
         ts: undefined,
-        message: "Du bist so 1 geiles podcast",
+        message: "Du bist so 1 geiles podcast 100%",
         sender_id: "123456",
         sender_name: "bumi@getalby.com",
         time: "00:00",
@@ -161,7 +161,7 @@ describe("TransactionsTable", () => {
     });
 
     expect(
-      await screen.findByText(/Message: Du bist so 1 geiles podcast/)
+      await screen.findByText(/Message: Du bist so 1 geiles podcast 100%/)
     ).toBeInTheDocument();
     expect(
       await screen.findByText(/Sender: bumi@getalby.com/)

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -127,7 +127,7 @@ export default function TransactionsTable({ transactions }: Props) {
                             {tComponents(
                               "transactionsTable.boostagram.message"
                             )}
-                            : {tx.boostagram.message && tx.boostagram.message}
+                            : {tx.boostagram.message}
                           </li>
                           <li>
                             {tComponents(

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -127,9 +127,7 @@ export default function TransactionsTable({ transactions }: Props) {
                             {tComponents(
                               "transactionsTable.boostagram.message"
                             )}
-                            :{" "}
-                            {tx.boostagram.message &&
-                              decodeURI(tx.boostagram.message)}
+                            : {tx.boostagram.message && tx.boostagram.message}
                           </li>
                           <li>
                             {tComponents(


### PR DESCRIPTION
the message is a random string provided by the user
