### PR TITLE
feat(settings): enable/disable browser notifications

### DIFF
--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -60,6 +60,21 @@ function Settings() {
       </h2>
       <div className="shadow bg-white sm:rounded-md sm:overflow-hidden px-6 py-2 divide-y divide-gray-200 dark:divide-white/10 dark:bg-surface-02dp">
         <Setting
+          title={t("browser_notifications.title")}
+          subtitle={t("browser_notifications.subtitle")}
+        >
+          {!isLoading && (
+            <Toggle
+              checked={settings.browserNotifications}
+              onChange={() => {
+                saveSetting({
+                  browserNotifications: !settings.browserNotifications,
+                });
+              }}
+            />
+          )}
+        </Setting>
+        <Setting
           title={t("website_enhancements.title")}
           subtitle={t("website_enhancements.subtitle")}
         >

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -1,6 +1,7 @@
 import PubSub from "pubsub-js";
 import browser, { Runtime } from "webextension-polyfill";
 import { ABORT_PROMPT_ERROR } from "~/common/constants";
+import state from "~/extension/background-script/state";
 import type {
   Invoice,
   Message,
@@ -34,6 +35,9 @@ const utils = {
       });
   },
   notify: (options: { title: string; message: string }) => {
+    const settings = state.getState().settings;
+    if (!settings.browserNotifications) return;
+
     const notification: browser.Notifications.CreateNotificationOptions = {
       type: "basic",
       iconUrl: "assets/icons/alby_icon_yellow_48x48.png",

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -36,6 +36,7 @@ interface BrowserStorage {
 }
 
 export const DEFAULT_SETTINGS: SettingsStorage = {
+  browserNotifications: true,
   websiteEnhancements: true,
   legacyLnurlAuth: false,
   isUsingLegacyLnurlAuthKey: false,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -245,6 +245,10 @@
     },
     "settings": {
       "title": "Settings",
+      "browser_notifications": {
+        "title": "Browser notifications",
+        "subtitle": "Payment and authentication related notifications."
+      },
       "website_enhancements": {
         "title": "Website enhancements",
         "subtitle": "Tipping enhancements for Twitter, YouTube, etc."

--- a/src/types.ts
+++ b/src/types.ts
@@ -508,6 +508,7 @@ export interface Allowance extends Omit<DbAllowance, "id"> {
 }
 
 export interface SettingsStorage {
+  browserNotifications: boolean;
   websiteEnhancements: boolean;
   legacyLnurlAuth: boolean;
   isUsingLegacyLnurlAuthKey: boolean;


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds an option to enable/disable browser notifs globally

### Link this PR to an issue

Closes #1367

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Demo

https://user-images.githubusercontent.com/64399555/190345484-026da224-9bc8-49b1-9d97-d618d9b22fe1.mp4

### How has this been tested?

Using send and receive as in above video

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
