### PR TITLE
fix: race condition when loading the currency rate

### DIFF
--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -60,7 +60,7 @@ export const SettingsProvider = ({
     api.getCurrencyRate().then((response) => {
       setCurrencyRate(response.rate);
     });
-  });
+  }, []);
 
   const getFiatValue = async (amount: number | string) =>
     await getFiatValueFunc({

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -57,10 +57,10 @@ export const SettingsProvider = ({
 
   // update rate
   useEffect(() => {
-    api.getCurrencyRate({ currency: settings.currency }).then((response) => {
+    api.getCurrencyRate().then((response) => {
       setCurrencyRate(response.rate);
     });
-  }, [settings.currency]);
+  });
 
   const getFiatValue = async (amount: number | string) =>
     await getFiatValueFunc({

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -121,7 +121,7 @@ export const lnurlAuth = (
   utils.call<LnurlAuthResponse>("lnurlAuth", options);
 
 export const getCurrencyRate = async (
-  options: MessageCurrencyRateGet["args"]
+  options?: MessageCurrencyRateGet["args"]
 ) => utils.call<{ rate: number }>("getCurrencyRate", options);
 
 export default {

--- a/src/extension/background-script/actions/cache/getCurrencyRate.ts
+++ b/src/extension/background-script/actions/cache/getCurrencyRate.ts
@@ -86,7 +86,13 @@ export const getCurrencyRateFromCache = async (currency: CURRENCIES) => {
 };
 
 const getCurrencyRate = async (message: MessageCurrencyRateGet) => {
-  const { currency } = message.args;
+  let currency;
+  if (message?.args?.currency) {
+    currency = message.args.currency;
+  } else {
+    const settings = state.getState().settings;
+    currency = settings.currency;
+  }
   const rate = await getCurrencyRateFromCache(currency);
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,7 +312,7 @@ export interface MessageSettingsSet extends MessageDefault {
 }
 
 export interface MessageCurrencyRateGet extends MessageDefault {
-  args: { currency: CURRENCIES };
+  args?: { currency?: CURRENCIES };
   action: "getCurrencyRate";
 }
 


### PR DESCRIPTION
when the settings was not loaded, yet the default currency was used. This change prevents that by simply using the currency that the background script alread know from the settings.
(no need to load it first in the context and then do the call for the rate)

alternative to #1522 
another option would probably be to load the rate only when the settings are loaded (isLoading = false) in the settings context?
