### PR TITLE
fix: adjust transaction toggle (vertical) position

### DIFF
--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -88,7 +88,7 @@ export default function TransactionsTable({ transactions }: Props) {
                       {(!!tx.description ||
                         [tx.type && "sent", "sending"].includes(tx.type) ||
                         (tx.type === "received" && tx.boostagram)) && (
-                        <Disclosure.Button className="block h-0 mt-2 text-gray-500 hover:text-black dark:hover:text-white transition-color duration-200">
+                        <Disclosure.Button className="block text-gray-500 hover:text-black dark:hover:text-white transition-color duration-200">
                           <CaretDownIcon
                             className={`${open ? "rotate-180" : ""} w-5 h-5`}
                           />


### PR DESCRIPTION
### Describe the changes you have made in this PR
Fix the vertical position of the **arrow toggler** on the right if no title exists and the option "Sats to Fiat" is disabled.

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]
<img src="https://user-images.githubusercontent.com/114179325/194126663-269b49bf-4a13-409a-b984-cf7ace684c4c.png" width=250>

_Wrong position_

<img src="https://user-images.githubusercontent.com/114179325/194126669-931d39ad-2796-4b0e-be0c-b906ad459ca5.png" width=250>

_Fixed position_

### How has this been tested?

No tests needed.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
