### PR TITLE
Fix/1492 handle ln address server error response

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -248,7 +248,7 @@ function Home() {
 
                   if (lnData[0].method === "lnurl") {
                     const lnurl = lnData[0].address;
-                    const lnurlDetails = await lnurlLib.getDetails(lnurl); // throws if invalid.
+                    const lnurlDetails = await lnurlLib.getDetails(lnurl);
                     if (!("tag" in lnurlDetails)) {
                       toast.error(lnurlDetails.reason);
                       return;

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -24,6 +24,7 @@ import { classNames } from "~/app/utils/index";
 import api from "~/common/lib/api";
 import lnurlLib from "~/common/lib/lnurl";
 import utils from "~/common/lib/utils";
+import { isLNURLDetailsError } from "~/common/utils/typeHelpers";
 import type { Allowance, Battery, Transaction } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -249,7 +250,7 @@ function Home() {
                   if (lnData[0].method === "lnurl") {
                     const lnurl = lnData[0].address;
                     const lnurlDetails = await lnurlLib.getDetails(lnurl);
-                    if (!("tag" in lnurlDetails)) {
+                    if (isLNURLDetailsError(lnurlDetails)) {
                       toast.error(lnurlDetails.reason);
                       return;
                     }

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -249,6 +249,10 @@ function Home() {
                   if (lnData[0].method === "lnurl") {
                     const lnurl = lnData[0].address;
                     const lnurlDetails = await lnurlLib.getDetails(lnurl); // throws if invalid.
+                    if (!("tag" in lnurlDetails)) {
+                      toast.error(lnurlDetails.reason);
+                      return;
+                    }
 
                     if (lnurlDetails.tag === "payRequest") {
                       navigate("/lnurlPay", {

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -20,7 +20,7 @@ import lnurl from "~/common/lib/lnurl";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 import type {
-  LNURLPaymentInfoError,
+  LNURLError,
   LNURLPaymentInfo,
   LNURLPaymentSuccessAction,
   LNURLPayServiceResponse,
@@ -111,7 +111,7 @@ function LNURLPay() {
       let response;
 
       try {
-        response = await axios.get<LNURLPaymentInfo | LNURLPaymentInfoError>(
+        response = await axios.get<LNURLPaymentInfo | LNURLError>(
           details.callback,
           {
             params,
@@ -121,13 +121,14 @@ function LNURLPay() {
         );
 
         const isSuccessResponse = function (
-          obj: LNURLPaymentInfo | LNURLPaymentInfoError
+          obj: LNURLPaymentInfo | LNURLError
         ): obj is LNURLPaymentInfo {
           return Object.prototype.hasOwnProperty.call(obj, "pr");
         };
 
         if (!isSuccessResponse(response.data)) {
-          throw new Error(response.data.reason);
+          toast.warn(response.data.reason);
+          return;
         }
       } catch (e) {
         const message = e instanceof Error ? `(${e.message})` : "";

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -41,6 +41,10 @@ function Send() {
 
       if (lnurl) {
         const lnurlDetails = await lnurlLib.getDetails(lnurl);
+        if (!("tag" in lnurlDetails)) {
+          toast.error(lnurlDetails.reason);
+          return;
+        }
 
         if (lnurlDetails.tag === "channelRequest") {
           navigate("/lnurlChannel", {

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import lnurlLib from "~/common/lib/lnurl";
+import { isLNURLDetailsError } from "~/common/utils/typeHelpers";
 
 function Send() {
   const { t } = useTranslation("translation", { keyPrefix: "send" });
@@ -41,7 +42,7 @@ function Send() {
 
       if (lnurl) {
         const lnurlDetails = await lnurlLib.getDetails(lnurl);
-        if (!("tag" in lnurlDetails)) {
+        if (isLNURLDetailsError(lnurlDetails)) {
           toast.error(lnurlDetails.reason);
           return;
         }

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import lightningPayReq from "bolt11";
 import Hex from "crypto-js/enc-hex";
 import sha256 from "crypto-js/sha256";
-import { LNURLDetails, LNURLError, LNURLPaymentInfo } from "~/types";
+import type { LNURLDetails, LNURLError, LNURLPaymentInfo } from "~/types";
 
 import { bech32Decode } from "../utils/helpers";
 

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -64,7 +64,7 @@ const lnurl = {
   async getDetails(lnurlString: string): Promise<LNURLError | LNURLDetails> {
     const url = normalizeLnurl(lnurlString);
     let lnurlDetails = {} as LNURLDetails;
-    lnurlDetails.tag = url.searchParams.get("tag") as LNURLDetails["tag"]; // is this still relevant?
+    lnurlDetails.tag = url.searchParams.get("tag") as LNURLDetails["tag"];
     if (lnurlDetails.tag === "login") {
       lnurlDetails.k1 = url.searchParams.get("k1") || "";
       lnurlDetails.action = url.searchParams.get("action") || undefined;

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import lightningPayReq from "bolt11";
 import Hex from "crypto-js/enc-hex";
 import sha256 from "crypto-js/sha256";
-import { LNURLDetails, LNURLPaymentInfo } from "~/types";
+import { LNURLDetails, LNURLError, LNURLPaymentInfo } from "~/types";
 
 import { bech32Decode } from "../utils/helpers";
 
@@ -61,10 +61,10 @@ const lnurl = {
 
     return null;
   },
-  async getDetails(lnurlString: string) {
+  async getDetails(lnurlString: string): Promise<LNURLError | LNURLDetails> {
     const url = normalizeLnurl(lnurlString);
     let lnurlDetails = {} as LNURLDetails;
-    lnurlDetails.tag = url.searchParams.get("tag") as LNURLDetails["tag"];
+    lnurlDetails.tag = url.searchParams.get("tag") as LNURLDetails["tag"]; // is this still relevant?
     if (lnurlDetails.tag === "login") {
       lnurlDetails.k1 = url.searchParams.get("k1") || "";
       lnurlDetails.action = url.searchParams.get("action") || undefined;

--- a/src/common/utils/typeHelpers.ts
+++ b/src/common/utils/typeHelpers.ts
@@ -3,5 +3,5 @@ import type { LNURLDetails, LNURLError } from "~/types";
 export const isLNURLDetailsError = (
   res: LNURLError | LNURLDetails
 ): res is LNURLError => {
-  return "status" in res && res.status === "ERROR";
+  return "status" in res && res.status.toUpperCase() === "ERROR";
 };

--- a/src/common/utils/typeHelpers.ts
+++ b/src/common/utils/typeHelpers.ts
@@ -1,0 +1,7 @@
+import type { LNURLDetails, LNURLError } from "~/types";
+
+export const isLNURLDetailsError = (
+  res: LNURLError | LNURLDetails
+): res is LNURLError => {
+  return "status" in res && res.status === "ERROR";
+};

--- a/src/extension/background-script/actions/lnurl/index.ts
+++ b/src/extension/background-script/actions/lnurl/index.ts
@@ -1,4 +1,5 @@
 import lnurlLib from "~/common/lib/lnurl";
+import { isLNURLDetailsError } from "~/common/utils/typeHelpers";
 import type { MessageWebLnLnurl } from "~/types";
 
 import auth from "./auth";
@@ -16,7 +17,7 @@ async function lnurl(message: MessageWebLnLnurl) {
   let lnurlDetails;
   try {
     lnurlDetails = await lnurlLib.getDetails(message.args.lnurlEncoded);
-    if (!("tag" in lnurlDetails)) {
+    if (isLNURLDetailsError(lnurlDetails)) {
       return { error: lnurlDetails.reason };
     }
   } catch (e) {

--- a/src/extension/background-script/actions/lnurl/index.ts
+++ b/src/extension/background-script/actions/lnurl/index.ts
@@ -16,6 +16,9 @@ async function lnurl(message: MessageWebLnLnurl) {
   let lnurlDetails;
   try {
     lnurlDetails = await lnurlLib.getDetails(message.args.lnurlEncoded);
+    if (!("tag" in lnurlDetails)) {
+      return { error: lnurlDetails.reason };
+    }
   } catch (e) {
     return { error: e instanceof Error ? e.message : "Failed to parse LNURL" };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,6 +370,11 @@ export interface LNURLChannelServiceResponse {
   url: string;
 }
 
+export interface LNURLError {
+  status: "ERROR";
+  reason: string;
+}
+
 export type LNURLDetails =
   | LNURLChannelServiceResponse
   | LNURLPayServiceResponse
@@ -386,11 +391,6 @@ export interface LNURLPaymentSuccessAction {
 export interface LNURLPaymentInfo {
   pr: string;
   successAction?: LNURLPaymentSuccessAction;
-}
-
-export interface LNURLPaymentInfoError {
-  status: string;
-  reason: string;
 }
 
 export interface RequestInvoiceArgs {


### PR DESCRIPTION
### Describe the changes you have made in this PR

- `lnurlLib.getDetails` can return LNURLDetails or LNURLError [as defined here](https://github.com/fiatjaf/lnurl-rfc/blob/luds/06.md#pay-to-static-qrnfclink).
- Implementations need to take care of this

### Link this PR to an issue

Fixes #1492

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots
- ![image](https://user-images.githubusercontent.com/1016218/192967388-92487bd9-027a-4c34-8e01-19b3323d1c2e.png)
- ![image](https://user-images.githubusercontent.com/1016218/192968871-46bba3ff-227f-4aa0-a65b-a3ab5f9b2a98.png)


### How has this been tested?

Created a error test response and used it: `lnurl1dp68gurn8ghj7emfwd6zuemfw3582cn4wdjhycm0de6x2mn59e3k7mf0v4ekxctsv4jxxct59uerxv3sxsexyctrxgekgwp3xp3njcnpvvckzctrvgurwve38pnxgtmjv9mj7dp5vy6njwfs8yersd33vfjnwdfjxsunxer9x5en2vmzvsukyc35xg6rwwr98ymrvtmvde6hymr9wfex7unjv4ehqmmwwdjju6nndahq9ujger`
