### PR TITLE
fix: add space after description

### DIFF
--- a/src/extension/content-script/batteries/LinkTree.ts
+++ b/src/extension/content-script/batteries/LinkTree.ts
@@ -11,7 +11,7 @@ function battery(): void {
     'head > meta[name="description"]'
   );
 
-  let text = description?.content;
+  let text = description?.content + " ";
 
   if (linkElement) {
     const url = new URL(linkElement.href);


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds space after description so that the lightning address if in end of description doesn't get appended like this:
`hello@getalby.comLightning Buzz for yo...`

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
