### PR TITLE
fix: success message positioning

### DIFF
--- a/src/app/components/Container.tsx
+++ b/src/app/components/Container.tsx
@@ -2,11 +2,15 @@ type MaxWidth = "sm" | "md" | "lg" | "xl" | "2xl";
 
 type Props = {
   children: React.ReactNode;
-  isScreenView?: boolean;
+  justifyBetween?: boolean;
   maxWidth?: MaxWidth;
 };
 
-function Container({ children, isScreenView = false, maxWidth = "lg" }: Props) {
+function Container({
+  children,
+  justifyBetween = false,
+  maxWidth = "lg",
+}: Props) {
   // Avoid dynamically created class strings as PurgeCSS doesn't understand this.
   const getMaxWidthClass = (maxWidth: MaxWidth) => {
     switch (maxWidth) {
@@ -26,7 +30,7 @@ function Container({ children, isScreenView = false, maxWidth = "lg" }: Props) {
   return (
     <div
       className={`container mx-auto px-4 ${getMaxWidthClass(maxWidth)} ${
-        isScreenView
+        justifyBetween
           ? "h-full flex flex-col justify-between overflow-y-auto no-scrollbar"
           : ""
       }`}

--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -121,7 +121,7 @@ function ConfirmKeysend(props: Props) {
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={t("title")} />
       {!successMessage ? (
-        <Container isScreenView maxWidth="sm">
+        <Container justifyBetween maxWidth="sm">
           <div>
             <PublisherCard
               title={origin.name}

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -102,7 +102,7 @@ function ConfirmPayment(props: Props) {
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={"Approve Payment"} />
       {!successMessage ? (
-        <Container isScreenView maxWidth="sm">
+        <Container justifyBetween maxWidth="sm">
           <div>
             <PublisherCard
               title={navState.origin.name}

--- a/src/app/screens/ConfirmSignMessage/index.tsx
+++ b/src/app/screens/ConfirmSignMessage/index.tsx
@@ -66,7 +66,7 @@ function ConfirmSignMessage(props: Props) {
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={t("title")} />
       {!successMessage ? (
-        <Container isScreenView maxWidth="sm">
+        <Container justifyBetween maxWidth="sm">
           <div>
             <PublisherCard
               title={originRef.current.name}

--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -78,7 +78,7 @@ function Enable(props: Props) {
   return (
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={"Connect"} />
-      <Container isScreenView maxWidth="sm">
+      <Container justifyBetween maxWidth="sm">
         <div>
           <PublisherCard
             title={props.origin.name}

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -86,7 +86,7 @@ function LNURLAuth() {
       <ScreenHeader title={"Authentication"} />
       {!successMessage ? (
         <>
-          <Container isScreenView maxWidth="sm">
+          <Container justifyBetween maxWidth="sm">
             <div>
               <PublisherCard
                 title={origin.name}

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -113,7 +113,7 @@ function LNURLAuth() {
           </Container>
         </>
       ) : (
-        <Container isScreenView maxWidth="sm">
+        <Container maxWidth="sm">
           <PublisherCard
             title={navState.origin.name}
             image={navState.origin.icon}

--- a/src/app/screens/LNURLChannel/index.tsx
+++ b/src/app/screens/LNURLChannel/index.tsx
@@ -93,7 +93,7 @@ function LNURLChannel() {
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={"Channel Request"} />
       {!successMessage ? (
-        <Container isScreenView maxWidth="sm">
+        <Container justifyBetween maxWidth="sm">
           <div>
             <PublisherCard
               title={navState.origin.name}

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -131,7 +131,7 @@ function LNURLWithdraw() {
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={"Withdraw"} />
       {!successMessage ? (
-        <Container isScreenView maxWidth="sm">
+        <Container justifyBetween maxWidth="sm">
           <div>
             <PublisherCard
               title={navState.origin.name}

--- a/src/app/screens/MakeInvoice.tsx
+++ b/src/app/screens/MakeInvoice.tsx
@@ -93,7 +93,7 @@ function MakeInvoice({
     <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
       <ScreenHeader title={t("title")} />
 
-      <Container isScreenView maxWidth="sm">
+      <Container justifyBetween maxWidth="sm">
         <div>
           <PublisherCard
             title={origin.name}


### PR DESCRIPTION
### Describe the changes you have made in this PR

Fixes success message positioning.
https://github.com/getAlby/lightning-browser-extension/pull/1330#discussion_r953850033: Also has been tested in other places as requested!

### Link this PR to an issue

~ #1330

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)

![Screenshot from 2022-08-31 18-46-15](https://user-images.githubusercontent.com/64399555/187687731-2d6ada1c-44d7-4bd1-b091-f301d078b443.png)

### How has this been tested?


Tested Manually


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
