### PR TITLE
fix: remove error toast from utils.call

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -8,6 +8,7 @@ import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import { useState, useEffect } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 import utils from "~/common/lib/utils";
@@ -50,6 +51,7 @@ function AccountMenu({ showOptions = true }: Props) {
       await fetchAccountInfo({ accountId });
     } catch (e) {
       console.error(e);
+      if (e instanceof Error) toast.error(`Error: ${e.message}`);
     } finally {
       setLoading(false);
     }

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import Modal from "react-modal";
+import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import utils from "~/common/lib/utils";
 import { getFiatValue } from "~/common/utils/currencyConvert";
@@ -86,6 +87,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
                   onDelete && onDelete();
                 } catch (e) {
                   console.error(e);
+                  if (e instanceof Error) toast.error(`Error: ${e.message}`);
                 }
               }
             }}

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -82,6 +82,7 @@ function Home() {
       setIsBlocked(false);
     } catch (e) {
       console.error(e);
+      if (e instanceof Error) toast.error(`Error: ${e.message}`);
     }
   }
 

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -3,6 +3,7 @@ import PasswordForm from "@components/PasswordForm";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 import utils from "~/common/lib/utils";
 
 const initialFormData = {
@@ -24,7 +25,10 @@ export default function SetPassword() {
       await utils.call("setPassword", { password: formData.password });
       navigate("/choose-connector");
     } catch (e) {
-      if (e instanceof Error) console.error(e.message);
+      if (e instanceof Error) {
+        console.error(e.message);
+        toast.error(`Error: ${e.message}`);
+      }
     }
   }
 

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -8,6 +8,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import utils from "~/common/lib/utils";
 import { getFiatValue } from "~/common/utils/currencyConvert";
@@ -89,6 +90,7 @@ function Publisher() {
       }
     } catch (e) {
       console.error(e);
+      if (e instanceof Error) toast.error(`Error: ${e.message}`);
     }
   }, [id, settings.showFiat]);
 

--- a/src/app/screens/Publishers/index.tsx
+++ b/src/app/screens/Publishers/index.tsx
@@ -3,6 +3,7 @@ import PublishersTable from "@components/PublishersTable";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 import utils from "~/common/lib/utils";
 import { Allowance, Publisher } from "~/types";
 
@@ -70,6 +71,7 @@ function Publishers() {
       setPublishers(allowances);
     } catch (e) {
       console.error(e);
+      if (e instanceof Error) toast.error(`Error: ${e.message}`);
     }
   }
 

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -1,5 +1,4 @@
 import PubSub from "pubsub-js";
-import { toast } from "react-toastify";
 import browser, { Runtime } from "webextension-polyfill";
 import { ABORT_PROMPT_ERROR } from "~/common/constants";
 import type {
@@ -28,7 +27,6 @@ const utils = {
       })
       .then((response: { data: T; error?: string }) => {
         if (response.error) {
-          toast.error(response.error);
           throw new Error(response.error);
         }
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

Removes the toast from being called in the utils function itself as in some places we again check if there's an error and add a _second_ toast.

### Link this PR to an issue

#1333

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
