### PR TITLE
proposal: use contentUrl field to trigger after actions on wallet side

### DIFF
--- a/src/extension/background-script/db.ts
+++ b/src/extension/background-script/db.ts
@@ -22,7 +22,7 @@ class DB extends Dexie {
     });
     this.version(3).stores({
       metadata:
-        "++id,allowanceId,host,metadata,paymentHash,createdAt,type",
+        "++id,allowanceId,host,metadata,paymentHash,createdAt,type,contentUrl",
     });
     this.on("ready", this.loadFromStorage.bind(this));
     this.allowances = this.table("allowances");

--- a/src/extension/background-script/events/persistMetadata.ts
+++ b/src/extension/background-script/events/persistMetadata.ts
@@ -10,9 +10,11 @@ const persistMetadata = async (_message, data) => {
 
   let metadata = data.metadata;
   let metadataType;
+  let contentUrl;
   if (data.metadata != undefined) {
     metadata = JSON.parse(data.metadata);
     metadataType = metadata.type;
+    contentUrl = metadata.contentUrl;
 
   }
   const paymentResponse = data.response;
@@ -23,7 +25,8 @@ const persistMetadata = async (_message, data) => {
     metadata: metadata,
     allowanceId: allowance?.id,
     createdAt: Date.now(),
-    type: metadataType
+    type: metadataType,
+    contentUrl: contentUrl
   });
   await db.saveToStorage();
   console.info(`Persisted metadata ${metadata}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,6 +310,7 @@ export interface Metadata {
   paymentHash: string;
   metadata?: JSON;
   type: string;
+  contentUrl?: string;
 }
 
 export interface PaymentResponse


### PR DESCRIPTION
### Describe the changes you have made in this PR
transaction metadata can be used for describing free transactions and well as commercial transactions (providing bought content in form of metadata)

add contentUrl field to be stored as an optional field in a separate column



### Proposal
Use case division
user can use transaction metadata spec, to give details about the transaction along with commercial purpose i.e give some content to the user after successful payment

1.  Metadata just describes the transaction, no confidential information is shared which shall be protected before payment

a> don't provide ```contentUrl```  in transaction metadata (as contentUrl field is optional) 
  transactions which are free, and don't give any content in return eg. donations
  	
b> provide ```contentUrl``` in transaction metadata (even if it's not confidential render it after successful payment only)


2. Metadata is used for digital content buy and sell purpose 

a> provide ```contentUrl``` field in transaction metadata - wallets render after successful payment)

b> don't provide ```contentUrl``` field in transaction metadata  - the client can do after actions in ```sendPayment``` callback function, eg. downloading a song in user local storage after successful payment


### security aspect of keeping ```contentUrl``` field optional::

any buying selling action is based on trust between lightning application and user. even if we make this field compulsory, there is no guarantee that the string passed in ```contentUrl``` field is a valid URL pointing to the digital content.


### features
1. after actions can be performed by client in ```sendPayment``` callback function on client side or they can be performed on wallet side after successful payment
2. In form of contentUrl now content can be access right inside the wallet, as well as outside the wallet
3. field is optional , hence it can used as per requirement for free as well as commercial transaction which involve buy and sell
### Checklist

- [X] My code follows the style guidelines of this project and performed a self-review of my own code
- [X] New and existing tests pass locally with my changes
- [X] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
