### PR TITLE
fix: ln address regex

### DIFF
--- a/src/extension/content-script/batteries/helpers.ts
+++ b/src/extension/content-script/batteries/helpers.ts
@@ -7,7 +7,9 @@ import { ExtensionIcon } from "../../background-script/actions/setup/setIcon";
 export const findLightningAddressInText = (text: string): string | null => {
   // The second lightning emoji is succeeded by an invisible
   // variation selector-16 character: https://regex101.com/r/Bf2GpN/1
-  const match = text.match(/((⚡|⚡️):?|lightning:|lnurl:)\s?(\S+@[\w-.]+)/i);
+  const match = text.match(
+    /((⚡|⚡️):?|lightning:|lnurl:)\s?([\w-.]+@[\w-.]+[.][\w-.]+)/i
+  );
   if (match) return match[3];
   const matchAlbyLink = text.match(
     /http(s)?:\/\/(www[.])?getalby\.com\/p\/(\w+)/


### PR DESCRIPTION
### Describe the changes you have made in this PR

Makes [.] after @ mandatory as it can confuse for links with @ in between

For example:
`⚡️ https://tippin.me/@njelsalvador` is a valid ln address as per the old regex as it has `⚡️ + words + @ + words`

Changed it to:
`⚡️ + words + @ + words + .(dot) + words`

### Link this PR to an issue

Fixes #1437 

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

https://www.youtube.com/watch?v=PqNRpStZRAE

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
