### PR TITLE
fix: success message positioning

### DIFF
--- a/src/app/components/SuccessMessage/index.tsx
+++ b/src/app/components/SuccessMessage/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 function SuccessMessage({ message, onClose }: Props) {
   return (
     <>
-      <dl className="shadow bg-white dark:bg-surface-02dp pt-4 px-4 rounded-lg mb-6 overflow-hidden">
+      <dl className="shadow bg-white dark:bg-surface-02dp my-4 p-4 s rounded-lg mb-6 overflow-hidden">
         <dt className="text-sm font-semibold text-gray-500">Success</dt>
         <dd className="text-sm mb-4 dark:text-white break-all">{message}</dd>
       </dl>

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -114,12 +114,12 @@ function LNURLAuth() {
         </>
       ) : (
         <Container isScreenView maxWidth="sm">
-          <PublisherCard
-            title={navState.origin.name}
-            image={navState.origin.icon}
-            url={details.domain}
-          />
-          <div className="my-4">
+          <div>
+            <PublisherCard
+              title={navState.origin.name}
+              image={navState.origin.icon}
+              url={details.domain}
+            />
             <SuccessMessage message={successMessage} onClose={close} />
           </div>
         </Container>


### PR DESCRIPTION
trying to fix this view
<img width="490" alt="image" src="https://user-images.githubusercontent.com/318/186382068-03a73847-5c9c-40b9-9ed3-3cb53c66d9d2.png">


I guess something like that also needs to be updated on the other views. maybe @im-adithya you can have a look a this?