### PR TITLE
fix: align signmessage response in all connectors

### DIFF
--- a/src/extension/background-script/connectors/citadel.ts
+++ b/src/extension/background-script/connectors/citadel.ts
@@ -106,6 +106,7 @@ class CitadelConnector implements Connector {
     await this.ensureLogin();
     return {
       data: {
+        message: args.message,
         signature: await this.citadel.middleware.lightning.signMessage(
           args.message
         ),

--- a/src/extension/background-script/connectors/connector.interface.ts
+++ b/src/extension/background-script/connectors/connector.interface.ts
@@ -92,6 +92,7 @@ export interface SignMessageArgs {
 
 export interface SignMessageResponse {
   data: {
+    message: string;
     signature: string;
   };
 }

--- a/src/extension/background-script/connectors/eclair.ts
+++ b/src/extension/background-script/connectors/eclair.ts
@@ -134,6 +134,7 @@ class Eclair implements Connector {
 
     return {
       data: {
+        message: args.message,
         signature: signature as string,
       },
     };

--- a/src/extension/background-script/connectors/lnbits.ts
+++ b/src/extension/background-script/connectors/lnbits.ts
@@ -160,6 +160,7 @@ class LnBits implements Connector {
     }
     return Promise.resolve({
       data: {
+        message: args.message,
         signature: signedMessageDERHex,
       },
     });

--- a/src/extension/background-script/connectors/lndhub.ts
+++ b/src/extension/background-script/connectors/lndhub.ts
@@ -290,6 +290,7 @@ export default class LndHub implements Connector {
     }
     return Promise.resolve({
       data: {
+        message: args.message,
         signature: signedMessageDERHex,
       },
     });


### PR DESCRIPTION
### Describe the changes you have made in this PR

Aligns the SignMessageResponse to send message back every time

### Link this PR to an issue

Closes #1405

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Tested using LND and LNDHub accounts

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
