### PR TITLE
fix(lndhub): send amounts as strings

### DIFF
--- a/src/extension/background-script/connectors/lndhub.ts
+++ b/src/extension/background-script/connectors/lndhub.ts
@@ -322,7 +322,7 @@ export default class LndHub implements Connector {
       payment_request: string;
       r_hash: { type: string; data: ArrayBuffer } | string;
     }>("POST", "/addinvoice", {
-      amt: args.amount,
+      amt: args.amount.toString(),
       memo: args.memo,
     });
     if (typeof data.r_hash === "object" && data.r_hash.type === "Buffer") {


### PR DESCRIPTION
seems some lndhub implementations (lntxbot) can not handle integer amounts and expect strings.
Alby accounts support both. Not sure about others.

https://twitter.com/ArthurLaiSg/status/1570356953725149185