### PR TITLE
Refactor/1285 use settings context for updates

### DIFF
--- a/src/app/components/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/src/app/components/LocaleSwitcher/LocaleSwitcher.tsx
@@ -2,7 +2,6 @@ import type { FallbackLng } from "i18next";
 import { useState, useEffect } from "react";
 import type { ChangeEvent } from "react";
 import { useSettings } from "~/app/context/SettingsContext";
-import api from "~/common/lib/api";
 import i18n from "~/i18n/i18nConfig";
 
 import Select from "../form/Select";
@@ -27,7 +26,6 @@ export default function LocaleSwitcher() {
     if (dropdownLang !== newLanguage) {
       setDropdownLang(newLanguage);
       updateSetting({ locale: newLanguage });
-      await api.setSetting({ locale: newLanguage });
     }
   };
 

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -22,14 +22,16 @@ export const SettingsProvider = ({
 }) => {
   const [settings, setSettings] =
     useState<SettingsContextType["settings"]>(DEFAULT_SETTINGS);
-
   const [isLoading, setIsLoading] = useState(true);
+
   // call this to trigger a re-render on all occassions
-  const updateSetting = (setting: Setting) =>
+  const updateSetting = async (setting: Setting) => {
     setSettings((prevState) => ({
       ...prevState,
       ...setting,
     }));
+    await api.setSetting(setting); // updates browser storage as well
+  };
 
   // Invoked only on on mount.
   useEffect(() => {

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -1,6 +1,7 @@
 import i18n from "i18next";
 import { useState, useEffect, createContext, useContext } from "react";
 import { toast } from "react-toastify";
+import { getTheme } from "~/app/utils";
 import api from "~/common/lib/api";
 import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
 import type { SettingsStorage } from "~/types";
@@ -50,10 +51,15 @@ export const SettingsProvider = ({
       });
   }, []);
 
-  // update i18n on every locale change
+  // update locale on every change
   useEffect(() => {
     i18n.changeLanguage(settings.locale);
   }, [settings.locale]);
+
+  // update theme on every change
+  useEffect(() => {
+    getTheme(); // Get the active theme and apply corresponding Tailwind classes to the document
+  }, [settings.theme]);
 
   const value = {
     settings,

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -15,7 +15,6 @@ import Modal from "react-modal";
 import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
-import { getTheme } from "~/app/utils";
 import { CURRENCIES } from "~/common/constants";
 import utils from "~/common/lib/utils";
 
@@ -112,7 +111,6 @@ function Settings() {
                   await saveSetting({
                     theme: event.target.value,
                   });
-                  getTheme(); // Get the active theme and apply corresponding Tailwind classes to the document
                 }}
               >
                 <option value="dark">{t("theme.options.dark")}</option>

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -17,7 +17,6 @@ import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import { getTheme } from "~/app/utils";
 import { CURRENCIES } from "~/common/constants";
-import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
 
 const initialFormData = {
@@ -53,7 +52,6 @@ function Settings() {
   ) {
     // ensure to update SettingsContext
     updateSetting(setting);
-    await api.setSetting(setting);
   }
 
   return (

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   SettingsStorage,
   MessageInvoices,
   DbPayment,
+  MessageSettingsSet,
 } from "~/types";
 
 import {
@@ -95,9 +96,7 @@ export const makeInvoice = ({ amount, memo }: MakeInvoiceArgs) =>
   utils.call<MakeInvoiceResponse["data"]>("makeInvoice", { amount, memo });
 export const connectPeer = ({ host, pubkey }: ConnectPeerArgs) =>
   utils.call<ConnectPeerResponse["data"]>("connectPeer", { host, pubkey });
-export const setSetting = (
-  setting: Record<string, string | number | boolean>
-) =>
+export const setSetting = (setting: MessageSettingsSet["args"]["setting"]) =>
   utils.call<SettingsStorage>("setSetting", {
     setting,
   });

--- a/src/extension/background-script/actions/settings/set.ts
+++ b/src/extension/background-script/actions/settings/set.ts
@@ -3,6 +3,20 @@ import { Message } from "~/types";
 import state from "../../state";
 
 const set = async (message: Message) => {
+  //   {
+  //     "application": "LBE",
+  //     "prompt": true,
+  //     "action": "setSetting",
+  //     "args": {
+  //         "setting": {
+  //             "locale": "hi"
+  //         }
+  //     },
+  //     "origin": {
+  //         "internal": true
+  //     }
+  // }
+
   const { settings } = state.getState();
   const { setting } = message.args;
   if (typeof setting === "object") {

--- a/src/extension/background-script/actions/settings/set.ts
+++ b/src/extension/background-script/actions/settings/set.ts
@@ -1,22 +1,8 @@
-import { Message } from "~/types";
+import { MessageSettingsSet } from "~/types";
 
 import state from "../../state";
 
-const set = async (message: Message) => {
-  //   {
-  //     "application": "LBE",
-  //     "prompt": true,
-  //     "action": "setSetting",
-  //     "args": {
-  //         "setting": {
-  //             "locale": "hi"
-  //         }
-  //     },
-  //     "origin": {
-  //         "internal": true
-  //     }
-  // }
-
+const set = async (message: MessageSettingsSet) => {
   const { settings } = state.getState();
   const { setting } = message.args;
   if (typeof setting === "object") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,6 +271,11 @@ export interface MessageConnectPeer extends MessageDefault {
   action: "connectPeer";
 }
 
+export interface MessageSettingsSet extends MessageDefault {
+  args: { setting: Partial<SettingsStorage> };
+  action: "setSetting";
+}
+
 export interface LNURLChannelServiceResponse {
   uri: string; // Remote node address of form node_key@ip_address:port_number
   callback: string; // a second-level URL which would initiate an OpenChannel message from target LN node


### PR DESCRIPTION
### Describe the changes you have made in this PR

Paired with @lisabaut 

The Settings Context is the only place for getting and updating the settings in/from browser.storage on component level

Also
- create new message type
- handle theme as well via context

### Link this PR to an issue

#1285

### Type of change (Remove other not matching type)

- refactor
 
### How has this been tested?

manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
