### PR TITLE
Feature/better tor support

### DIFF
--- a/src/app/components/CompanionDownloadInfo.tsx
+++ b/src/app/components/CompanionDownloadInfo.tsx
@@ -1,7 +1,13 @@
 import { ReceiveIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-function CompanionDownloadInfo() {
+type Props = {
+  hasTorCallback: () => void;
+};
+
+function CompanionDownloadInfo({ hasTorCallback }: Props) {
+  const [hasTorSupport, setHasTorSupport] = useState(false);
   const { t } = useTranslation("components", {
     keyPrefix: "companionDownloadInfo",
   });
@@ -15,17 +21,38 @@ function CompanionDownloadInfo() {
 
   // TODO: check if the companion app is already installed
   return (
-    <div className="dark:text-white">
-      {t("info")}{" "}
-      <a
-        href={`https://getalby.com/install/companion/${getOS()}`}
-        target="_blank"
-        rel="noreferrer"
-      >
-        {t("download_here")}
-        <ReceiveIcon className="w-6 h-6 inline" />.
-      </a>
-    </div>
+    <>
+      {!hasTorSupport && (
+        <div className="dark:text-white">
+          <p className="mb-2">{t("info")} </p>
+          <p className="mb-2">
+            <a
+              href={`https://getalby.com/install/companion/${getOS()}`}
+              target="_blank"
+              rel="noreferrer"
+              className="font-bold"
+            >
+              {t("download_here")}
+              <ReceiveIcon className="w-6 h-6 inline" />
+            </a>
+          </p>
+          <p>
+            {t("or")}{" "}
+            <a
+              href="#"
+              className="font-bold"
+              onClick={(e) => {
+                e.preventDefault();
+                setHasTorSupport(true);
+                hasTorCallback();
+              }}
+            >
+              {t("using_tor")}
+            </a>
+          </p>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/app/components/toasts/ConnectionErrorToast.tsx
+++ b/src/app/components/toasts/ConnectionErrorToast.tsx
@@ -15,6 +15,7 @@ export default function ConnectionErrorToast({ message }: { message: string }) {
           href="https://guides.getalby.com/overall-guide/alby-browser-extension/connect-lightning-wallets-and-nodes-to-alby-extension"
           className="underline"
           target="_blank"
+          rel="noreferrer"
         >
           {t("help_link")}
         </a>

--- a/src/app/components/toasts/ConnectionErrorToast.tsx
+++ b/src/app/components/toasts/ConnectionErrorToast.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from "react-i18next";
 
-export default function ConnectionErrorToast({ message }: { message: string }) {
+export default function ConnectionErrorToast({
+  message,
+  link,
+}: {
+  message: string;
+  link?: string;
+}) {
   const { t } = useTranslation("components", {
     keyPrefix: "toasts.connection_error",
   });
@@ -8,18 +14,37 @@ export default function ConnectionErrorToast({ message }: { message: string }) {
     <>
       <p className="mb-2">
         {t("connection_failed")}
-        <br />(<span className="italic">{message}</span>)
+        <br />(<span className="italic text-sm">{message}</span>)
       </p>
-      <p>
-        <a
-          href="https://guides.getalby.com/overall-guide/alby-browser-extension/connect-lightning-wallets-and-nodes-to-alby-extension"
-          className="underline"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {t("help_link")}
-        </a>
-      </p>
+      <p className="my-2 text-sm">Here is what you can do:</p>
+      <ul className="list-disc text-sm list-inside">
+        <li>Double check your connection details</li>
+        {link && (
+          <li>
+            Open{" "}
+            <a
+              href={link}
+              className="underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {link.substring(0, 21)}...
+            </a>{" "}
+            and if there are SSL errors (e.g. ERR_CERT_AUTHORITY_INVALID), click
+            &quot;advanced&quot; and proceed to accept the certificate.
+          </li>
+        )}
+        <li>
+          <a
+            href="https://guides.getalby.com/overall-guide/alby-browser-extension/connect-lightning-wallets-and-nodes-to-alby-extension"
+            className="underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Visit our guides for more help
+          </a>
+        </li>
+      </ul>
     </>
   );
 }

--- a/src/app/components/toasts/ConnectionErrorToast.tsx
+++ b/src/app/components/toasts/ConnectionErrorToast.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from "react-i18next";
+
+export default function ConnectionErrorToast({ message }: { message: string }) {
+  const { t } = useTranslation("components", {
+    keyPrefix: "toasts.connection_error",
+  });
+  return (
+    <>
+      <p className="mb-2">
+        {t("connection_failed")}
+        <br />(<span className="italic">{message}</span>)
+      </p>
+      <p>
+        <a
+          href="https://guides.getalby.com/overall-guide/alby-browser-extension/connect-lightning-wallets-and-nodes-to-alby-extension"
+          className="underline"
+          target="_blank"
+        >
+          {t("help_link")}
+        </a>
+      </p>
+    </>
+  );
+}

--- a/src/app/components/toasts/LoginFailedToast.tsx
+++ b/src/app/components/toasts/LoginFailedToast.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from "react-i18next";
+
+export default function LoginFailedToast({
+  passwordResetUrl,
+}: {
+  passwordResetUrl: string;
+}) {
+  const { t } = useTranslation("components", {
+    keyPrefix: "toasts.login_failed",
+  });
+  return (
+    <>
+      <p className="mb-2">{t("invalid_credentials")}</p>
+      <p>
+        <a
+          href={passwordResetUrl}
+          className="underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {t("password_reset")}
+        </a>
+      </p>
+    </>
+  );
+}

--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -100,7 +100,7 @@ function Options() {
             element={
               <>
                 <Unlock />
-                <ToastContainer />
+                <ToastContainer autoClose={10000} hideProgressBar={true} />
               </>
             }
           />
@@ -129,7 +129,7 @@ const Layout = () => {
           {t("settings", commonI18nNamespace)}
         </Navbar.Link>
       </Navbar>
-      <ToastContainer />
+      <ToastContainer autoClose={10000} hideProgressBar={true} />
 
       <Outlet />
     </div>

--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -129,7 +129,11 @@ const Layout = () => {
           {t("settings", commonI18nNamespace)}
         </Navbar.Link>
       </Navbar>
-      <ToastContainer autoClose={10000} hideProgressBar={true} />
+      <ToastContainer
+        autoClose={15000}
+        hideProgressBar={true}
+        className="w-fit max-w-2xl"
+      />
 
       <Outlet />
     </div>

--- a/src/app/router/Popup/Popup.tsx
+++ b/src/app/router/Popup/Popup.tsx
@@ -43,7 +43,7 @@ function Popup() {
             element={
               <>
                 <Unlock />
-                <ToastContainer />
+                <ToastContainer autoClose={10000} hideProgressBar={true} />
               </>
             }
           />
@@ -60,7 +60,7 @@ const Layout = () => {
 
       <main className="flex flex-col grow min-h-0">
         <Outlet />
-        <ToastContainer />
+        <ToastContainer autoClose={10000} hideProgressBar={true} />
       </main>
     </div>
   );

--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -117,7 +117,7 @@ function Prompt() {
             element={
               <>
                 <Unlock />
-                <ToastContainer />
+                <ToastContainer autoClose={10000} hideProgressBar={true} />
               </>
             }
           />
@@ -130,7 +130,7 @@ function Prompt() {
 const Layout = () => {
   return (
     <>
-      <ToastContainer />
+      <ToastContainer autoClose={10000} hideProgressBar={true} />
       <div className="px-4 py-2 bg-white flex border-b border-gray-200 dark:bg-surface-02dp dark:border-neutral-500">
         <AccountMenu showOptions={false} />
       </div>

--- a/src/app/router/Welcome/Welcome.tsx
+++ b/src/app/router/Welcome/Welcome.tsx
@@ -1,5 +1,3 @@
-import DevMenu from "@components/DevMenu";
-import LocaleSwitcher from "@components/LocaleSwitcher/LocaleSwitcher";
 import type { Step } from "@components/Steps";
 import Steps from "@components/Steps";
 import Intro from "@screens/Onboard/Intro";
@@ -9,6 +7,7 @@ import ChooseConnector from "@screens/connectors/ChooseConnector";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { HashRouter as Router, useRoutes, useLocation } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 import { SettingsProvider } from "~/app/context/SettingsContext";
 import getConnectorRoutes from "~/app/router/connectorRoutes";
 import i18n from "~/i18n/i18nConfig";
@@ -77,6 +76,7 @@ function WelcomeRouter() {
   return (
     <SettingsProvider>
       <Router>
+        <ToastContainer autoClose={10000} />
         <App />
       </Router>
     </SettingsProvider>
@@ -129,14 +129,6 @@ function App() {
 
   return (
     <div>
-      {process.env.NODE_ENV === "development" && (
-        <>
-          <DevMenu />
-          <div className="w-32 mr-4 mt-1 pt-3 float-right">
-            <LocaleSwitcher />
-          </div>
-        </>
-      )}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center font-serif font-medium text-2xl pt-7 pb-3 dark:text-white">
           <p>{t("welcome.title")}</p>

--- a/src/app/router/Welcome/Welcome.tsx
+++ b/src/app/router/Welcome/Welcome.tsx
@@ -76,7 +76,7 @@ function WelcomeRouter() {
   return (
     <SettingsProvider>
       <Router>
-        <ToastContainer autoClose={10000} />
+        <ToastContainer autoClose={10000} hideProgressBar={true} />
         <App />
       </Router>
     </SettingsProvider>

--- a/src/app/router/Welcome/Welcome.tsx
+++ b/src/app/router/Welcome/Welcome.tsx
@@ -76,7 +76,11 @@ function WelcomeRouter() {
   return (
     <SettingsProvider>
       <Router>
-        <ToastContainer autoClose={10000} hideProgressBar={true} />
+        <ToastContainer
+          autoClose={15000}
+          hideProgressBar={true}
+          className="w-fit max-w-2xl"
+        />
         <App />
       </Router>
     </SettingsProvider>

--- a/src/app/router/Welcome/index.tsx
+++ b/src/app/router/Welcome/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import "react-loading-skeleton/dist/skeleton.css";
 import Modal from "react-modal";
+import "react-toastify/dist/ReactToastify.css";
 import "~/app/styles/index.css";
 import { getTheme } from "~/app/utils";
 import "~/i18n/i18nConfig";

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -29,6 +29,9 @@ export default function TestConnection() {
 
   async function loadAccountInfo() {
     setLoading(true);
+    setTimeout(() => {
+      setErrorMessage(t("connection_taking_long"));
+    }, 45000);
     try {
       const response = await api.getAccountInfo();
       const name = response.name;
@@ -60,12 +63,22 @@ export default function TestConnection() {
               <h1 className="text-3xl font-bold dark:text-white">
                 {t("connection_error")}
               </h1>
-              <p className="dark:text-neutral-500">{errorMessage}</p>
+              <p className="text-gray-500 dark:text-white">
+                {t("review_connection_details")}
+              </p>
+
+              <p className="text-gray-500 dark:text-grey-500 mt-4 mb-4">
+                <i>{errorMessage}</i>
+              </p>
+
               <Button
-                label={tCommon("actions.edit")}
+                label={t("actions.delete_edit_account")}
                 onClick={handleEdit}
                 primary
               />
+              <p className="text-gray-500 dark:text-white">
+                {t("contact_support")}
+              </p>
             </div>
           )}
 

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -29,7 +29,7 @@ export default function TestConnection() {
 
   async function loadAccountInfo() {
     setLoading(true);
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setErrorMessage(t("connection_taking_long"));
     }, 45000);
     try {
@@ -47,6 +47,7 @@ export default function TestConnection() {
       setErrorMessage(message);
     } finally {
       setLoading(false);
+      clearTimeout(timer);
     }
   }
 

--- a/src/app/screens/connectors/ConnectBtcpay/index.tsx
+++ b/src/app/screens/connectors/ConnectBtcpay/index.tsx
@@ -21,6 +21,7 @@ export default function ConnectBtcpay() {
   });
   const [formData, setFormData] = useState(initialFormData);
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function getConfigUrl(data: string) {
     const configUrl = data.trim().replace("config=", "");
@@ -55,7 +56,7 @@ export default function ConnectBtcpay() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnd";
     }
     // default to LND
@@ -127,7 +128,11 @@ export default function ConnectBtcpay() {
       </div>
       {formData.url.match(/\.onion/i) && (
         <div className="mb-6">
-          <CompanionDownloadInfo />
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
         </div>
       )}
     </ConnectorForm>

--- a/src/app/screens/connectors/ConnectBtcpay/index.tsx
+++ b/src/app/screens/connectors/ConnectBtcpay/index.tsx
@@ -1,6 +1,7 @@
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import axios from "axios";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -94,16 +95,17 @@ export default function ConnectBtcpay() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          ${t("errors.connection_failed")} \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);
-      let message = t("errors.connection_failed");
+      let message = "";
       if (e instanceof Error) {
-        message += `\n\n${e.message}`;
+        message += `${e.message}`;
       }
-      toast.error(message);
+      toast.error(<ConnectionErrorToast message={message} />);
     }
     setLoading(false);
   }

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -5,6 +5,7 @@ import {
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -69,16 +70,17 @@ export default function ConnectCitadel() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          Connection failed. Is your password correct? \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);
-      let message = "Connection failed. Is your password correct?";
+      let message = "";
       if (e instanceof Error) {
-        message += `\n\n${e.message}`;
+        message += `${e.message}`;
       }
-      toast.error(message);
+      toast.error(<ConnectionErrorToast message={message} />);
     }
     setLoading(false);
   }

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -2,6 +2,7 @@ import {
   HiddenIcon,
   VisibleIcon,
 } from "@bitcoin-design/bitcoin-icons-react/outline";
+import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import { useState } from "react";
@@ -17,6 +18,7 @@ export default function ConnectCitadel() {
     url: "http://citadel.local",
   });
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -26,7 +28,7 @@ export default function ConnectCitadel() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativecitadel";
     }
     return "citadel";
@@ -119,15 +121,26 @@ export default function ConnectCitadel() {
           }
         />
       </div>
-      <TextField
-        label="Citadel URL"
-        id="url"
-        placeholder="citadel.local"
-        type="text"
-        value={formData.url}
-        required
-        onChange={handleChange}
-      />
+      <div className="mb-6">
+        <TextField
+          label="Citadel URL"
+          id="url"
+          placeholder="citadel.local"
+          type="text"
+          value={formData.url}
+          required
+          onChange={handleChange}
+        />
+      </div>
+      {formData.url.match(/\.onion/i) && (
+        <div className="mb-6">
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
+        </div>
+      )}
     </ConnectorForm>
   );
 }

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -4,6 +4,7 @@ import {
 } from "@bitcoin-design/bitcoin-icons-react/outline";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -51,17 +52,16 @@ export default function ConnectEclair() {
       } else {
         console.error(validation);
         toast.error(
-          `Connection failed. Do you have the correct URL and password? \n\n(${validation.error})`
+          <ConnectionErrorToast message={validation.error as string} />
         );
       }
     } catch (e) {
       console.error(e);
-      let message =
-        "Connection failed. Do you have the correct URL and password?";
+      let message = "";
       if (e instanceof Error) {
-        message += `\n\n${e.message}`;
+        message += `${e.message}`;
       }
-      toast.error(message);
+      toast.error(<ConnectionErrorToast message={message} />);
     }
     setLoading(false);
   }

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -1,6 +1,7 @@
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -63,7 +64,7 @@ export default function ConnectLnbits() {
       } else {
         console.error(validation);
         toast.error(
-          `Connection failed. Do you have the correct URL and Admin Key? \n\n(${validation.error})`
+          <ConnectionErrorToast message={validation.error as string} />
         );
       }
     } catch (e) {

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -1,3 +1,4 @@
+import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import { useState } from "react";
@@ -12,6 +13,7 @@ export default function ConnectLnbits() {
     url: "https://legend.lnbits.com",
   });
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -21,7 +23,7 @@ export default function ConnectLnbits() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnbits";
     }
     // default to LNbits
@@ -99,14 +101,25 @@ export default function ConnectLnbits() {
           onChange={handleChange}
         />
       </div>
-      <TextField
-        id="url"
-        label="LNbits URL"
-        type="text"
-        value={formData.url}
-        required
-        onChange={handleChange}
-      />
+      <div className="mb-6">
+        <TextField
+          id="url"
+          label="LNbits URL"
+          type="text"
+          value={formData.url}
+          required
+          onChange={handleChange}
+        />
+      </div>
+      {formData.url.match(/\.onion/i) && (
+        <div className="mb-6">
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
+        </div>
+      )}
     </ConnectorForm>
   );
 }

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -24,6 +24,7 @@ export default function ConnectLnd() {
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
   const [hasTorSupport, setHasTorSupport] = useState(false);
+  const [connectionError, setConnectionError] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -72,8 +73,13 @@ export default function ConnectLnd() {
         }
       } else {
         toast.error(
-          <ConnectionErrorToast message={validation.error as string} />
+          <ConnectionErrorToast
+            message={validation.error as string}
+            link={formData.url}
+          />,
+          { autoClose: false }
         );
+        setConnectionError(true);
       }
     } catch (e) {
       console.error(e);
@@ -81,7 +87,9 @@ export default function ConnectLnd() {
       if (e instanceof Error) {
         message += `${e.message}`;
       }
-      toast.error(<ConnectionErrorToast message={message} />);
+      toast.error(
+        <ConnectionErrorToast message={message} link={formData.url} />
+      );
     }
     setLoading(false);
   }
@@ -147,6 +155,22 @@ export default function ConnectLnd() {
           required
         />
       </div>
+      {connectionError && (
+        <div className="mb-6">
+          If you're sure you've setup your node correctly, try{" "}
+          <a
+            href={`${formData.url}/v1/getinfo`}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            clicking this link
+          </a>{" "}
+          and making sure it loads correctly. If there are SSL errors (e.g.
+          ERR_CERT_AUTHORITY_INVALID), click "advanced" and proceed to accept
+          the certificate. Contact support@getalby.com for help.
+        </div>
+      )}
       {formData.url.match(/\.onion/i) && (
         <div className="mb-6">
           <CompanionDownloadInfo

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -2,6 +2,7 @@ import { SendIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -70,16 +71,17 @@ export default function ConnectLnd() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          ${t("errors.connection_failed")} \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);
-      let message = t("errors.connection_failed");
+      let message = "";
       if (e instanceof Error) {
-        message += `\n\n${e.message}`;
+        message += `${e.message}`;
       }
-      toast.error(message);
+      toast.error(<ConnectionErrorToast message={message} />);
     }
     setLoading(false);
   }
@@ -139,7 +141,7 @@ export default function ConnectLnd() {
           id="url"
           label={t("url_label")}
           placeholder={t("url_placeholder")}
-          pattern="https://.+"
+          pattern="https?://.+"
           title={t("url_placeholder")}
           onChange={handleChange}
           required

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -86,7 +86,10 @@ export default function ConnectLnd() {
         message += `${e.message}`;
       }
       toast.error(
-        <ConnectionErrorToast message={message} link={formData.url} />
+        <ConnectionErrorToast
+          message={message}
+          link={`${formData.url}/v1/getinfo`}
+        />
       );
     }
     setLoading(false);

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -22,6 +22,7 @@ export default function ConnectLnd() {
   const [isDragging, setDragging] = useState(false);
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -31,7 +32,7 @@ export default function ConnectLnd() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnd";
     }
     // default to LND
@@ -146,7 +147,11 @@ export default function ConnectLnd() {
       </div>
       {formData.url.match(/\.onion/i) && (
         <div className="mb-6">
-          <CompanionDownloadInfo />
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
         </div>
       )}
       <div>

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -24,7 +24,6 @@ export default function ConnectLnd() {
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
   const [hasTorSupport, setHasTorSupport] = useState(false);
-  const [connectionError, setConnectionError] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -79,7 +78,6 @@ export default function ConnectLnd() {
           />,
           { autoClose: false }
         );
-        setConnectionError(true);
       }
     } catch (e) {
       console.error(e);
@@ -155,22 +153,6 @@ export default function ConnectLnd() {
           required
         />
       </div>
-      {connectionError && (
-        <div className="mb-6">
-          If you're sure you've setup your node correctly, try{" "}
-          <a
-            href={`${formData.url}/v1/getinfo`}
-            target="_blank"
-            rel="noreferrer"
-            className="underline"
-          >
-            clicking this link
-          </a>{" "}
-          and making sure it loads correctly. If there are SSL errors (e.g.
-          ERR_CERT_AUTHORITY_INVALID), click "advanced" and proceed to accept
-          the certificate. Contact support@getalby.com for help.
-        </div>
-      )}
       {formData.url.match(/\.onion/i) && (
         <div className="mb-6">
           <CompanionDownloadInfo

--- a/src/app/screens/connectors/ConnectLndHub/index.tsx
+++ b/src/app/screens/connectors/ConnectLndHub/index.tsx
@@ -17,6 +17,7 @@ export default function ConnectLndHub() {
     uri: "",
   });
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFormData({
@@ -26,7 +27,7 @@ export default function ConnectLndHub() {
   }
 
   function getConnectorType() {
-    if (formData.uri.match(/\.onion/i)) {
+    if (formData.uri.match(/\.onion/i) && !hasTorSupport) {
       return "nativelndhub";
     }
     // default to LndHub
@@ -112,7 +113,11 @@ export default function ConnectLndHub() {
       </div>
       {formData.uri.match(/\.onion/i) && (
         <div className="mb-6">
-          <CompanionDownloadInfo />
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
         </div>
       )}
       <div>

--- a/src/app/screens/connectors/ConnectLndHub/index.tsx
+++ b/src/app/screens/connectors/ConnectLndHub/index.tsx
@@ -2,6 +2,7 @@ import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import QrcodeScanner from "@components/QrcodeScanner";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -76,7 +77,7 @@ export default function ConnectLndHub() {
       } else {
         console.error(validation);
         toast.error(
-          `${t("errors.connection_failed")} \n\n(${validation.error})`
+          <ConnectionErrorToast message={validation.error as string} />
         );
       }
     } catch (e) {

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -1,6 +1,7 @@
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -76,8 +77,9 @@ export default function ConnectMyNode() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          Connection failed. Are your credentials correct? \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -80,7 +80,7 @@ export default function ConnectMyNode() {
         toast.error(
           <ConnectionErrorToast
             message={validation.error as string}
-            link={formData.url}
+            link={`${formData.url}/v1/getinfo`}
           />
         );
       }

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -78,7 +78,10 @@ export default function ConnectMyNode() {
         }
       } else {
         toast.error(
-          <ConnectionErrorToast message={validation.error as string} />
+          <ConnectionErrorToast
+            message={validation.error as string}
+            link={formData.url}
+          />
         );
       }
     } catch (e) {

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -15,6 +15,7 @@ export default function ConnectMyNode() {
   const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormData);
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleLndconnectUrl(event: React.ChangeEvent<HTMLInputElement>) {
     try {
@@ -37,7 +38,7 @@ export default function ConnectMyNode() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnd";
     }
     // default to LND
@@ -117,16 +118,22 @@ export default function ConnectMyNode() {
       onSubmit={handleSubmit}
       video="https://cdn.getalby-assets.com/connector-guides/in_extension_guide_mynode.mp4"
     >
-      <TextField
-        id="lndconnect"
-        label="lndconnect REST URL"
-        placeholder="lndconnect://yournode:8080?..."
-        onChange={handleLndconnectUrl}
-        required
-      />
+      <div className="mb-6">
+        <TextField
+          id="lndconnect"
+          label="lndconnect REST URL"
+          placeholder="lndconnect://yournode:8080?..."
+          onChange={handleLndconnectUrl}
+          required
+        />
+      </div>
       {formData.url.match(/\.onion/i) && (
         <div className="mt-6">
-          <CompanionDownloadInfo />
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
         </div>
       )}
     </ConnectorForm>

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -78,7 +78,7 @@ export default function ConnectRaspiBlitz() {
         toast.error(
           <ConnectionErrorToast
             message={validation.error as string}
-            link={formData.url}
+            link={`${formData.url}/v1/getinfo`}
           />
         );
       }

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -1,6 +1,7 @@
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -74,17 +75,17 @@ export default function ConnectRaspiBlitz() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          Connection failed. Are your RaspiBlitz credentials correct? \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);
-      let message =
-        "Connection failed. Are your RaspiBlitz credentials correct?";
+      let message = "";
       if (e instanceof Error) {
-        message += `\n\n${e.message}`;
+        message += `${e.message}`;
       }
-      toast.error(message);
+      toast.error(<ConnectionErrorToast message={message} />);
     }
     setLoading(false);
   }

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -15,6 +15,7 @@ export default function ConnectRaspiBlitz() {
   const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormData);
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleUrl(event: React.ChangeEvent<HTMLInputElement>) {
     let url = event.target.value.trim();
@@ -35,7 +36,7 @@ export default function ConnectRaspiBlitz() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnd";
     }
     // default to LND
@@ -129,7 +130,13 @@ export default function ConnectRaspiBlitz() {
           required
         />
       </div>
-      {formData.url.match(/\.onion/i) && <CompanionDownloadInfo />}
+      {formData.url.match(/\.onion/i) && (
+        <CompanionDownloadInfo
+          hasTorCallback={() => {
+            setHasTorSupport(true);
+          }}
+        />
+      )}
       <div className="mt-6">
         <p className="mb-6 text-gray-500 mt-6 dark:text-neutral-400">
           Select <b>CONNECT</b>.<br />

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -76,7 +76,10 @@ export default function ConnectRaspiBlitz() {
         }
       } else {
         toast.error(
-          <ConnectionErrorToast message={validation.error as string} />
+          <ConnectionErrorToast
+            message={validation.error as string}
+            link={formData.url}
+          />
         );
       }
     } catch (e) {

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -78,7 +78,10 @@ export default function ConnectStart9() {
         }
       } else {
         toast.error(
-          <ConnectionErrorToast message={validation.error as string} />
+          <ConnectionErrorToast
+            message={validation.error as string}
+            link={formData.url}
+          />
         );
       }
     } catch (e) {

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -80,7 +80,7 @@ export default function ConnectStart9() {
         toast.error(
           <ConnectionErrorToast
             message={validation.error as string}
-            link={formData.url}
+            link={`${formData.url}/v1/getinfo`}
           />
         );
       }

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -15,6 +15,7 @@ export default function ConnectStart9() {
   const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormData);
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleLndconnectUrl(event: React.ChangeEvent<HTMLInputElement>) {
     try {
@@ -37,7 +38,7 @@ export default function ConnectStart9() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnd";
     }
     // default to LND
@@ -124,7 +125,11 @@ export default function ConnectStart9() {
       />
       {formData.url.match(/\.onion/i) && (
         <div className="mt-6">
-          <CompanionDownloadInfo />
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
         </div>
       )}
     </ConnectorForm>

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -1,6 +1,7 @@
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -76,8 +77,9 @@ export default function ConnectStart9() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          Connection failed. Are your Embassy credentials correct? \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -1,6 +1,7 @@
 import CompanionDownloadInfo from "@components/CompanionDownloadInfo";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -76,8 +77,9 @@ export default function ConnectUmbrel() {
           navigate("/test-connection");
         }
       } else {
-        toast.error(`
-          Connection failed. Are your Umbrel credentials correct? \n\n(${validation.error})`);
+        toast.error(
+          <ConnectionErrorToast message={validation.error as string} />
+        );
       }
     } catch (e) {
       console.error(e);

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -15,6 +15,7 @@ export default function ConnectUmbrel() {
   const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormData);
   const [loading, setLoading] = useState(false);
+  const [hasTorSupport, setHasTorSupport] = useState(false);
 
   function handleLndconnectUrl(event: React.ChangeEvent<HTMLInputElement>) {
     try {
@@ -37,7 +38,7 @@ export default function ConnectUmbrel() {
   }
 
   function getConnectorType() {
-    if (formData.url.match(/\.onion/i)) {
+    if (formData.url.match(/\.onion/i) && !hasTorSupport) {
       return "nativelnd";
     }
     // default to LND
@@ -123,7 +124,11 @@ export default function ConnectUmbrel() {
       />
       {formData.url.match(/\.onion/i) && (
         <div className="mt-6">
-          <CompanionDownloadInfo />
+          <CompanionDownloadInfo
+            hasTorCallback={() => {
+              setHasTorSupport(true);
+            }}
+          />
         </div>
       )}
     </ConnectorForm>

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -78,7 +78,10 @@ export default function ConnectUmbrel() {
         }
       } else {
         toast.error(
-          <ConnectionErrorToast message={validation.error as string} />
+          <ConnectionErrorToast
+            message={validation.error as string}
+            link={formData.url}
+          />
         );
       }
     } catch (e) {

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -80,7 +80,7 @@ export default function ConnectUmbrel() {
         toast.error(
           <ConnectionErrorToast
             message={validation.error as string}
-            link={formData.url}
+            link={`${formData.url}/v1/getinfo`}
           />
         );
       }

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -4,6 +4,7 @@ import {
 } from "@bitcoin-design/bitcoin-icons-react/outline";
 import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
+import LoginFailedToast from "@components/toasts/LoginFailedToast";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -60,12 +61,19 @@ export default function NewWallet() {
           });
         } else {
           console.error(data);
-          toast.error(
-            `${t("pre_connect.errors.create_wallet_error")} ${JSON.stringify(
-              data
-            )}`
-          );
           setLoading(false);
+          if (data.login_failed) {
+            toast.error(
+              <LoginFailedToast passwordResetUrl={data.password_reset_url} />,
+              { autoClose: false }
+            );
+          } else {
+            toast.error(
+              `${t("pre_connect.errors.create_wallet_error")} ${JSON.stringify(
+                data
+              )}`
+            );
+          }
         }
       })
       .catch((e) => {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -452,8 +452,10 @@
       }
     },
     "companionDownloadInfo": {
-      "info": "You are trying to connect to a node behind Tor. Because browsers cannot directly connect to your node please make sure you have the Alby companion app installed.",
-      "download_here": "Download it here!"
+      "info": "You are trying to connect to a node behind Tor. To do this you either need to have the Alby companion app installed or have Tor running. (When you're unsure, we recommend the Alby companion app.)",
+      "download_here": "Download the Alby companion here!",
+      "using_tor": "click here to continue if you use the Tor Browser",
+      "or": "Or:"
     }
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -456,6 +456,12 @@
       "download_here": "Download the Alby companion here!",
       "using_tor": "click here to continue if you use the Tor Browser",
       "or": "Or:"
+    },
+    "toasts": {
+      "connection_error": {
+        "connection_failed": "Connection failed. Are your credentials correct?",
+        "help_link": "For help visit our connection guides"
+      }
     }
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -459,8 +459,7 @@
     },
     "toasts": {
       "connection_error": {
-        "connection_failed": "Connection failed. Are your credentials correct?",
-        "help_link": "For help visit our connection guides"
+        "connection_failed": "Connection failed"
       },
       "login_failed": {
         "invalid_credentials": "Invalid password. Please review your password and email address and try again.",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -67,7 +67,7 @@
           "optional_lightning_address_label": "Choose your Lightning Address (optional)",
           "optional_lightning_address_suffix": "@getalby.com",
           "errors": {
-            "create_wallet_error": "Failed to create a new wallet"
+            "create_wallet_error": "Failed to login or create a new account. If you need help, please contact support@getalby.com"
           }
         }
       },
@@ -461,6 +461,10 @@
       "connection_error": {
         "connection_failed": "Connection failed. Are your credentials correct?",
         "help_link": "For help visit our connection guides"
+      },
+      "login_failed": {
+        "invalid_credentials": "Invalid password. Please review your password and email address and try again.",
+        "password_reset": "Forgot your password? Click here"
       }
     }
   }


### PR DESCRIPTION
### Describe the changes you have made in this PR

if a user has Tor installed or is using the Tor Browser there is no
need to install the companion app. - it actually also does not work.
So users of the Tor Browser should not install the companion app
and we need to use the normal connectors (and not the native connectors)

Sadly I don't know of a good way to detect the Tor Browser automatically.
(except of doing a HTTP request, which is slow and more complicated)

### Link this PR to an issue

#670
also closes #1162 #1182

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)
- `feat`: New feature (non-breaking change which adds functionality)

### How has this been tested?

Use Alby with the Tor Browser and add a node that is behind Tor

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
