### PR TITLE
fix(lnurlpay): correct close for popup/prompt

### DIFF
--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -53,6 +53,8 @@ function LNURLAuth() {
         throw new Error("Auth status is not ok");
       }
 
+      // ATTENTION: if this LNURL is called through `webln.lnurl` then we immediately return and return the response. This closes the window which means the user will NOT see the above successAction.
+      // We assume this is OK when it is called through webln.
       if (navState.isPrompt) {
         return await msg.reply(response);
       }

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -56,7 +56,6 @@ function LNURLPay() {
   const [successAction, setSuccessAction] = useState<
     LNURLPaymentSuccessAction | undefined
   >();
-  const [payment, setPayment] = useState<PaymentResponse | undefined>();
 
   useEffect(() => {
     if (showFiat) {
@@ -157,8 +156,6 @@ function LNURLPay() {
         }
       );
 
-      setPayment(paymentResponse);
-
       // Once payment is fulfilled LN WALLET executes a non-null successAction
       // LN WALLET should also store successAction data on the transaction record
       if (paymentInfo.successAction) {
@@ -205,12 +202,9 @@ function LNURLPay() {
   }
 
   function close(e: MouseEvent) {
+    // will never be reached via prompt
     e.preventDefault();
-    if (navState.isPrompt) {
-      msg.reply(payment);
-    } else {
-      window.close();
-    }
+    navigate(-1);
   }
 
   function getRecipient() {

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -65,6 +65,12 @@ function LNURLWithdraw() {
       } else {
         setErrorMessage(`Error: ${response.data.reason}`);
       }
+
+      // ATTENTION: if this LNURL is called through `webln.lnurl` then we immediately return and return the response. This closes the window which means the user will NOT see the above successAction.
+      // We assume this is OK when it is called through webln.
+      if (navState.isPrompt) {
+        return await msg.reply(response);
+      }
     } catch (e) {
       console.error(e);
       if (e instanceof Error) {
@@ -116,12 +122,9 @@ function LNURLWithdraw() {
   }
 
   function close(e: MouseEvent) {
+    // will never be reached via prompt
     e.preventDefault();
-    if (navState.isPrompt) {
-      window.close();
-    } else {
-      navigate(-1);
-    }
+    navigate(-1);
   }
 
   return (


### PR DESCRIPTION
### Describe the changes you have made in this PR

Align close actions for all actions. Those will not be reached by the modal because it is closing itself on success.

### Link this PR to an issue

#1216 

### Type of change (Remove other not matching type)

- `refactor`

### How has this been tested?
Manually tested with fiatjef and starblocks


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
