### PR TITLE
fix: remove Remember & set budget from send #1510

### DIFF
--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -131,16 +131,17 @@ function ConfirmPayment() {
                   description={invoice.tagsObject.description}
                 />
               </div>
-
-              <BudgetControl
-                fiatAmount={fiatBudgetAmount}
-                remember={rememberMe}
-                onRememberChange={(event) => {
-                  setRememberMe(event.target.checked);
-                }}
-                budget={budget}
-                onBudgetChange={(event) => setBudget(event.target.value)}
-              />
+              {navState.origin && (
+                <BudgetControl
+                  fiatAmount={fiatBudgetAmount}
+                  remember={rememberMe}
+                  onRememberChange={(event) => {
+                    setRememberMe(event.target.checked);
+                  }}
+                  budget={budget}
+                  onBudgetChange={(event) => setBudget(event.target.value)}
+                />
+              )}
             </div>
           </div>
           <div>


### PR DESCRIPTION
### Describe the changes you have made in this PR

_Remove "Remember and set a budget" option from send screen when opting for lightning invoice_

### Link this PR to an issue

_Fixes #1510_

### Type of change (Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes (If any)

- _Previous behaviour_ 
![image](https://user-images.githubusercontent.com/67408018/192829597-8a9eb5e1-4063-4c95-a104-6f5884e15092.png)

- _After removal of "Remember and set a budget"_
![image](https://user-images.githubusercontent.com/67408018/192828898-2c0388f7-4875-490c-97a4-67c5934ae865.png)
![image](https://user-images.githubusercontent.com/67408018/192828583-39203637-d75e-4aa9-b072-0eb80e4c9643.png)


### How has this been tested?

_Manual Testing_
- I used ln invoice from Phoenix and tapped Send on popup and website, which shows "Remember and set a budget" but with the changes it has been removed
- Lightning invoice used:  lnbc1m1p3ngewjpp578s6uh2gvmsuldc7khppc57spggzjuy9aj0cg4633put5x20p6cqdqqxqyjw5q9q7sqqqqqqqqqqqqqqqqqqqqqqqqq9qsqsp5e5a6h39y85fnvlenly6dmfx97y32tru4hkn84x0wcgjf8egyfk4qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glclll0mxh6jgh2xuqqqqlgqqqqqeqqjqfs7gjqntggjnpgxp9rjh78gx2cczjuha65wdz9w2462chm8a7d78s2gwpdndsra4lf7940dh03dw67xcr8dd605lm68j6pusjj7n9tspm0mtde

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes 
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
