### PR TITLE
chore: indicate a user can pay a ln address or add a LNURL string

### DIFF
--- a/src/app/screens/Send/index.test.tsx
+++ b/src/app/screens/Send/index.test.tsx
@@ -26,26 +26,28 @@ describe("Send", () => {
     );
 
     expect(
-      await screen.getByLabelText("Lightning Invoice")
+      await screen.getByLabelText("Invoice, Lightning Address or LNURL")
     ).toBeInTheDocument();
     await act(async () => {
       await user.type(
-        screen.getByLabelText("Lightning Invoice"),
+        screen.getByLabelText("Invoice, Lightning Address or LNURL"),
         "    sampleinvoice  "
       );
     });
-    expect(screen.getByLabelText("Lightning Invoice")).toHaveValue(
-      "sampleinvoice"
-    );
+    expect(
+      screen.getByLabelText("Invoice, Lightning Address or LNURL")
+    ).toHaveValue("sampleinvoice");
     await act(async () => {
-      await user.clear(screen.getByLabelText("Lightning Invoice"));
+      await user.clear(
+        screen.getByLabelText("Invoice, Lightning Address or LNURL")
+      );
       await user.type(
-        screen.getByLabelText("Lightning Invoice"),
+        screen.getByLabelText("Invoice, Lightning Address or LNURL"),
         "lightning:test@getalby.com"
       );
     });
-    expect(screen.getByLabelText("Lightning Invoice")).toHaveValue(
-      "test@getalby.com"
-    );
+    expect(
+      screen.getByLabelText("Invoice, Lightning Address or LNURL")
+    ).toHaveValue("test@getalby.com");
   });
 });

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -267,10 +267,10 @@
     "send": {
       "title": "Send",
       "qrcode": {
-        "title": "Waiting to scan invoice"
+        "title": "Waiting to scan"
       },
       "input": {
-        "label": "Lightning Invoice",
+        "label": "Invoice, Lightning Address or LNURL",
         "placeholder": "Paste invoice, lnurl or lightning address"
       },
       "submit": {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Small label update to indicate the user can enter a LNURL or a lightning address

### Link this PR to an issue

first quick minor improvement for #1303 

