### PR TITLE
fix: remove default image in publisher card

### DIFF
--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -32,25 +32,29 @@ export default function PublisherCard({
       className={classNames(
         isSmall ? "p-2" : "flex-col justify-center p-4",
         isCard && "drop-shadow rounded-lg mt-4",
+        !image && "py-8",
         "flex items-center bg-white dark:bg-surface-02dp"
       )}
     >
-      <img
-        className={`m-2 shrink-0 bg-white border-solid border-2 border-white object-cover rounded-lg shadow-2xl ${
-          isSmall ? "w-14 h-14 mr-4" : "w-20 h-20"
-        }`}
-        src={image || DEFAULT_IMAGE}
-        alt={`${title} logo`}
-        onError={(e) => {
-          const target = e.target as HTMLImageElement;
-          target.onerror = null;
-          target.src = DEFAULT_IMAGE;
-        }}
-      />
+      {image && (
+        <img
+          className={`m-2 shrink-0 bg-white border-solid border-2 border-white object-cover rounded-lg shadow-2xl ${
+            isSmall ? "w-14 h-14 mr-4" : "w-20 h-20"
+          }`}
+          src={image || DEFAULT_IMAGE}
+          alt={`${title} logo`}
+          onError={(e) => {
+            const target = e.target as HTMLImageElement;
+            target.onerror = null;
+            target.src = DEFAULT_IMAGE;
+          }}
+        />
+      )}
       <div
         className={
           "flex flex-col overflow-hidden w-full " +
-          (isSmall ? "" : "text-center")
+          (isSmall ? "" : "text-center ") +
+          (isSmall && !image && "ml-4")
         }
       >
         <h2

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -226,6 +226,22 @@ function LNURLPay() {
     return details.domain;
   }
 
+  function getImage() {
+    if (!details?.metadata) return;
+
+    try {
+      const metadata = JSON.parse(details.metadata);
+      const image = metadata.find(
+        ([type]: [string]) =>
+          type === "image/png;base64" || type === "image/jpeg;base64"
+      );
+
+      if (image) return `data:${image[0]},${image[1]}`;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   function formattedMetadata(
     metadataJSON: string
   ): [string, string | React.ReactNode][] {
@@ -278,7 +294,7 @@ function LNURLPay() {
         <PublisherCard
           title={navState.origin?.name}
           description={getRecipient()}
-          image={navState.origin?.icon}
+          image={navState.origin?.icon || getImage()}
         />
 
         <dl className="shadow bg-white dark:bg-surface-02dp mt-4 pt-4 px-4 rounded-lg mb-6 overflow-hidden">
@@ -310,7 +326,7 @@ function LNURLPay() {
                 <PublisherCard
                   title={navState.origin?.name}
                   description={getRecipient()}
-                  image={navState.origin?.icon}
+                  image={navState.origin?.icon || getImage()}
                 />
 
                 <div className="my-4">


### PR DESCRIPTION
### Describe the changes you have made in this PR

Removes the default image whenever there isn't one.
[It still shows up when there's an error in loading the image, though]

### Link this PR to an issue

#1379 

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)

![Screenshot from 2022-09-09 13-11-27](https://user-images.githubusercontent.com/64399555/189301417-f81c9e51-ec74-4ce5-9597-740d2e2ade1a.png)

<p>
<img width="24.5%" src="https://user-images.githubusercontent.com/64399555/189301433-41c14a74-dd88-4647-af42-a1ec3c61ff50.png" />
<img width="24.5%" src="https://user-images.githubusercontent.com/64399555/189301434-46adb06f-ad98-4ede-8242-4214f3f2c35c.png" />
<img width="24.5%" src="https://user-images.githubusercontent.com/64399555/189301440-018b8905-340c-44d1-9453-f694c0fc948e.png" />
<img width="24.5%" src="https://user-images.githubusercontent.com/64399555/189301442-d7125914-54eb-459b-b3ce-d9292f7965b9.png" />

</p>


### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
