### PR TITLE
fix(home): wait for allowance before loading payments

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -188,12 +188,7 @@ function Home() {
     setLoadingInvoices(false);
   }
 
-  useEffect(() => {
-    if (!isLoadingSettings) {
-      loadPayments();
-    }
-  }, [isLoadingSettings, loadPayments]);
-
+  // Effects on Mount
   useEffect(() => {
     loadAllowance();
 
@@ -211,6 +206,12 @@ function Home() {
       browser.runtime.onMessage.removeListener(handleLightningDataMessage);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isLoadingSettings && !loadingAllowance) {
+      loadPayments();
+    }
+  }, [isLoadingSettings, loadingAllowance, loadPayments]);
 
   function renderPublisherCard() {
     let title, image;


### PR DESCRIPTION
### Describe the changes you have made in this PR

This PR fixes these issues:

- loadPayment was running twice on Home because the dependency `allowance`  changed too late
- All Payments were shown, because loadPayments was running too fast and loaded all payments from DB

The fix is to wait until `loadAllowance` is done and then trigger `loadPayments`.

**Please test again ! 🙏** 

### Follow-Up 👞 👟
We agreed on refactoring the whole HOME screen, which will follow in another PR. See ticket https://github.com/getAlby/lightning-browser-extension/issues/1359

### Link this PR to an issue

Resolves https://github.com/getAlby/lightning-browser-extension/issues/1350


### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)

#### FIXED THIS BUG 📛

![Bildschirmfoto 2022-08-29 um 10 32 22](https://user-images.githubusercontent.com/11243967/187393266-e1cf8d72-65f5-4fc9-9804-85b368a083b3.png)


### How has this been tested?

- Manually with doing payments on https://stacker.news and https://insatgram.getalby.com/
- Then open the extension on both websites again to check that the correct payments for each website are shown

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
