### PR TITLE
refactor: use navstate for confirm payment

### DIFF
--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -58,9 +58,6 @@ function Prompt() {
                 <Navigate
                   to={`/${navigationState.action}`}
                   replace
-                  // no need to check for serializable data for the navState here,
-                  // navState does not fail when data is coming via a LNURL called by webLn
-                  // as all data in deep nested object are serializable in this case
                   state={navigationState}
                 />
               }

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -86,17 +86,7 @@ function Prompt() {
                 />
               }
             />
-            <Route
-              path="confirmPayment"
-              element={
-                <ConfirmPayment
-                  paymentRequest={
-                    navigationState.args?.paymentRequest as string
-                  }
-                  origin={navigationState.origin}
-                />
-              }
-            />
+            <Route path="confirmPayment" element={<ConfirmPayment />} />
             <Route
               path="confirmKeysend"
               element={

--- a/src/app/screens/ConfirmPayment/index.test.tsx
+++ b/src/app/screens/ConfirmPayment/index.test.tsx
@@ -4,8 +4,8 @@ import lightningPayReq from "bolt11";
 import { MemoryRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import * as SettingsContext from "~/app/context/SettingsContext";
+import type { OriginData } from "~/types";
 
-import type { Props } from "./index";
 import ConfirmPayment from "./index";
 
 jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
@@ -20,37 +20,45 @@ jest.mock("~/common/utils/currencyConvert", () => {
   };
 });
 
+const mockOrigin: OriginData = {
+  location: "https://getalby.com/demo",
+  domain: "https://getalby.com",
+  host: "getalby.com",
+  pathname: "/demo",
+  name: "Alby",
+  description: "",
+  icon: "https://getalby.com/assets/alby-503261fa1b83c396b7ba8d927db7072d15fea5a84d387a654c5d0a2cefd44604.svg",
+  metaData: {
+    title: "Alby Demo",
+    url: "https://getalby.com/demo",
+    provider: "Alby",
+    image:
+      "https://getalby.com/assets/alby-503261fa1b83c396b7ba8d927db7072d15fea5a84d387a654c5d0a2cefd44604.svg",
+    icon: "https://getalby.com/favicon.ico",
+  },
+  external: true,
+};
+
 const paymentRequest =
   "lnbc250n1p3qzycupp58uc2wa29470f98wrxmy4xwuqt8cywjygf5t2cp0s376y7nwdyq3sdqhf35kw6r5de5kueeqg3jk6mccqzpgxqyz5vqsp5wfdmwtv5rmru00ajsnn3f8lzpxa4snug2tmqvc8zj8semr4kjjts9qyyssq83h74pte8nrkqs8sr2hscv5zcdmhwunwnd6xr3mskeayh96pu7ksswa6p7trknlpp6t3js4k6uytxutv5ecgcwaxz7fj4zfy5khjcjcpf66muy";
 
-const props: Props = {
-  origin: {
-    location: "https://getalby.com/demo",
-    domain: "https://getalby.com",
-    host: "getalby.com",
-    pathname: "/demo",
-    name: "Alby",
-    description: "",
-    icon: "https://getalby.com/assets/alby-503261fa1b83c396b7ba8d927db7072d15fea5a84d387a654c5d0a2cefd44604.svg",
-    metaData: {
-      title: "Alby Demo",
-      url: "https://getalby.com/demo",
-      provider: "Alby",
-      image:
-        "https://getalby.com/assets/alby-503261fa1b83c396b7ba8d927db7072d15fea5a84d387a654c5d0a2cefd44604.svg",
-      icon: "https://getalby.com/favicon.ico",
-    },
-    external: true,
-  },
-  paymentRequest,
-};
+jest.mock("~/app/hooks/useNavigationState", () => {
+  return {
+    useNavigationState: jest.fn(() => ({
+      origin: mockOrigin,
+      args: {
+        paymentRequest,
+      },
+    })),
+  };
+});
 
 describe("ConfirmPayment", () => {
   test("render", async () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <ConfirmPayment {...props} />
+          <ConfirmPayment />
         </MemoryRouter>
       );
     });
@@ -66,7 +74,7 @@ describe("ConfirmPayment", () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <ConfirmPayment {...props} />
+          <ConfirmPayment />
         </MemoryRouter>
       );
     });

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -5,7 +5,7 @@ import PaymentSummary from "@components/PaymentSummary";
 import PublisherCard from "@components/PublisherCard";
 import SuccessMessage from "@components/SuccessMessage";
 import lightningPayReq from "bolt11";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -33,13 +33,13 @@ function ConfirmPayment(props: Props) {
 
   const navState = useNavigationState();
   const paymentRequest = navState.args?.paymentRequest as string;
+  const invoice = lightningPayReq.decode(paymentRequest);
 
   const navigate = useNavigate();
   const auth = useAccount();
 
-  const invoiceRef = useRef(lightningPayReq.decode(paymentRequest));
   const [budget, setBudget] = useState(
-    ((invoiceRef.current?.satoshis || 0) * 10).toString()
+    ((invoice.satoshis || 0) * 10).toString()
   );
   const [fiatAmount, setFiatAmount] = useState("");
 
@@ -112,8 +112,8 @@ function ConfirmPayment(props: Props) {
             <div className="my-4">
               <div className="mb-4 p-4 shadow bg-white dark:bg-surface-02dp rounded-lg">
                 <PaymentSummary
-                  amount={invoiceRef.current?.satoshis}
-                  description={invoiceRef.current?.tagsObject.description}
+                  amount={invoice.satoshis}
+                  description={invoice.tagsObject.description}
                 />
               </div>
 

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -38,7 +38,6 @@ function ConfirmPayment(props: Props) {
   const auth = useAccount();
 
   const invoiceRef = useRef(lightningPayReq.decode(paymentRequest));
-  const paymentRequestRef = useRef(paymentRequest);
   const [budget, setBudget] = useState(
     ((invoiceRef.current?.satoshis || 0) * 10).toString()
   );
@@ -66,7 +65,7 @@ function ConfirmPayment(props: Props) {
       setLoading(true);
       const response = await utils.call(
         "sendPayment",
-        { paymentRequest: paymentRequestRef.current },
+        { paymentRequest: paymentRequest },
         { origin: navState.origin }
       );
       auth.fetchAccountInfo(); // Update balance.

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -38,7 +38,6 @@ function ConfirmPayment(props: Props) {
   const auth = useAccount();
 
   const invoiceRef = useRef(lightningPayReq.decode(paymentRequest));
-  const originRef = useRef(navState.origin);
   const paymentRequestRef = useRef(paymentRequest);
   const [budget, setBudget] = useState(
     ((invoiceRef.current?.satoshis || 0) * 10).toString()
@@ -68,7 +67,7 @@ function ConfirmPayment(props: Props) {
       const response = await utils.call(
         "sendPayment",
         { paymentRequest: paymentRequestRef.current },
-        { origin: originRef.current }
+        { origin: navState.origin }
       );
       auth.fetchAccountInfo(); // Update balance.
       msg.reply(response);
@@ -94,9 +93,9 @@ function ConfirmPayment(props: Props) {
     if (!budget) return;
     return msg.request("addAllowance", {
       totalBudget: parseInt(budget),
-      host: originRef.current.host,
-      name: originRef.current.name,
-      imageURL: originRef.current.icon,
+      host: navState.origin.host,
+      name: navState.origin.name,
+      imageURL: navState.origin.icon,
     });
   }
 
@@ -107,9 +106,9 @@ function ConfirmPayment(props: Props) {
         <Container isScreenView maxWidth="sm">
           <div>
             <PublisherCard
-              title={originRef.current.name}
-              image={originRef.current.icon}
-              url={originRef.current.host}
+              title={navState.origin.name}
+              image={navState.origin.icon}
+              url={navState.origin.host}
             />
             <div className="my-4">
               <div className="mb-4 p-4 shadow bg-white dark:bg-surface-02dp rounded-lg">
@@ -146,9 +145,9 @@ function ConfirmPayment(props: Props) {
       ) : (
         <Container maxWidth="sm">
           <PublisherCard
-            title={originRef.current.name}
-            image={originRef.current.icon}
-            url={originRef.current.host}
+            title={navState.origin.name}
+            image={navState.origin.icon}
+            url={navState.origin.host}
           />
           <div className="my-4">
             <SuccessMessage

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -33,6 +33,7 @@ function Send() {
     event.preventDefault();
     try {
       setLoading(true);
+
       let lnurl = lnurlLib.findLnurl(invoice);
       if (!lnurl && lnurlLib.isLightningAddress(invoice)) {
         lnurl = invoice;
@@ -40,11 +41,12 @@ function Send() {
 
       if (lnurl) {
         const lnurlDetails = await lnurlLib.getDetails(lnurl);
+        const originData = getOriginData();
 
         if (lnurlDetails.tag === "channelRequest") {
           navigate("/lnurlChannel", {
             state: {
-              origin: getOriginData(),
+              origin: originData,
               args: {
                 lnurlDetails,
               },
@@ -55,7 +57,7 @@ function Send() {
         if (lnurlDetails.tag === "login") {
           navigate("/lnurlAuth", {
             state: {
-              origin: getOriginData(),
+              origin: originData,
               args: {
                 lnurlDetails,
               },
@@ -66,7 +68,7 @@ function Send() {
         if (lnurlDetails.tag === "payRequest") {
           navigate("/lnurlPay", {
             state: {
-              origin: getOriginData(),
+              origin: originData,
               args: {
                 lnurlDetails,
               },
@@ -77,7 +79,7 @@ function Send() {
         if (lnurlDetails.tag === "withdrawRequest") {
           navigate("/lnurlWithdraw", {
             state: {
-              origin: getOriginData(),
+              origin: originData,
               args: {
                 lnurlDetails,
               },

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -88,7 +88,7 @@ function Send() {
         navigate(`/keysend?destination=${invoice}`);
       } else {
         lightningPayReq.decode(invoice); // throws if invalid.
-        navigate(`/confirmPayment?paymentRequest=${invoice}`, {
+        navigate("/confirmPayment", {
           state: {
             origin: getOriginData(),
             args: {

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -88,7 +88,14 @@ function Send() {
         navigate(`/keysend?destination=${invoice}`);
       } else {
         lightningPayReq.decode(invoice); // throws if invalid.
-        navigate(`/confirmPayment?paymentRequest=${invoice}`);
+        navigate(`/confirmPayment?paymentRequest=${invoice}`, {
+          state: {
+            origin: getOriginData(),
+            args: {
+              paymentRequest: invoice,
+            },
+          },
+        });
       }
     } catch (e) {
       if (e instanceof Error) {


### PR DESCRIPTION
### Describe the changes you have made in this PR

A follow up refactoring for Confirm Payment:
- use navState for receiving origin and paymentRequest data
- remove useRef from storing data which is already existent


### Link this PR to an issue

Follow-Up on PR https://github.com/getAlby/lightning-browser-extension/pull/1264

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)


### How has this been tested?

Making payments on Stackernews

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
