### PR TITLE
fix(settings): make sure new fiat-rate is being used on currency switch

### DIFF
--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -3,6 +3,7 @@ import i18n from "i18next";
 import { useState, useEffect, createContext, useContext } from "react";
 import { toast } from "react-toastify";
 import { getTheme } from "~/app/utils";
+import { CURRENCIES } from "~/common/constants";
 import api from "~/common/lib/api";
 import { getFiatValue as getFiatValueFunc } from "~/common/utils/currencyConvert";
 import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
@@ -24,17 +25,22 @@ export const SettingsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [settings, setSettings] =
-    useState<SettingsContextType["settings"]>(DEFAULT_SETTINGS);
+  const [settings, setSettings] = useState<
+    SettingsContextType["settings"] | undefined
+  >();
   const [isLoading, setIsLoading] = useState(true);
   const [currencyRate, setCurrencyRate] = useState(0);
 
   // call this to trigger a re-render on all occassions
   const updateSetting = async (setting: Setting) => {
-    setSettings((prevState) => ({
-      ...prevState,
-      ...setting,
-    }));
+    if (!setting) return;
+    setSettings((prevState) => {
+      if (prevState)
+        return {
+          ...prevState,
+          ...setting,
+        };
+    });
     await api.setSetting(setting); // updates browser storage as well
   };
 
@@ -60,34 +66,34 @@ export const SettingsProvider = ({
     api.getCurrencyRate().then((response) => {
       setCurrencyRate(response.rate);
     });
-  }, [settings.currency]);
+  }, [settings?.currency]);
 
   const getFiatValue = async (amount: number | string) =>
     await getFiatValueFunc({
       amount,
       rate: currencyRate,
-      currency: settings.currency,
+      currency: settings?.currency || CURRENCIES["USD"],
     });
 
   // update locale on every change
   useEffect(() => {
-    i18n.changeLanguage(settings.locale);
+    i18n.changeLanguage(settings?.locale);
 
     // need to switch i.e. `pt_BR` to `pt-br`
-    const daysjsLocaleFormatted = settings.locale
+    const daysjsLocaleFormatted = settings?.locale
       .toLocaleLowerCase()
       .replace("_", "-");
     dayjs.locale(daysjsLocaleFormatted);
-  }, [settings.locale]);
+  }, [settings?.locale]);
 
   // update theme on every change
   useEffect(() => {
     getTheme(); // Get the active theme and apply corresponding Tailwind classes to the document
-  }, [settings.theme]);
+  }, [settings?.theme]);
 
   const value = {
     getFiatValue,
-    settings,
+    settings: settings || DEFAULT_SETTINGS,
     updateSetting,
     isLoading,
   };

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -60,7 +60,7 @@ export const SettingsProvider = ({
     api.getCurrencyRate().then((response) => {
       setCurrencyRate(response.rate);
     });
-  }, []);
+  }, [settings.currency]);
 
   const getFiatValue = async (amount: number | string) =>
     await getFiatValueFunc({

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -3,7 +3,6 @@ import i18n from "i18next";
 import { useState, useEffect, createContext, useContext } from "react";
 import { toast } from "react-toastify";
 import { getTheme } from "~/app/utils";
-import { CURRENCIES } from "~/common/constants";
 import api from "~/common/lib/api";
 import { getFiatValue as getFiatValueFunc } from "~/common/utils/currencyConvert";
 import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
@@ -25,22 +24,17 @@ export const SettingsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [settings, setSettings] = useState<
-    SettingsContextType["settings"] | undefined
-  >();
+  const [settings, setSettings] =
+    useState<SettingsContextType["settings"]>(DEFAULT_SETTINGS);
   const [isLoading, setIsLoading] = useState(true);
   const [currencyRate, setCurrencyRate] = useState(0);
 
   // call this to trigger a re-render on all occassions
   const updateSetting = async (setting: Setting) => {
-    if (!setting) return;
-    setSettings((prevState) => {
-      if (prevState)
-        return {
-          ...prevState,
-          ...setting,
-        };
-    });
+    setSettings((prevState) => ({
+      ...prevState,
+      ...setting,
+    }));
     await api.setSetting(setting); // updates browser storage as well
   };
 
@@ -66,34 +60,34 @@ export const SettingsProvider = ({
     api.getCurrencyRate().then((response) => {
       setCurrencyRate(response.rate);
     });
-  }, [settings?.currency]);
+  }, [settings.currency]);
 
   const getFiatValue = async (amount: number | string) =>
     await getFiatValueFunc({
       amount,
       rate: currencyRate,
-      currency: settings?.currency || CURRENCIES["USD"],
+      currency: settings.currency,
     });
 
   // update locale on every change
   useEffect(() => {
-    i18n.changeLanguage(settings?.locale);
+    i18n.changeLanguage(settings.locale);
 
     // need to switch i.e. `pt_BR` to `pt-br`
-    const daysjsLocaleFormatted = settings?.locale
+    const daysjsLocaleFormatted = settings.locale
       .toLocaleLowerCase()
       .replace("_", "-");
     dayjs.locale(daysjsLocaleFormatted);
-  }, [settings?.locale]);
+  }, [settings.locale]);
 
   // update theme on every change
   useEffect(() => {
     getTheme(); // Get the active theme and apply corresponding Tailwind classes to the document
-  }, [settings?.theme]);
+  }, [settings.theme]);
 
   const value = {
     getFiatValue,
-    settings: settings || DEFAULT_SETTINGS,
+    settings,
     updateSetting,
     isLoading,
   };

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -13,7 +13,6 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import Modal from "react-modal";
 import { toast } from "react-toastify";
-import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import { CURRENCIES } from "~/common/constants";
 import utils from "~/common/lib/utils";
@@ -26,7 +25,6 @@ const initialFormData = {
 function Settings() {
   const { t } = useTranslation("translation", { keyPrefix: "settings" });
   const { isLoading, settings, updateSetting } = useSettings();
-  const { fetchAccountInfo } = useAccount();
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [formData, setFormData] = useState(initialFormData);
@@ -201,7 +199,6 @@ function Settings() {
                     name="currency"
                     value={settings.currency}
                     onChange={async (event) => {
-                      fetchAccountInfo();
                       await saveSetting({
                         currency: event.target.value,
                       });


### PR DESCRIPTION
## Issue

When changing currency in settings the fiat-rate in the account-menu is not being updated

### Describe the changes you have made in this PR

- make sure fiat-rate is being renewed when changing currency in settings (re-add dependency to effect)
- remove `fetachAccountInfo` call because it's not needed anymore

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Manually
