### PR TITLE
Task notify payment

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -241,6 +241,7 @@ function Home() {
                     host: lnData[0].host,
                     description: lnData[0].description,
                     icon: lnData[0].icon,
+                    notify: lnData[0].notify,
                   };
 
                   if (lnData[0].method === "lnurl") {

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -10,6 +10,7 @@ import React, { Fragment, useState, useEffect, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import browser from "webextension-polyfill";
 import ScreenHeader from "~/app/components/ScreenHeader";
 import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
@@ -178,6 +179,18 @@ function LNURLPay() {
       }
 
       auth.fetchAccountInfo(); // Update balance.
+
+      browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+        if (
+          tabs.length > 0 &&
+          tabs[0].url?.startsWith("http") &&
+          navState.origin?.notify
+        ) {
+          browser.tabs.sendMessage(tabs[0].id as number, {
+            action: "emitPaymentFulfilled",
+          });
+        }
+      });
 
       // ATTENTION: if this LNURL is called through `webln.lnurl` then we immediately return and return the payment response. This closes the window which means the user will NOT see the above successAction.
       // We assume this is OK when it is called through webln.

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -37,7 +37,15 @@ const enhancements = [
   Monetization,
 ];
 
-async function extractLightningData() {
+export const emitPaymentFulfilled = (preimage: string) => {
+  window.dispatchEvent(
+    new CustomEvent("lightning:transaction", {
+      detail: { preimage: "Alby" },
+    })
+  );
+};
+
+export const extractLightningData = async () => {
   const settings = await api.getSettings();
   if (!settings.websiteEnhancements) return;
 
@@ -48,5 +56,4 @@ async function extractLightningData() {
   if (match) {
     match.battery();
   }
-}
-export default extractLightningData;
+};

--- a/src/extension/content-script/onend.js
+++ b/src/extension/content-script/onend.js
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 
-import extractLightningData from "./batteries";
+import { extractLightningData, emitPaymentFulfilled } from "./batteries";
 import injectScript from "./injectScript";
 import getOriginData from "./originData";
 import shouldInject from "./shouldInject";
@@ -35,6 +35,9 @@ async function init() {
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "extractLightningData") {
       extractLightningData();
+    }
+    if (request.action === "emitPaymentFulfilled") {
+      emitPaymentFulfilled();
     }
   });
 

--- a/src/extension/content-script/originData.ts
+++ b/src/extension/content-script/originData.ts
@@ -735,6 +735,9 @@ export default function getOriginData(): OriginData {
   const metaData = getMetaData();
 
   return {
+    notify: !!document.querySelector<HTMLMetaElement>(
+      'head > meta[name="lightning"]'
+    ),
     location: window.location.toString(),
     domain: window.location.origin,
     host: window.location.host,

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface OriginData {
   icon: string;
   metaData: MetaData;
   external: boolean;
+  notify?: boolean;
 }
 
 export interface PaymentNotificationData {


### PR DESCRIPTION
### Describe the changes you have made in this PR

This adds `notify` to `OriginData` which is set to true only when lightning meta tag is used in a website.
This is then used in the LNURLPay screen (for now) to send `emitPaymentFulfilled` which emits a custom event `"lightning:transaction"`

### Link this PR to an issue

#1020

### Type of change (Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### How has this been tested?

Tested using console statements at [twentyuno](https://webln.twentyuno.net/)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
