### PR TITLE
ci: add coverage as github action summary

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,4 +21,6 @@ jobs:
       - run: yarn install
 
       - name: Testing
-        run: yarn test:unit
+        run: |
+          yarn test:unit
+          yarn test:coverage >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This is adding a coverage report to the Github action summary.
Can be useful to check coverage without running it locally. And this does not add spamy comments to a PR.


Looks like this:
![image](https://user-images.githubusercontent.com/1016218/190974216-4a060735-4e70-4dcf-97f7-c222df2ae0e6.png)
![image](https://user-images.githubusercontent.com/1016218/190974176-1c2ac20f-f310-46fa-9044-5364745f267e.png)