### PR TITLE
feat(transactiontable): show payment memo as description

### DIFF
--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -85,7 +85,8 @@ export default function TransactionsTable({ transactions }: Props) {
                           </p>
                         )}
                       </div>
-                      {([tx.type && "sent", "sending"].includes(tx.type) ||
+                      {(!!tx.description ||
+                        [tx.type && "sent", "sending"].includes(tx.type) ||
                         (tx.type === "received" && tx.boostagram)) && (
                         <Disclosure.Button className="block h-0 mt-2 text-gray-500 hover:text-black dark:hover:text-white transition-color duration-200">
                           <CaretDownIcon
@@ -95,9 +96,10 @@ export default function TransactionsTable({ transactions }: Props) {
                       )}
                     </div>
                   </div>
+
                   <Disclosure.Panel>
                     <div className="mt-1 ml-9 text-xs text-gray-600 dark:text-neutral-400">
-                      <p>{tx.description}</p>
+                      {tx.description && <p>{tx.description}</p>}
                       {tx.totalFees && (
                         <p>
                           {tComponents("transactionsTable.fee")}: {tx.totalFees}{" "}

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -174,6 +174,7 @@ function Home() {
     const invoices: Transaction[] = result.invoices.map((invoice) => ({
       ...invoice,
       title: invoice.memo,
+      description: invoice.memo,
       date: dayjs(invoice.settleDate).fromNow(),
     }));
 

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -1,7 +1,6 @@
 import {
   ConnectPeerArgs,
   ConnectPeerResponse,
-  GetInvoicesResponse,
   MakeInvoiceArgs,
   MakeInvoiceResponse,
 } from "~/extension/background-script/connectors/connector.interface";
@@ -16,6 +15,7 @@ import type {
   MessageLnurlAuth,
   MessageSettingsSet,
   LnurlAuthResponse,
+  Invoice,
 } from "~/types";
 
 import {
@@ -113,7 +113,7 @@ export const unlock = (password: string) =>
 export const getBlocklist = (host: string) =>
   utils.call<BlocklistRes>("getBlocklist", { host });
 export const getInvoices = (options?: MessageInvoices["args"]) =>
-  utils.call<GetInvoicesResponse["data"]>("getInvoices", options);
+  utils.call<{ invoices: Invoice[] }>("getInvoices", options);
 export const lnurlAuth = (
   options: MessageLnurlAuth["args"]
 ): Promise<LnurlAuthResponse> =>

--- a/src/extension/background-script/actions/ln/invoices.ts
+++ b/src/extension/background-script/actions/ln/invoices.ts
@@ -6,12 +6,12 @@ const invoices = async (message: MessageInvoices) => {
   const isSettled = message.args.isSettled;
 
   const connector = await state.getState().getConnector();
-  const data = await connector.getInvoices();
+  const result = await connector.getInvoices();
 
-  if (data instanceof Error) {
-    return { error: data.message };
+  if (result instanceof Error) {
+    return { error: result.message };
   } else {
-    const invoices: Invoice[] = data.data.invoices
+    const invoices: Invoice[] = result.data.invoices
       .filter((invoice) => (isSettled ? invoice.settled : !invoice.settled))
       .map((invoice: Invoice) => {
         const boostagram = utils.getBoostagramFromInvoiceCustomRecords(


### PR DESCRIPTION
### Describe the changes you have made in this PR

Payments have `memo` instead of description.
We currently use this as title for a (payment-)transaction. But titles get cut-off if they are too long, see screenshot.
With this we make sure the full description can always be checked.

Also
- updated type
- renamed some code to make it easier to understand

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes

![image](https://user-images.githubusercontent.com/1016218/188380351-69185452-5bd1-4a9f-8a9d-9bd09dedd99d.png)

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
