### PR TITLE
fix: expose ready event on window

### DIFF
--- a/src/extension/inpage-script/index.js
+++ b/src/extension/inpage-script/index.js
@@ -6,7 +6,7 @@ if (document) {
   window.webln = new WebLNProvider();
 
   const readyEvent = new Event("webln:ready");
-  document.dispatchEvent(readyEvent);
+  window.dispatchEvent(readyEvent);
 
   // Intercept any `lightning:` requests
   window.addEventListener("click", (ev) => {


### PR DESCRIPTION
### Describe the changes you have made in this PR

All WebLN interactions are using `window`. Let's also expose the ready event on the window object for consistency (it automatically bubbles to the document so this change is fully backwards-compatible)