### PR TITLE
Fix/770 show relevant/correct auth-data in auth-notfications

### DIFF
--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import Button from "../Button";
 
 type Props = {
-  title: string;
+  title: string | React.ReactNode;
   description?: string | React.ReactNode;
   submitLabel?: string;
   submitLoading?: boolean;
@@ -31,10 +31,10 @@ function ConnectorForm({
       <div className="relative lg:flex mt-14 bg-white dark:bg-surface-02dp px-10 py-12">
         <div className="lg:w-1/2">
           {typeof title === "string" ? (
-                <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
-              ) : (
-                title
-              )}
+            <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
+          ) : (
+            title
+          )}
           {description && (
             <div className="mb-6 text-gray-500 dark:text-neutral-400">
               {typeof description === "string" ? (

--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -30,7 +30,11 @@ function ConnectorForm({
     <form onSubmit={onSubmit}>
       <div className="relative lg:flex mt-14 bg-white dark:bg-surface-02dp px-10 py-12">
         <div className="lg:w-1/2">
-          <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
+          {typeof title === "string" ? (
+                <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
+              ) : (
+                title
+              )}
           {description && (
             <div className="mb-6 text-gray-500 dark:text-neutral-400">
               {typeof description === "string" ? (

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -175,12 +175,7 @@ function Home() {
     setLoadingInvoices(false);
   }
 
-  useEffect(() => {
-    if (!isLoadingSettings) {
-      loadPayments();
-    }
-  }, [isLoadingSettings, loadPayments]);
-
+  // Effects on Mount
   useEffect(() => {
     loadAllowance();
 
@@ -198,6 +193,12 @@ function Home() {
       browser.runtime.onMessage.removeListener(handleLightningDataMessage);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isLoadingSettings && !loadingAllowance) {
+      loadPayments();
+    }
+  }, [isLoadingSettings, loadingAllowance, loadPayments]);
 
   function renderPublisherCard() {
     let title, image;

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -98,9 +98,9 @@ function LNURLAuth() {
               )}
 
               <ContentMessage
-                heading={`${
+                heading={`Do you want to login to ${
                   origin ? origin.name : details.domain
-                } asks you to login to`}
+                }?`}
                 content={details.domain}
               />
             </div>

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -37,7 +37,7 @@ function LNURLAuth() {
         lnurlDetails: details,
       });
 
-      if (navState.isPrompt && origin.host) {
+      if (navState.isPrompt && origin?.host) {
         const allowance = await api.getAllowance(origin.host);
 
         if (allowance.lnurlAuth === false) {
@@ -120,11 +120,13 @@ function LNURLAuth() {
         </>
       ) : (
         <Container isScreenView maxWidth="sm">
-          <PublisherCard
-            title={origin.name}
-            image={origin.icon}
-            url={details.domain}
-          />
+          {origin && (
+            <PublisherCard
+              title={origin.name}
+              image={origin.icon}
+              url={details.domain}
+            />
+          )}
           <div className="my-4">
             <SuccessMessage message={successMessage} onClose={close} />
           </div>

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -20,6 +20,7 @@ function LNURLAuth() {
   const navigate = useNavigate();
 
   const navState = useNavigationState();
+
   const details = navState.args?.lnurlDetails as LNURLAuthServiceResponse;
   const origin = navState.origin as OriginData; // this action will always have an `origin` set, just the type is optional to support usage via PopUp
 
@@ -88,13 +89,18 @@ function LNURLAuth() {
         <>
           <Container isScreenView maxWidth="sm">
             <div>
-              <PublisherCard
-                title={origin.name}
-                image={origin.icon}
-                url={details.domain}
-              />
+              {origin && (
+                <PublisherCard
+                  title={origin.name}
+                  image={origin.icon}
+                  url={details.domain}
+                />
+              )}
+
               <ContentMessage
-                heading={`${origin.name} asks you to login to`}
+                heading={`${
+                  origin ? origin.name : details.domain
+                } asks you to login to`}
                 content={details.domain}
               />
             </div>

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -57,7 +57,6 @@ function Send() {
         if (lnurlDetails.tag === "login") {
           navigate("/lnurlAuth", {
             state: {
-              // origin: originData,
               args: {
                 lnurlDetails,
               },

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -57,7 +57,7 @@ function Send() {
         if (lnurlDetails.tag === "login") {
           navigate("/lnurlAuth", {
             state: {
-              origin: originData,
+              // origin: originData,
               args: {
                 lnurlDetails,
               },

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -83,7 +83,7 @@ export default function ConnectCitadel() {
 
   return (
     <ConnectorForm
-      title="Connect to your Citadel Node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://runcitadel.space/">Citadel</a></u> Node</h1>}
       description="This currently doesn't work if 2FA is enabled."
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -83,7 +83,13 @@ export default function ConnectCitadel() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://runcitadel.space/">Citadel</a></u> Node</h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline"href="https://runcitadel.space/">Citadel</a>{" "}
+          Node
+        </h1>
+      }
       description="This currently doesn't work if 2FA is enabled."
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -86,7 +86,9 @@ export default function ConnectCitadel() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline"href="https://runcitadel.space/">Citadel</a>{" "}
+          <a className="underline" href="https://runcitadel.space/">
+            Citadel
+          </a>{" "}
           Node
         </h1>
       }

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -68,7 +68,12 @@ export default function ConnectEclair() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://github.com/ACINQ/eclair">Eclair</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to{" "}
+            <a className="underline" href="https://github.com/ACINQ/eclair">Eclair</a>
+        </h1>
+      }
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -71,7 +71,9 @@ export default function ConnectEclair() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to{" "}
-            <a className="underline" href="https://github.com/ACINQ/eclair">Eclair</a>
+          <a className="underline" href="https://github.com/ACINQ/eclair">
+            Eclair
+          </a>
         </h1>
       }
       submitLoading={loading}

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -68,7 +68,7 @@ export default function ConnectEclair() {
 
   return (
     <ConnectorForm
-      title="Connect to Eclair"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://github.com/ACINQ/eclair">Eclair</a></u></h1>}
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -280,7 +280,12 @@ export default function ConnectGaloy(props: Props) {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href={website}>{label}</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to{" "}
+            <a className="underline" href={website}>{label}</a>
+        </h1>
+      }
       submitLabel={
         smsCodeRequested || smsCode || acceptJwtDirectly || jwt
           ? "Login"

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -9,12 +9,14 @@ import utils from "~/common/lib/utils";
 export const galoyUrls = {
   "galoy-bitcoin-beach": {
     label: "Bitcoin Beach Wallet",
+    website: "https://galoy.io/bitcoin-beach-wallet/",
     url:
       process.env.BITCOIN_BEACH_GALOY_URL ||
       "https://api.mainnet.galoy.io/graphql/",
   },
   "galoy-bitcoin-jungle": {
     label: "Bitcoin Jungle Wallet",
+    website: "https://bitcoinjungle.app/",
     url:
       process.env.BITCOIN_JUNGLE_GALOY_URL ||
       "https://api.mainnet.bitcoinjungle.app/graphql",
@@ -33,7 +35,7 @@ type Props = {
 
 export default function ConnectGaloy(props: Props) {
   const { instance } = props;
-  const { url, label } = galoyUrls[instance];
+  const { url, label, website } = galoyUrls[instance];
 
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -278,7 +280,7 @@ export default function ConnectGaloy(props: Props) {
 
   return (
     <ConnectorForm
-      title={`Connect to ${label}`}
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href={website}>{label}</a></u></h1>}
       submitLabel={
         smsCodeRequested || smsCode || acceptJwtDirectly || jwt
           ? "Login"

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -283,7 +283,9 @@ export default function ConnectGaloy(props: Props) {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to{" "}
-            <a className="underline" href={website}>{label}</a>
+          <a className="underline" href={website}>
+            {label}
+          </a>
         </h1>
       }
       submitLabel={

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -81,7 +81,9 @@ export default function ConnectLnbits() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to{" "}
-            <a className="underline" href="https://lnbits.com/">LNbits</a>
+          <a className="underline" href="https://lnbits.com/">
+            LNbits
+          </a>
         </h1>
       }
       submitLoading={loading}

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -78,7 +78,7 @@ export default function ConnectLnbits() {
 
   return (
     <ConnectorForm
-      title="Connect to LNbits"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://lnbits.com/">LNbits</a></u></h1>}
       submitLoading={loading}
       submitDisabled={formData.adminkey === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -78,7 +78,12 @@ export default function ConnectLnbits() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://lnbits.com/">LNbits</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to{" "}
+            <a className="underline" href="https://lnbits.com/">LNbits</a>
+        </h1>
+      }
       submitLoading={loading}
       submitDisabled={formData.adminkey === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -91,7 +91,7 @@ export default function ConnectMyNode() {
 
   return (
     <ConnectorForm
-      title="Connect to your myNode"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://mynodebtc.com/">myNode</a></u></h1>}
       description={
         <p>
           On your myNode homepage click on the <strong>Wallet</strong> button

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -94,7 +94,9 @@ export default function ConnectMyNode() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline" href="https://mynodebtc.com/">myNode</a>
+          <a className="underline" href="https://mynodebtc.com/">
+            myNode
+          </a>
         </h1>
       }
       description={

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -91,7 +91,12 @@ export default function ConnectMyNode() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://mynodebtc.com/">myNode</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline" href="https://mynodebtc.com/">myNode</a>
+        </h1>
+      }
       description={
         <p>
           On your myNode homepage click on the <strong>Wallet</strong> button

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -93,7 +93,9 @@ export default function ConnectRaspiBlitz() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline" href="https://raspiblitz.org/">RaspiBlitz</a>{" "}
+          <a className="underline" href="https://raspiblitz.org/">
+            RaspiBlitz
+          </a>{" "}
           node
         </h1>
       }

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -90,8 +90,13 @@ export default function ConnectRaspiBlitz() {
 
   return (
     <ConnectorForm
-      title="Connect to your RaspiBlitz node"
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://raspiblitz.org/">RaspiBlitz</a></u> node</h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline" href="https://raspiblitz.org/">RaspiBlitz</a>{" "}
+          node
+        </h1>
+      }
       description={
         <p>
           You need your node onion address, port, and a macaroon with read and

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -91,6 +91,7 @@ export default function ConnectRaspiBlitz() {
   return (
     <ConnectorForm
       title="Connect to your RaspiBlitz node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://raspiblitz.org/">RaspiBlitz</a></u> node</h1>}
       description={
         <p>
           You need your node onion address, port, and a macaroon with read and

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -91,7 +91,9 @@ export default function ConnectStart9() {
 
   return (
     <ConnectorForm
-      title="Connect to your Embassy node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">
+        Connect to your <a className="underline" href="https://start9.com/latest/">Embassy</a> Node
+        </h1>}
       description={
         <p>
           <strong>Note</strong>: Currently we only support LND but we will be

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -91,9 +91,15 @@ export default function ConnectStart9() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">
-        Connect to your <a className="underline" href="https://start9.com/latest/">Embassy</a> Node
-        </h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+          <a className="underline" href="https://start9.com/latest/">
+            Embassy
+          </a>{" "}
+          Node
+        </h1>
+      }
       description={
         <p>
           <strong>Note</strong>: Currently we only support LND but we will be

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -91,10 +91,10 @@ export default function ConnectUmbrel() {
 
   return (
     <ConnectorForm
-      title="Connect to your Umbrel node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://umbrel.com/">Umbrel</a></u> node</h1>}
       description={
         <p>
-          In your Umbrel dashboard go to <strong>Connect Wallet</strong>.<br />
+          In your <u><a href="https://umbrel.com/">Umbrel</a></u> dashboard go to <strong>Connect Wallet</strong>.<br />
           Select <strong>lndconnect REST</strong> and copy the{" "}
           <strong>lndconnect URL</strong>. (Depending on your setup you can
           either use the <em>local</em> connection or the <em>Tor</em>{" "}

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -91,10 +91,16 @@ export default function ConnectUmbrel() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://umbrel.com/">Umbrel</a></u> node</h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline" href="https://umbrel.com/">Umbrel</a>{" "}
+          node
+        </h1>
+      }
       description={
         <p>
-          In your <u><a href="https://umbrel.com/">Umbrel</a></u> dashboard go to <strong>Connect Wallet</strong>.<br />
+          In your Umbrel dashboard go to <strong>Connect Wallet</strong>.<br />
           Select <strong>lndconnect REST</strong> and copy the{" "}
           <strong>lndconnect URL</strong>. (Depending on your setup you can
           either use the <em>local</em> connection or the <em>Tor</em>{" "}

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -94,7 +94,9 @@ export default function ConnectUmbrel() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline" href="https://umbrel.com/">Umbrel</a>{" "}
+          <a className="underline" href="https://umbrel.com/">
+            Umbrel
+          </a>{" "}
           node
         </h1>
       }

--- a/src/extension/background-script/actions/lnurl/auth.ts
+++ b/src/extension/background-script/actions/lnurl/auth.ts
@@ -104,6 +104,7 @@ export async function authFunction({
         success: true,
         status: authResponse.data.status,
         reason: authResponse.data.reason,
+        authResponseData: authResponse.data,
       };
 
       return response;

--- a/src/extension/background-script/actions/lnurl/auth.ts
+++ b/src/extension/background-script/actions/lnurl/auth.ts
@@ -11,6 +11,7 @@ import {
   LNURLDetails,
   LnurlAuthResponse,
   OriginData,
+  AuthResponseObject,
 } from "~/types";
 
 const LNURLAUTH_CANONICAL_PHRASE =
@@ -26,7 +27,7 @@ export async function authFunction({
   origin,
 }: {
   lnurlDetails: LNURLDetails;
-  origin: OriginData;
+  origin?: OriginData;
 }) {
   if (lnurlDetails.tag !== "login")
     throw new Error(
@@ -83,7 +84,7 @@ export async function authFunction({
   loginURL.searchParams.set("t", Date.now().toString());
 
   try {
-    const authResponse = await axios.get<{ status: string; reason?: string }>(
+    const authResponse = await axios.get<AuthResponseObject>(
       loginURL.toString()
     );
 

--- a/src/extension/background-script/actions/lnurl/auth.ts
+++ b/src/extension/background-script/actions/lnurl/auth.ts
@@ -114,7 +114,7 @@ export async function authFunction({
       const error =
         (e.response?.data as { reason?: string })?.reason || e.message; // lnurl error or exception message
 
-      PubSub.publish(`lnurl.auth.failed`, {
+      PubSub.publish("lnurl.auth.failed", {
         error,
         lnurlDetails,
         origin,
@@ -122,7 +122,7 @@ export async function authFunction({
 
       throw new Error(error);
     } else if (e instanceof Error) {
-      PubSub.publish(`lnurl.auth.failed`, {
+      PubSub.publish("lnurl.auth.failed", {
         error: e.message,
         lnurlDetails,
         origin,

--- a/src/extension/background-script/events/__test__/notifications.test.ts
+++ b/src/extension/background-script/events/__test__/notifications.test.ts
@@ -1,9 +1,16 @@
 import utils from "~/common/lib/utils";
-import type { PaymentNotificationData } from "~/types";
+import type { PaymentNotificationData, AuthNotificationData } from "~/types";
 
-import { paymentSuccessNotification } from "../notifications";
+import {
+  paymentSuccessNotification,
+  lnurlAuthSuccessNotification,
+} from "../notifications";
 
 describe("Payment notifications", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const data: PaymentNotificationData = {
     response: {
       data: {
@@ -88,8 +95,8 @@ describe("Payment notifications", () => {
     paymentSuccessNotification("ln.sendPayment.success", data);
 
     expect(notifySpy).toHaveBeenCalledWith({
-      message: "Fee: 0 sats",
       title: "✅ Successfully paid 1 sat to »escapedcat@getalby.com«",
+      message: "Fee: 0 sats",
     });
   });
 
@@ -100,8 +107,63 @@ describe("Payment notifications", () => {
     paymentSuccessNotification("ln.sendPayment.success", dataWitouthOrigin);
 
     expect(notifySpy).toHaveBeenCalledWith({
-      message: "Fee: 0 sats",
       title: "✅ Successfully paid 1 sat",
+      message: "Fee: 0 sats",
+    });
+  });
+});
+
+describe("Auth notifications", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const data: AuthNotificationData = {
+    authResponse: {
+      status: "OK",
+    },
+    lnurlDetails: {
+      tag: "login",
+      k1: "42033a863825a495feed197ae2c9c3777b771695e7f2251983b323e5354246d6",
+      domain: "lnurl.fiatjaf.com",
+      url: "https://lnurl.fiatjaf.com/lnurl-login?tag=login&k1=42033a863825a495feed197ae2c9c3777b771695e7f2251983b323e5354246d6",
+    },
+  };
+
+  test("success via login from popup", async () => {
+    const notifySpy = jest.spyOn(utils, "notify");
+    lnurlAuthSuccessNotification("lnurl.auth.success", data);
+
+    expect(notifySpy).toHaveBeenCalledWith({
+      title: "✅ Login",
+      message: "Successfully logged in to lnurl.fiatjaf.com",
+    });
+  });
+
+  test("success via login from prompt with origin", async () => {
+    const notifySpy = jest.spyOn(utils, "notify");
+    lnurlAuthSuccessNotification("lnurl.auth.success", {
+      ...data,
+      origin: {
+        location: "https://lnurl.fiatjaf.com/",
+        domain: "https://lnurl.fiatjaf.com",
+        host: "lnurl.fiatjaf.com",
+        pathname: "/",
+        name: "lnurl fiatjaf",
+        description: "",
+        icon: "",
+        metaData: {
+          title: "lnurl playground",
+          url: "https://lnurl.fiatjaf.com/",
+          provider: "lnurl fiatjaf",
+        },
+        external: true,
+      },
+    });
+
+    expect(notifySpy).toHaveBeenCalledWith({
+      title: "✅ Login to lnurl fiatjaf",
+      message: "Successfully logged in to lnurl.fiatjaf.com",
     });
   });
 });

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -1,5 +1,5 @@
 import utils from "~/common/lib/utils";
-import type { PaymentNotificationData } from "~/types";
+import type { PaymentNotificationData, AuthNotificationData } from "~/types";
 
 const paymentSuccessNotification = (
   message: "ln.sendPayment.success",
@@ -57,9 +57,20 @@ const paymentFailedNotification = (
   });
 };
 
-const lnurlAuthSuccessNotification = (message: FixMe, data: FixMe) => {
+const lnurlAuthSuccessNotification = (
+  message: "lnurl.auth.success",
+  data: AuthNotificationData
+) => {
+  // console.log("lnurlAuthSuccessNotification", message, data);
+
+  let title = "✅ Login";
+
+  if (data?.origin?.name) {
+    title = `${title} to ${data.origin.name}`;
+  }
+
   return utils.notify({
-    title: `✅ Login to ${data.origin.name}`,
+    title,
     message: `Successfully logged into ${data.lnurlDetails.domain}`,
   });
 };

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -61,8 +61,6 @@ const lnurlAuthSuccessNotification = (
   message: "lnurl.auth.success",
   data: AuthNotificationData
 ) => {
-  // console.log("lnurlAuthSuccessNotification", message, data);
-
   let title = "✅ Login";
 
   if (data?.origin?.name) {

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -75,7 +75,12 @@ const lnurlAuthSuccessNotification = (
   });
 };
 
-const lnurlAuthFailedNotification = (message: FixMe, data: FixMe) => {
+const lnurlAuthFailedNotification = (
+  message: "lnurl.auth.failed",
+  data: {
+    error: string;
+  }
+) => {
   return utils.notify({
     title: `⚠️ Login failed`,
     message: `${data.error}`,

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -71,7 +71,7 @@ const lnurlAuthSuccessNotification = (
 
   return utils.notify({
     title,
-    message: `Successfully logged into ${data.lnurlDetails.domain}`,
+    message: `Successfully logged in to ${data.lnurlDetails.domain}`,
   });
 };
 

--- a/src/extension/inpage-script/index.js
+++ b/src/extension/inpage-script/index.js
@@ -6,7 +6,7 @@ if (document) {
   window.webln = new WebLNProvider();
 
   const readyEvent = new Event("webln:ready");
-  document.dispatchEvent(readyEvent);
+  window.dispatchEvent(readyEvent);
 
   // Intercept any `lightning:` requests
   window.addEventListener("click", (ev) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,12 +68,8 @@ export interface PaymentNotificationData {
 }
 
 export interface AuthResponseObject {
-  status: string;
   reason?: string;
-  data: {
-    status: string;
-  };
-  statusText: string;
+  status: string;
 }
 export interface AuthNotificationData {
   authResponse?: AuthResponseObject;

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,7 +287,7 @@ export interface MessageConnectPeer extends MessageDefault {
 
 export interface MessageLnurlAuth {
   args: {
-    origin?: OriginData;
+    origin?: OriginData; // only set if troggered via Prompt
     lnurlDetails: {
       tag: "login";
       k1: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,7 @@ export type LnurlAuthResponse = {
   success: boolean;
   status: string;
   reason?: string;
+  authResponseData: unknown;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,20 @@ export interface PaymentNotificationData {
   };
 }
 
+export interface AuthResponseObject {
+  status: string;
+  reason?: string;
+  data: {
+    status: string;
+  };
+  statusText: string;
+}
+export interface AuthNotificationData {
+  authResponse?: AuthResponseObject;
+  origin?: OriginData;
+  lnurlDetails: LNURLAuthServiceResponse;
+}
+
 export interface OriginDataInternal {
   internal: boolean;
 }
@@ -277,7 +291,7 @@ export interface MessageConnectPeer extends MessageDefault {
 
 export interface MessageLnurlAuth {
   args: {
-    origin: OriginData;
+    origin?: OriginData;
     lnurlDetails: {
       tag: "login";
       k1: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,8 +72,8 @@ export interface AuthResponseObject {
   status: string;
 }
 export interface AuthNotificationData {
-  authResponse?: AuthResponseObject;
-  origin?: OriginData;
+  authResponse: AuthResponseObject;
+  origin?: OriginData; // only set if troggered via Prompt
   lnurlDetails: LNURLAuthServiceResponse;
 }
 

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -119,6 +119,79 @@ test.describe("Create or connect wallets", () => {
     await browser.close();
   });
 
+  test("create invoice", async () => {
+    const { page, browser, extensionId } = await loadExtension();
+    await page.waitForTimeout(1000);
+
+    const optionsPage = `chrome-extension://${extensionId}/options.html`;
+    await page.goto(optionsPage);
+    await page.waitForTimeout(1000);
+
+    const $optionsdocument = await getDocument(page);
+    const passwordField = await getByPlaceholderText(
+      $optionsdocument,
+      "Password"
+    );
+    await passwordField.type(user.password);
+
+    const unlockButton = await findByText($optionsdocument, "Unlock");
+    unlockButton.click();
+
+    // create invoice
+    await (await findByText($optionsdocument, "Receive")).click();
+
+    const amountField = await getByLabelText($optionsdocument, "Amount");
+    await amountField.type("888");
+
+    const descriptionField = await getByLabelText(
+      $optionsdocument,
+      "Description"
+    );
+    await descriptionField.type("It is a lucky number");
+
+    await (await getByText($optionsdocument, "Create Invoice")).click();
+    await page.waitForTimeout(2000);
+    // copy invoice
+    await (await findByText($optionsdocument, "Copy")).click();
+
+    await browser.close();
+  });
+
+  test("send to a LN-adddress", async () => {
+    const { page, browser, extensionId } = await loadExtension();
+    await page.waitForTimeout(1000);
+
+    const optionsPage = `chrome-extension://${extensionId}/options.html`;
+    await page.goto(optionsPage);
+    await page.waitForTimeout(1000);
+
+    const $optionsdocument = await getDocument(page);
+    const passwordField = await getByPlaceholderText(
+      $optionsdocument,
+      "Password"
+    );
+    await passwordField.type(user.password);
+
+    const unlockButton = await findByText($optionsdocument, "Unlock");
+    unlockButton.click();
+
+    // go to send
+    await page.waitForTimeout(1000);
+    await (await getByText($optionsdocument, "Send")).click();
+    const invoiceInput = await findByText(
+      $optionsdocument,
+      "Invoice, Lightning Address or LNURL"
+    );
+    await invoiceInput.type("bumi@getalby.com");
+    await (await getByText($optionsdocument, "Continue")).click();
+    await page.waitForTimeout(2000);
+
+    await findByText($optionsdocument, "bumi@getalby.com");
+    await findByText($optionsdocument, "Sats for bumi");
+
+    await browser.close();
+  });
+
   test("successfully connects to LNBits wallet", async () => {
     const { browser, page, $document } = await commonCreateWalletUserCreate();
 

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -126,7 +126,7 @@ test.describe("Create or connect wallets", () => {
     const createNewWalletButton = await getByText($document, "LNbits");
     createNewWalletButton.click();
 
-    await findByText($document, "Connect to LNbits");
+    await findByText($document, /Connect to LNbits/);
 
     const lnBitsAdminKey = "d8de4f373561446aa298cae2b9424325";
     const adminKeyField = await getByLabelText($document, "LNbits Admin Key");

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -255,7 +255,7 @@ test.describe("Create or connect wallets", () => {
       "config=https://gist.githubusercontent.com/bumi/71885ed90617b3ba2dd485ecfb7829eb/raw/26a91185ee273df4eaa75f6ec406001ab4a5d2cf/mock-btcpay-lnd.json"
     );
 
-    await page.waitForTimeout(1000);
+    await new Promise((r) => setTimeout(r, 1000));
     await commonCreateWalletSuccessCheck({ page, $document });
     await browser.close();
   });

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -4,13 +4,7 @@ import { getDocument, queries } from "pptr-testing-library";
 
 import { loadExtension } from "./helpers/loadExtension";
 
-const {
-  getByText,
-  getByLabelText,
-  findByLabelText,
-  findByText,
-  getByPlaceholderText,
-} = queries;
+const { getByText, getByLabelText, findByLabelText, findByText } = queries;
 
 const user = USER.SINGLE();
 
@@ -35,13 +29,13 @@ const commonCreateWalletUserCreate = async () => {
     $document,
     "Choose an unlock password:"
   );
-  await passwordField.type(user.password);
+  await passwordField.type("unlock-password");
 
   const passwordConfirmationField = await getByLabelText(
     $document,
     "Let's confirm you typed it correct:"
   );
-  await passwordConfirmationField.type(user.password);
+  await passwordConfirmationField.type("unlock-password");
 
   // submit password form
   const passwordFormNextButton = await findByText($document, "Next");
@@ -90,104 +84,6 @@ test.describe("Create or connect wallets", () => {
     await walletPasswordField.type(user.password);
 
     await commonCreateWalletSuccessCheck({ page, $document });
-
-    await browser.close();
-  });
-
-  test("opens publishers screen", async () => {
-    const { page, browser, extensionId } = await loadExtension();
-    await page.waitForTimeout(1000);
-
-    const optionsPage = `chrome-extension://${extensionId}/options.html`;
-    await page.goto(optionsPage);
-    await page.waitForTimeout(1000);
-
-    const $optionsdocument = await getDocument(page);
-    const passwordField = await getByPlaceholderText(
-      $optionsdocument,
-      "Password"
-    );
-    await passwordField.type(user.password);
-
-    const unlockButton = await findByText($optionsdocument, "Unlock");
-    unlockButton.click();
-
-    await findByText($optionsdocument, "Your ⚡️ Websites");
-    await findByText($optionsdocument, "Other ⚡️ Websites");
-
-    await page.waitForTimeout(2000);
-    await browser.close();
-  });
-
-  test("create invoice", async () => {
-    const { page, browser, extensionId } = await loadExtension();
-    await page.waitForTimeout(1000);
-
-    const optionsPage = `chrome-extension://${extensionId}/options.html`;
-    await page.goto(optionsPage);
-    await page.waitForTimeout(1000);
-
-    const $optionsdocument = await getDocument(page);
-    const passwordField = await getByPlaceholderText(
-      $optionsdocument,
-      "Password"
-    );
-    await passwordField.type(user.password);
-
-    const unlockButton = await findByText($optionsdocument, "Unlock");
-    unlockButton.click();
-
-    // create invoice
-    await (await findByText($optionsdocument, "Receive")).click();
-
-    const amountField = await getByLabelText($optionsdocument, "Amount");
-    await amountField.type("888");
-
-    const descriptionField = await getByLabelText(
-      $optionsdocument,
-      "Description"
-    );
-    await descriptionField.type("It is a lucky number");
-
-    await (await getByText($optionsdocument, "Create Invoice")).click();
-    await page.waitForTimeout(2000);
-    // copy invoice
-    await (await findByText($optionsdocument, "Copy")).click();
-
-    await browser.close();
-  });
-
-  test("send to a LN-adddress", async () => {
-    const { page, browser, extensionId } = await loadExtension();
-    await page.waitForTimeout(1000);
-
-    const optionsPage = `chrome-extension://${extensionId}/options.html`;
-    await page.goto(optionsPage);
-    await page.waitForTimeout(1000);
-
-    const $optionsdocument = await getDocument(page);
-    const passwordField = await getByPlaceholderText(
-      $optionsdocument,
-      "Password"
-    );
-    await passwordField.type(user.password);
-
-    const unlockButton = await findByText($optionsdocument, "Unlock");
-    unlockButton.click();
-
-    // go to send
-    await page.waitForTimeout(1000);
-    await (await getByText($optionsdocument, "Send")).click();
-    const invoiceInput = await findByText(
-      $optionsdocument,
-      "Invoice, Lightning Address or LNURL"
-    );
-    await invoiceInput.type("bumi@getalby.com");
-    await (await getByText($optionsdocument, "Continue")).click();
-    await page.waitForTimeout(2000);
-
-    await findByText($optionsdocument, "bumi@getalby.com");
-    await findByText($optionsdocument, "Sats for bumi");
 
     await browser.close();
   });

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -126,10 +126,8 @@ test.describe("Create or connect wallets", () => {
     const createNewWalletButton = await getByText($document, "LNbits");
     createNewWalletButton.click();
 
-    await findByText($document, /Connect to LNbits/);
-
     const lnBitsAdminKey = "d8de4f373561446aa298cae2b9424325";
-    const adminKeyField = await getByLabelText($document, "LNbits Admin Key");
+    const adminKeyField = await findByLabelText($document, "LNbits Admin Key");
     await adminKeyField.type(lnBitsAdminKey);
 
     await commonCreateWalletSuccessCheck({ page, $document });

--- a/tests/e2e/walletFeatures.spec.ts
+++ b/tests/e2e/walletFeatures.spec.ts
@@ -5,24 +5,30 @@ import { loadExtension } from "./helpers/loadExtension";
 
 const { getByText, getByLabelText, findByText, getByPlaceholderText } = queries;
 
+const unlockExtension = async ({ page, extensionId }) => {
+  await page.waitForTimeout(1000);
+
+  const optionsPage = `chrome-extension://${extensionId}/options.html`;
+  await page.goto(optionsPage);
+  await page.waitForTimeout(1000);
+
+  const $optionsdocument = await getDocument(page);
+  const passwordField = await getByPlaceholderText(
+    $optionsdocument,
+    "Password"
+  );
+  await passwordField.type("unlock-password");
+
+  const unlockButton = await findByText($optionsdocument, "Unlock");
+  unlockButton.click();
+
+  return $optionsdocument;
+};
+
 test.describe("Wallet features", () => {
   test("opens publishers screen", async () => {
     const { page, browser, extensionId } = await loadExtension();
-    await page.waitForTimeout(1000);
-
-    const optionsPage = `chrome-extension://${extensionId}/options.html`;
-    await page.goto(optionsPage);
-    await page.waitForTimeout(1000);
-
-    const $optionsdocument = await getDocument(page);
-    const passwordField = await getByPlaceholderText(
-      $optionsdocument,
-      "Password"
-    );
-    await passwordField.type("unlock-password");
-
-    const unlockButton = await findByText($optionsdocument, "Unlock");
-    unlockButton.click();
+    const $optionsdocument = await unlockExtension({ page, extensionId });
 
     await findByText($optionsdocument, "Your ⚡️ Websites");
     await findByText($optionsdocument, "Other ⚡️ Websites");
@@ -33,21 +39,7 @@ test.describe("Wallet features", () => {
 
   test("create invoice", async () => {
     const { page, browser, extensionId } = await loadExtension();
-    await page.waitForTimeout(1000);
-
-    const optionsPage = `chrome-extension://${extensionId}/options.html`;
-    await page.goto(optionsPage);
-    await page.waitForTimeout(1000);
-
-    const $optionsdocument = await getDocument(page);
-    const passwordField = await getByPlaceholderText(
-      $optionsdocument,
-      "Password"
-    );
-    await passwordField.type("unlock-password");
-
-    const unlockButton = await findByText($optionsdocument, "Unlock");
-    unlockButton.click();
+    const $optionsdocument = await unlockExtension({ page, extensionId });
 
     // create invoice
     await (await findByText($optionsdocument, "Receive")).click();

--- a/tests/e2e/walletFeatures.spec.ts
+++ b/tests/e2e/walletFeatures.spec.ts
@@ -1,0 +1,106 @@
+import { test } from "@playwright/test";
+import { getDocument, queries } from "pptr-testing-library";
+
+import { loadExtension } from "./helpers/loadExtension";
+
+const { getByText, getByLabelText, findByText, getByPlaceholderText } = queries;
+
+test.describe("Wallet features", () => {
+  test("opens publishers screen", async () => {
+    const { page, browser, extensionId } = await loadExtension();
+    await page.waitForTimeout(1000);
+
+    const optionsPage = `chrome-extension://${extensionId}/options.html`;
+    await page.goto(optionsPage);
+    await page.waitForTimeout(1000);
+
+    const $optionsdocument = await getDocument(page);
+    const passwordField = await getByPlaceholderText(
+      $optionsdocument,
+      "Password"
+    );
+    await passwordField.type("unlock-password");
+
+    const unlockButton = await findByText($optionsdocument, "Unlock");
+    unlockButton.click();
+
+    await findByText($optionsdocument, "Your ⚡️ Websites");
+    await findByText($optionsdocument, "Other ⚡️ Websites");
+
+    await page.waitForTimeout(2000);
+    await browser.close();
+  });
+
+  test("create invoice", async () => {
+    const { page, browser, extensionId } = await loadExtension();
+    await page.waitForTimeout(1000);
+
+    const optionsPage = `chrome-extension://${extensionId}/options.html`;
+    await page.goto(optionsPage);
+    await page.waitForTimeout(1000);
+
+    const $optionsdocument = await getDocument(page);
+    const passwordField = await getByPlaceholderText(
+      $optionsdocument,
+      "Password"
+    );
+    await passwordField.type("unlock-password");
+
+    const unlockButton = await findByText($optionsdocument, "Unlock");
+    unlockButton.click();
+
+    // create invoice
+    await (await findByText($optionsdocument, "Receive")).click();
+
+    const amountField = await getByLabelText($optionsdocument, "Amount");
+    await amountField.type("888");
+
+    const descriptionField = await getByLabelText(
+      $optionsdocument,
+      "Description"
+    );
+    await descriptionField.type("It is a lucky number");
+
+    await (await getByText($optionsdocument, "Create Invoice")).click();
+    await page.waitForTimeout(2000);
+    // copy invoice
+    await (await findByText($optionsdocument, "Copy")).click();
+
+    await browser.close();
+  });
+
+  test("send to a LN-adddress", async () => {
+    const { page, browser, extensionId } = await loadExtension();
+    await page.waitForTimeout(1000);
+
+    const optionsPage = `chrome-extension://${extensionId}/options.html`;
+    await page.goto(optionsPage);
+    await page.waitForTimeout(1000);
+
+    const $optionsdocument = await getDocument(page);
+    const passwordField = await getByPlaceholderText(
+      $optionsdocument,
+      "Password"
+    );
+    await passwordField.type("unlock-password");
+
+    const unlockButton = await findByText($optionsdocument, "Unlock");
+    unlockButton.click();
+
+    // go to send
+    await page.waitForTimeout(1000);
+    await (await getByText($optionsdocument, "Send")).click();
+    const invoiceInput = await findByText(
+      $optionsdocument,
+      "Invoice, Lightning Address or LNURL"
+    );
+    await invoiceInput.type("bumi@getalby.com");
+    await (await getByText($optionsdocument, "Continue")).click();
+    await page.waitForTimeout(2000);
+
+    await findByText($optionsdocument, "bumi@getalby.com");
+    await findByText($optionsdocument, "Sats for bumi");
+
+    await browser.close();
+  });
+});

--- a/tests/e2e/walletFeatures.spec.ts
+++ b/tests/e2e/walletFeatures.spec.ts
@@ -33,7 +33,6 @@ test.describe("Wallet features", () => {
     await findByText($optionsdocument, "Your ⚡️ Websites");
     await findByText($optionsdocument, "Other ⚡️ Websites");
 
-    await page.waitForTimeout(2000);
     await browser.close();
   });
 
@@ -54,7 +53,7 @@ test.describe("Wallet features", () => {
     await descriptionField.type("It is a lucky number");
 
     await (await getByText($optionsdocument, "Create Invoice")).click();
-    await page.waitForTimeout(2000);
+    page.waitForSelector("button");
     // copy invoice
     await (await findByText($optionsdocument, "Copy")).click();
 
@@ -63,11 +62,11 @@ test.describe("Wallet features", () => {
 
   test("send to a LN-adddress", async () => {
     const { page, browser, extensionId } = await loadExtension();
-    await page.waitForTimeout(1000);
+    await new Promise((r) => setTimeout(r, 1000));
 
     const optionsPage = `chrome-extension://${extensionId}/options.html`;
     await page.goto(optionsPage);
-    await page.waitForTimeout(1000);
+    await new Promise((r) => setTimeout(r, 1000));
 
     const $optionsdocument = await getDocument(page);
     const passwordField = await getByPlaceholderText(
@@ -78,9 +77,9 @@ test.describe("Wallet features", () => {
 
     const unlockButton = await findByText($optionsdocument, "Unlock");
     unlockButton.click();
+    await new Promise((r) => setTimeout(r, 1000));
 
     // go to send
-    await page.waitForTimeout(1000);
     await (await getByText($optionsdocument, "Send")).click();
     const invoiceInput = await findByText(
       $optionsdocument,
@@ -88,8 +87,8 @@ test.describe("Wallet features", () => {
     );
     await invoiceInput.type("bumi@getalby.com");
     await (await getByText($optionsdocument, "Continue")).click();
-    await page.waitForTimeout(2000);
 
+    page.waitForSelector("label");
     await findByText($optionsdocument, "bumi@getalby.com");
     await findByText($optionsdocument, "Sats for bumi");
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

- Handle empty origin for auth-notifications

### Link this PR to an issue

#770

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)

- Login via `Send` without `Origin`
  ![image](https://user-images.githubusercontent.com/1016218/186820872-557da096-4f5b-4b5a-bdbb-e4b8b3cf79f8.png)
- Login via `Prompt` with `Origin`
  ![image](https://user-images.githubusercontent.com/1016218/186820942-b3dd4f94-6042-4ff9-8cd0-5cce79bc005e.png)


### How has this been tested?

Manually and added a basic unit-test

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
