### PR TITLE
feat: show fiat in Confirm Payment

### DIFF
--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -13,7 +13,7 @@ function PaymentSummary({ amount, amountAlt, description, fiatAmount }: Props) {
       {amountAlt && <dd className="text-gray-400">{amountAlt}</dd>}
       {!!fiatAmount && (
         <>
-          <dt className="mt-4 font-medium dark:text-white">Amount (Fiats)</dt>
+          <dt className="mt-4 font-medium dark:text-white">Amount (Fiat)</dt>
           <dd className="text-gray-500 dark:text-neutral-400">~{fiatAmount}</dd>
         </>
       )}

--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -8,15 +8,14 @@ type Props = {
 function PaymentSummary({ amount, amountAlt, description, fiatAmount }: Props) {
   return (
     <dl className="mb-0">
-      <dt className="font-medium dark:text-white">Amount (Satoshi)</dt>
-      <dd className="text-gray-500 dark:text-neutral-400">{amount} sats</dd>
+      <dt className="font-medium dark:text-white">Amount</dt>
+      <dd className="text-gray-500 dark:text-neutral-400">
+        {amount} sats
+        {!!fiatAmount && (
+          <span className="text-gray-400"> (~{fiatAmount})</span>
+        )}
+      </dd>
       {amountAlt && <dd className="text-gray-400">{amountAlt}</dd>}
-      {!!fiatAmount && (
-        <>
-          <dt className="mt-4 font-medium dark:text-white">Amount (Fiat)</dt>
-          <dd className="text-gray-500 dark:text-neutral-400">~{fiatAmount}</dd>
-        </>
-      )}
       <dt className="mt-4 font-medium dark:text-white">Description</dt>
       <dd className="text-gray-500 dark:text-neutral-400 break-all">
         {description}

--- a/src/app/components/PaymentSummary.tsx
+++ b/src/app/components/PaymentSummary.tsx
@@ -2,14 +2,21 @@ type Props = {
   amount: string | React.ReactNode;
   amountAlt?: string;
   description?: string | React.ReactNode;
+  fiatAmount: string;
 };
 
-function PaymentSummary({ amount, amountAlt, description }: Props) {
+function PaymentSummary({ amount, amountAlt, description, fiatAmount }: Props) {
   return (
     <dl className="mb-0">
       <dt className="font-medium dark:text-white">Amount (Satoshi)</dt>
       <dd className="text-gray-500 dark:text-neutral-400">{amount} sats</dd>
       {amountAlt && <dd className="text-gray-400">{amountAlt}</dd>}
+      {!!fiatAmount && (
+        <>
+          <dt className="mt-4 font-medium dark:text-white">Amount (Fiats)</dt>
+          <dd className="text-gray-500 dark:text-neutral-400">~{fiatAmount}</dd>
+        </>
+      )}
       <dt className="mt-4 font-medium dark:text-white">Description</dt>
       <dd className="text-gray-500 dark:text-neutral-400 break-all">
         {description}

--- a/src/app/components/PaymentSummary/index.test.tsx
+++ b/src/app/components/PaymentSummary/index.test.tsx
@@ -34,6 +34,6 @@ describe("PaymentSummary", () => {
     });
 
     expect(getByTestId("fiat_amount")).toBeDefined();
-    expect(getByText("$0,02")).toBeDefined();
+    expect(getByText(/(~\$0,02)/)).toBeInTheDocument();
   });
 });

--- a/src/app/components/PaymentSummary/index.test.tsx
+++ b/src/app/components/PaymentSummary/index.test.tsx
@@ -1,0 +1,39 @@
+import PaymentSummary, { Props } from "@components/PaymentSummary";
+import { render } from "@testing-library/react";
+
+const defaultProps = {
+  amount: "1234",
+  fiatAmount: "",
+};
+
+describe("PaymentSummary", () => {
+  const renderComponent = (props?: Partial<Props>) =>
+    render(<PaymentSummary {...defaultProps} {...props} />);
+
+  test("renders correctly with default props", () => {
+    const { getByText, queryByText, queryByTestId } = renderComponent();
+
+    expect(getByText("1234 sats")).toBeDefined();
+    expect(queryByText("Description")).toBeNull();
+    expect(queryByTestId("fiat_amount")).toBeNull();
+  });
+
+  test("renders with description", () => {
+    const { getByText } = renderComponent({
+      description: "The lovely description",
+    });
+
+    expect(getByText("1234 sats")).toBeDefined();
+    expect(getByText("Description")).toBeDefined();
+    expect(getByText("The lovely description")).toBeDefined();
+  });
+
+  test("renders with fiat amount", () => {
+    const { getByText, getByTestId } = renderComponent({
+      fiatAmount: "$0,02",
+    });
+
+    expect(getByTestId("fiat_amount")).toBeDefined();
+    expect(getByText("$0,02")).toBeDefined();
+  });
+});

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -19,7 +19,10 @@ const PaymentSummary: FC<Props> = ({
       <dd className="text-gray-500 dark:text-neutral-400">
         {amount} sats
         {!!fiatAmount && (
-          <span className="text-gray-400"> (~{fiatAmount})</span>
+          <span className="text-gray-400" data-testid="fiat_amount">
+            {" "}
+            (~{fiatAmount})
+          </span>
         )}
       </dd>
       {amountAlt && <dd className="text-gray-400">{amountAlt}</dd>}

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -1,11 +1,18 @@
-type Props = {
+import { FC } from "react";
+
+export type Props = {
   amount: string | React.ReactNode;
   amountAlt?: string;
   description?: string | React.ReactNode;
   fiatAmount: string;
 };
 
-function PaymentSummary({ amount, amountAlt, description, fiatAmount }: Props) {
+const PaymentSummary: FC<Props> = ({
+  amount,
+  amountAlt,
+  description,
+  fiatAmount,
+}) => {
   return (
     <dl className="mb-0">
       <dt className="font-medium dark:text-white">Amount</dt>
@@ -22,6 +29,6 @@ function PaymentSummary({ amount, amountAlt, description, fiatAmount }: Props) {
       </dd>
     </dl>
   );
-}
+};
 
 export default PaymentSummary;

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -23,10 +23,14 @@ const PaymentSummary: FC<Props> = ({
         )}
       </dd>
       {amountAlt && <dd className="text-gray-400">{amountAlt}</dd>}
-      <dt className="mt-4 font-medium dark:text-white">Description</dt>
-      <dd className="text-gray-500 dark:text-neutral-400 break-all">
-        {description}
-      </dd>
+      {!!description && (
+        <>
+          <dt className="mt-4 font-medium dark:text-white">Description</dt>
+          <dd className="text-gray-500 dark:text-neutral-400 break-all">
+            {description}
+          </dd>
+        </>
+      )}
     </dl>
   );
 };

--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -122,6 +122,7 @@ function ConfirmKeysend(props: Props) {
               <div className="shadow mb-4 bg-white dark:bg-surface-02dp p-4 rounded-lg">
                 <PaymentSummary
                   amount={amount}
+                  fiatAmount={fiatAmount}
                   description={`Send payment to ${destination}`}
                 />
               </div>

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -112,8 +112,9 @@ function ConfirmPayment(props: Props) {
             <div className="my-4">
               <div className="mb-4 p-4 shadow bg-white dark:bg-surface-02dp rounded-lg">
                 <PaymentSummary
-                  amount={invoice.satoshis}
-                  description={invoice.tagsObject.description}
+                  amount={invoiceRef.current?.satoshis}
+                  fiatAmount={fiatAmount}
+                  description={invoiceRef.current?.tagsObject.description}
                 />
               </div>
 

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -112,9 +112,9 @@ function ConfirmPayment(props: Props) {
             <div className="my-4">
               <div className="mb-4 p-4 shadow bg-white dark:bg-surface-02dp rounded-lg">
                 <PaymentSummary
-                  amount={invoiceRef.current?.satoshis}
+                  amount={invoice.satoshis}
                   fiatAmount={fiatAmount}
-                  description={invoiceRef.current?.tagsObject.description}
+                  description={invoice.tagsObject.description}
                 />
               </div>
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

This PR renders the Fiat Amount of a confirmable payment (if the setting "showFiat" is true and fiatAmount exists accordingly).

~Design came from https://github.com/getAlby/lightning-browser-extension/issues/1306#issuecomment-1222261734~
=> Design changed, see Screenshot and comments below



### Link this PR to an issue

Closes https://github.com/getAlby/lightning-browser-extension/issues/1306


### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)


### Screenshots of the changes (If any)

<img width="395" alt="Bildschirmfoto 2022-08-24 um 10 27 26" src="https://user-images.githubusercontent.com/11243967/186369711-a282598f-e030-496d-a83c-c4e9d4144ffc.png">

### How has this been tested?
usign Stackernews and invoke payments

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
