### PR TITLE
feat(unlock): render Toasts on Errors

### DIFF
--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -77,7 +77,15 @@ function Options() {
               }
             />
           </Route>
-          <Route path="unlock" element={<Unlock />} />
+          <Route
+            path="unlock"
+            element={
+              <>
+                <Unlock />
+                <ToastContainer />
+              </>
+            }
+          />
         </Routes>
       </HashRouter>
     </Providers>

--- a/src/app/router/Popup/Popup.tsx
+++ b/src/app/router/Popup/Popup.tsx
@@ -36,7 +36,15 @@ function Popup() {
             <Route path="keysend" element={<Keysend />} />
             <Route path="confirmPayment" element={<ConfirmPayment />} />
           </Route>
-          <Route path="unlock" element={<Unlock />} />
+          <Route
+            path="unlock"
+            element={
+              <>
+                <Unlock />
+                <ToastContainer />
+              </>
+            }
+          />
         </Routes>
       </HashRouter>
     </Providers>

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -141,7 +141,15 @@ function Prompt() {
               }
             />
           </Route>
-          <Route path="unlock" element={<Unlock />} />
+          <Route
+            path="unlock"
+            element={
+              <>
+                <Unlock />
+                <ToastContainer />
+              </>
+            }
+          />
         </Routes>
       </HashRouter>
     </Providers>

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -27,13 +27,7 @@ const utils = {
       })
       .then((response: { data: T; error?: string }) => {
         if (response.error) {
-          // trigger toast only on screens which contain <ToastContainer />
-          // otherwise toast are cached and appear in a different context again => see ticket #1286
-          // Also, Screen "Unlock" has it's own UI error rendering
-          if (action !== "unlock") {
-            toast.error(response.error);
-          }
-          // TBD: Or remove toast from this file completely, and ensure that toast are triggered on all Components where needed (=> larger refactor, remove this comment before merge)
+          toast.error(response.error);
           throw new Error(response.error);
         }
         return response.data;

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -27,7 +27,13 @@ const utils = {
       })
       .then((response: { data: T; error?: string }) => {
         if (response.error) {
-          toast.error(response.error);
+          // trigger toast only on screens which contain <ToastContainer />
+          // otherwise toast are cached and appear in a different context again => see ticket #1286
+          // Also, Screen "Unlock" has it's own UI error rendering
+          if (action !== "unlock") {
+            toast.error(response.error);
+          }
+          // TBD: Or remove toast from this file completely, and ensure that toast are triggered on all Components where needed (=> larger refactor, remove this comment before merge)
           throw new Error(response.error);
         }
         return response.data;


### PR DESCRIPTION
### Describe the changes you have made in this PR

As discussed below:
The problem of the [bug ticket](https://github.com/getAlby/lightning-browser-extension/issues/1286) is not that the Toast Messages of an Invalid Password should surpressed if the screen is not Unlock (because Unlock screen has its own error rendering).
Instead, the problem is that the Screen Unlock is not aware of Toasts at all. 
This has to be changed and toasts should appear on this screen too.

<img width="300" alt="unlock" src="https://user-images.githubusercontent.com/11243967/185853599-7b2f417a-ae1b-499f-8b68-f9f87eb37368.png">


### Link this PR to an issue

Closes https://github.com/getAlby/lightning-browser-extension/issues/1286

### Type of change (Remove other not matching type)

- Feature

### How has this been tested?


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
