### PR TITLE
refactor(lnurl): getDetails - avoid typecasting

### DIFF
--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -71,25 +71,25 @@ const lnurl = {
 
   async getDetails(lnurlString: string): Promise<LNURLError | LNURLDetails> {
     const url = normalizeLnurl(lnurlString);
-    const searchParamstag = url.searchParams.get("tag") as LNURLDetails["tag"];
+    const searchParamsTag = url.searchParams.get("tag");
 
-    if (searchParamstag === "login") {
-      const searchParamsK1 = url.searchParams.get(
-        "k1"
-      ) as LNURLAuthServiceResponse["tag"];
-      const searchParamsAction = url.searchParams.get(
-        "action"
-      ) as LNURLAuthServiceResponse["tag"];
+    if (searchParamsTag && searchParamsTag === "login") {
+      const searchParamsK1 = url.searchParams.get("k1");
+      const searchParamsAction = url.searchParams.get("action");
 
-      const lnurlAuthDetails: LNURLAuthServiceResponse = {
-        action: searchParamsAction,
-        domain: url.hostname,
-        k1: searchParamsK1,
-        tag: searchParamstag,
-        url: url.toString(),
-      };
+      if (searchParamsK1) {
+        const lnurlAuthDetails: LNURLAuthServiceResponse = {
+          ...(searchParamsAction && { action: searchParamsAction }),
+          domain: url.hostname,
+          k1: searchParamsK1,
+          tag: searchParamsTag,
+          url: url.toString(),
+        };
 
-      return lnurlAuthDetails;
+        return lnurlAuthDetails;
+      }
+
+      throw new Error("LNURL AUTH Login is missing search params: k1");
     } else {
       try {
         const { data }: { data: LNURLDetails | LNURLError } = await axios.get(

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -72,24 +72,19 @@ const lnurl = {
   async getDetails(lnurlString: string): Promise<LNURLError | LNURLDetails> {
     const url = normalizeLnurl(lnurlString);
     const searchParamsTag = url.searchParams.get("tag");
+    const searchParamsK1 = url.searchParams.get("k1");
+    const searchParamsAction = url.searchParams.get("action");
 
-    if (searchParamsTag && searchParamsTag === "login") {
-      const searchParamsK1 = url.searchParams.get("k1");
-      const searchParamsAction = url.searchParams.get("action");
+    if (searchParamsTag && searchParamsTag === "login" && searchParamsK1) {
+      const lnurlAuthDetails: LNURLAuthServiceResponse = {
+        ...(searchParamsAction && { action: searchParamsAction }),
+        domain: url.hostname,
+        k1: searchParamsK1,
+        tag: searchParamsTag,
+        url: url.toString(),
+      };
 
-      if (searchParamsK1) {
-        const lnurlAuthDetails: LNURLAuthServiceResponse = {
-          ...(searchParamsAction && { action: searchParamsAction }),
-          domain: url.hostname,
-          k1: searchParamsK1,
-          tag: searchParamsTag,
-          url: url.toString(),
-        };
-
-        return lnurlAuthDetails;
-      }
-
-      throw new Error("LNURL AUTH Login is missing search params: k1");
+      return lnurlAuthDetails;
     } else {
       try {
         const { data }: { data: LNURLDetails | LNURLError } = await axios.get(

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -93,7 +93,7 @@ const lnurl = {
         const lnurlDetails = data;
 
         if (isLNURLDetailsError(lnurlDetails)) {
-          throw new Error(`LNURL Details Error: ${lnurlDetails.reason}`);
+          throw new Error(`LNURL Error: ${lnurlDetails.reason}`);
         } else {
           lnurlDetails.domain = url.hostname;
           lnurlDetails.url = url.toString();

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -92,7 +92,9 @@ const lnurl = {
         );
         const lnurlDetails = data;
 
-        if (!isLNURLDetailsError(lnurlDetails)) {
+        if (isLNURLDetailsError(lnurlDetails)) {
+          throw new Error(`LNURL Details Error: ${lnurlDetails.reason}`);
+        } else {
           lnurlDetails.domain = url.hostname;
           lnurlDetails.url = url.toString();
         }


### PR DESCRIPTION
Mainly trying to avoid `let lnurlDetails = {} as LNURLDetails;` and be more explicit about types. So instead of forcing the type we let TS figure it out by defining possible types in other places.