### PR TITLE
adding website-links to connectors

### DIFF
--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import Button from "../Button";
 
 type Props = {
-  title: string;
+  title: string | React.ReactNode;
   description?: string | React.ReactNode;
   submitLabel?: string;
   submitLoading?: boolean;
@@ -31,10 +31,10 @@ function ConnectorForm({
       <div className="relative lg:flex mt-14 bg-white dark:bg-surface-02dp px-10 py-12">
         <div className="lg:w-1/2">
           {typeof title === "string" ? (
-                <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
-              ) : (
-                title
-              )}
+            <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
+          ) : (
+            title
+          )}
           {description && (
             <div className="mb-6 text-gray-500 dark:text-neutral-400">
               {typeof description === "string" ? (

--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -30,7 +30,11 @@ function ConnectorForm({
     <form onSubmit={onSubmit}>
       <div className="relative lg:flex mt-14 bg-white dark:bg-surface-02dp px-10 py-12">
         <div className="lg:w-1/2">
-          <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
+          {typeof title === "string" ? (
+                <h1 className="mb-6 text-2xl font-bold dark:text-white">{title}</h1>
+              ) : (
+                title
+              )}
           {description && (
             <div className="mb-6 text-gray-500 dark:text-neutral-400">
               {typeof description === "string" ? (

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -83,7 +83,7 @@ export default function ConnectCitadel() {
 
   return (
     <ConnectorForm
-      title="Connect to your Citadel Node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://runcitadel.space/">Citadel</a></u> Node</h1>}
       description="This currently doesn't work if 2FA is enabled."
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -83,7 +83,13 @@ export default function ConnectCitadel() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://runcitadel.space/">Citadel</a></u> Node</h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline"href="https://runcitadel.space/">Citadel</a>{" "}
+          Node
+        </h1>
+      }
       description="This currently doesn't work if 2FA is enabled."
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -86,7 +86,9 @@ export default function ConnectCitadel() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline"href="https://runcitadel.space/">Citadel</a>{" "}
+          <a className="underline" href="https://runcitadel.space/">
+            Citadel
+          </a>{" "}
           Node
         </h1>
       }

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -68,7 +68,12 @@ export default function ConnectEclair() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://github.com/ACINQ/eclair">Eclair</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to{" "}
+            <a className="underline" href="https://github.com/ACINQ/eclair">Eclair</a>
+        </h1>
+      }
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -71,7 +71,9 @@ export default function ConnectEclair() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to{" "}
-            <a className="underline" href="https://github.com/ACINQ/eclair">Eclair</a>
+          <a className="underline" href="https://github.com/ACINQ/eclair">
+            Eclair
+          </a>
         </h1>
       }
       submitLoading={loading}

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -68,7 +68,7 @@ export default function ConnectEclair() {
 
   return (
     <ConnectorForm
-      title="Connect to Eclair"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://github.com/ACINQ/eclair">Eclair</a></u></h1>}
       submitLoading={loading}
       submitDisabled={formData.password === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -280,7 +280,12 @@ export default function ConnectGaloy(props: Props) {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href={website}>{label}</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to{" "}
+            <a className="underline" href={website}>{label}</a>
+        </h1>
+      }
       submitLabel={
         smsCodeRequested || smsCode || acceptJwtDirectly || jwt
           ? "Login"

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -9,12 +9,14 @@ import utils from "~/common/lib/utils";
 export const galoyUrls = {
   "galoy-bitcoin-beach": {
     label: "Bitcoin Beach Wallet",
+    website: "https://galoy.io/bitcoin-beach-wallet/",
     url:
       process.env.BITCOIN_BEACH_GALOY_URL ||
       "https://api.mainnet.galoy.io/graphql/",
   },
   "galoy-bitcoin-jungle": {
     label: "Bitcoin Jungle Wallet",
+    website: "https://bitcoinjungle.app/",
     url:
       process.env.BITCOIN_JUNGLE_GALOY_URL ||
       "https://api.mainnet.bitcoinjungle.app/graphql",
@@ -33,7 +35,7 @@ type Props = {
 
 export default function ConnectGaloy(props: Props) {
   const { instance } = props;
-  const { url, label } = galoyUrls[instance];
+  const { url, label, website } = galoyUrls[instance];
 
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -278,7 +280,7 @@ export default function ConnectGaloy(props: Props) {
 
   return (
     <ConnectorForm
-      title={`Connect to ${label}`}
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href={website}>{label}</a></u></h1>}
       submitLabel={
         smsCodeRequested || smsCode || acceptJwtDirectly || jwt
           ? "Login"

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -283,7 +283,9 @@ export default function ConnectGaloy(props: Props) {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to{" "}
-            <a className="underline" href={website}>{label}</a>
+          <a className="underline" href={website}>
+            {label}
+          </a>
         </h1>
       }
       submitLabel={

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -81,7 +81,9 @@ export default function ConnectLnbits() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to{" "}
-            <a className="underline" href="https://lnbits.com/">LNbits</a>
+          <a className="underline" href="https://lnbits.com/">
+            LNbits
+          </a>
         </h1>
       }
       submitLoading={loading}

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -78,7 +78,7 @@ export default function ConnectLnbits() {
 
   return (
     <ConnectorForm
-      title="Connect to LNbits"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://lnbits.com/">LNbits</a></u></h1>}
       submitLoading={loading}
       submitDisabled={formData.adminkey === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -78,7 +78,12 @@ export default function ConnectLnbits() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to <u><a href="https://lnbits.com/">LNbits</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to{" "}
+            <a className="underline" href="https://lnbits.com/">LNbits</a>
+        </h1>
+      }
       submitLoading={loading}
       submitDisabled={formData.adminkey === "" || formData.url === ""}
       onSubmit={handleSubmit}

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -91,7 +91,7 @@ export default function ConnectMyNode() {
 
   return (
     <ConnectorForm
-      title="Connect to your myNode"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://mynodebtc.com/">myNode</a></u></h1>}
       description={
         <p>
           On your myNode homepage click on the <strong>Wallet</strong> button

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -94,7 +94,9 @@ export default function ConnectMyNode() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline" href="https://mynodebtc.com/">myNode</a>
+          <a className="underline" href="https://mynodebtc.com/">
+            myNode
+          </a>
         </h1>
       }
       description={

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -91,7 +91,12 @@ export default function ConnectMyNode() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://mynodebtc.com/">myNode</a></u></h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline" href="https://mynodebtc.com/">myNode</a>
+        </h1>
+      }
       description={
         <p>
           On your myNode homepage click on the <strong>Wallet</strong> button

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -93,7 +93,9 @@ export default function ConnectRaspiBlitz() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline" href="https://raspiblitz.org/">RaspiBlitz</a>{" "}
+          <a className="underline" href="https://raspiblitz.org/">
+            RaspiBlitz
+          </a>{" "}
           node
         </h1>
       }

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -90,8 +90,13 @@ export default function ConnectRaspiBlitz() {
 
   return (
     <ConnectorForm
-      title="Connect to your RaspiBlitz node"
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://raspiblitz.org/">RaspiBlitz</a></u> node</h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline" href="https://raspiblitz.org/">RaspiBlitz</a>{" "}
+          node
+        </h1>
+      }
       description={
         <p>
           You need your node onion address, port, and a macaroon with read and

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -91,6 +91,7 @@ export default function ConnectRaspiBlitz() {
   return (
     <ConnectorForm
       title="Connect to your RaspiBlitz node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://raspiblitz.org/">RaspiBlitz</a></u> node</h1>}
       description={
         <p>
           You need your node onion address, port, and a macaroon with read and

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -91,7 +91,9 @@ export default function ConnectStart9() {
 
   return (
     <ConnectorForm
-      title="Connect to your Embassy node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">
+        Connect to your <a className="underline" href="https://start9.com/latest/">Embassy</a> Node
+        </h1>}
       description={
         <p>
           <strong>Note</strong>: Currently we only support LND but we will be

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -91,9 +91,15 @@ export default function ConnectStart9() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">
-        Connect to your <a className="underline" href="https://start9.com/latest/">Embassy</a> Node
-        </h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+          <a className="underline" href="https://start9.com/latest/">
+            Embassy
+          </a>{" "}
+          Node
+        </h1>
+      }
       description={
         <p>
           <strong>Note</strong>: Currently we only support LND but we will be

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -91,10 +91,10 @@ export default function ConnectUmbrel() {
 
   return (
     <ConnectorForm
-      title="Connect to your Umbrel node"
+      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://umbrel.com/">Umbrel</a></u> node</h1>}
       description={
         <p>
-          In your Umbrel dashboard go to <strong>Connect Wallet</strong>.<br />
+          In your <u><a href="https://umbrel.com/">Umbrel</a></u> dashboard go to <strong>Connect Wallet</strong>.<br />
           Select <strong>lndconnect REST</strong> and copy the{" "}
           <strong>lndconnect URL</strong>. (Depending on your setup you can
           either use the <em>local</em> connection or the <em>Tor</em>{" "}

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -91,10 +91,16 @@ export default function ConnectUmbrel() {
 
   return (
     <ConnectorForm
-      title={<h1 className="mb-6 text-2xl font-bold dark:text-white">Connect to your <u><a href="https://umbrel.com/">Umbrel</a></u> node</h1>}
+      title={
+        <h1 className="mb-6 text-2xl font-bold dark:text-white">
+          Connect to your{" "}
+            <a className="underline" href="https://umbrel.com/">Umbrel</a>{" "}
+          node
+        </h1>
+      }
       description={
         <p>
-          In your <u><a href="https://umbrel.com/">Umbrel</a></u> dashboard go to <strong>Connect Wallet</strong>.<br />
+          In your Umbrel dashboard go to <strong>Connect Wallet</strong>.<br />
           Select <strong>lndconnect REST</strong> and copy the{" "}
           <strong>lndconnect URL</strong>. (Depending on your setup you can
           either use the <em>local</em> connection or the <em>Tor</em>{" "}

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -94,7 +94,9 @@ export default function ConnectUmbrel() {
       title={
         <h1 className="mb-6 text-2xl font-bold dark:text-white">
           Connect to your{" "}
-            <a className="underline" href="https://umbrel.com/">Umbrel</a>{" "}
+          <a className="underline" href="https://umbrel.com/">
+            Umbrel
+          </a>{" "}
           node
         </h1>
       }

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -126,7 +126,7 @@ test.describe("Create or connect wallets", () => {
     const createNewWalletButton = await getByText($document, "LNbits");
     createNewWalletButton.click();
 
-    await findByText($document, "Connect to LNbits");
+    await findByText($document, /Connect to LNbits/);
 
     const lnBitsAdminKey = "d8de4f373561446aa298cae2b9424325";
     const adminKeyField = await getByLabelText($document, "LNbits Admin Key");

--- a/tests/e2e/createWallets.spec.ts
+++ b/tests/e2e/createWallets.spec.ts
@@ -126,10 +126,8 @@ test.describe("Create or connect wallets", () => {
     const createNewWalletButton = await getByText($document, "LNbits");
     createNewWalletButton.click();
 
-    await findByText($document, /Connect to LNbits/);
-
     const lnBitsAdminKey = "d8de4f373561446aa298cae2b9424325";
-    const adminKeyField = await getByLabelText($document, "LNbits Admin Key");
+    const adminKeyField = await findByLabelText($document, "LNbits Admin Key");
     await adminKeyField.type(lnBitsAdminKey);
 
     await commonCreateWalletSuccessCheck({ page, $document });


### PR DESCRIPTION
Pull request for issue #1151 

This will add a hyperlink to the titles of the different Wallet Connectors. I haven't manage to add them at all connectors (such as BTCPay) because they get their title from the translation file and I couldn't figure out how to do it effectively yet. 

