### PR TITLE
case insensitive monetization and more consistent alby metatags

### DIFF
--- a/src/extension/content-script/batteries/Monetization.ts
+++ b/src/extension/content-script/batteries/Monetization.ts
@@ -22,7 +22,7 @@ const parseRecipient = (content: string): BatteryMetaTagRecipient => {
 
 const battery = (): void => {
   const monetizationTag = document.querySelector<HTMLMetaElement>(
-    'head > meta[name="lightning"]'
+    'head > meta[name="lightning" i]'
   );
   if (!monetizationTag) {
     return;

--- a/src/extension/content-script/originData.ts
+++ b/src/extension/content-script/originData.ts
@@ -79,6 +79,10 @@ const metaDataRules: Record<string, RuleSet> = {
         (element) => element.getAttribute("content"),
       ],
       [
+        'meta[name="alby:description"][content]',
+        (element) => element.getAttribute("content"),
+      ],
+      [
         'meta[property="og:description"][content]',
         (element) => element.getAttribute("content"),
       ],
@@ -195,6 +199,10 @@ const metaDataRules: Record<string, RuleSet> = {
     rules: [
       [
         'meta[property="alby:name"][content]',
+        (element) => element.getAttribute("content"),
+      ],
+      [
+        'meta[name="alby:name"][content]',
         (element) => element.getAttribute("content"),
       ],
       [


### PR DESCRIPTION
this make the check for the lightning metatag case in-sensitive. 

Checks for `name="alby:name"` and "alby:description" metatags to load the website information.
currently we only checked for `property="alby:name"` this feels a bit inconsistent because for the lightning meta tage we use the `name` attribute.

