### PR TITLE
fix(lnurlpay): disable input fields buttons #1572

### DIFF
--- a/src/app/components/ConfirmOrCancel/index.tsx
+++ b/src/app/components/ConfirmOrCancel/index.tsx
@@ -9,7 +9,7 @@ export type Props = {
   disabled?: boolean;
   loading?: boolean;
   label?: string;
-  onConfirm: MouseEventHandler;
+  onConfirm?: MouseEventHandler;
   onCancel: MouseEventHandler;
 };
 
@@ -29,8 +29,10 @@ export default function ConfirmOrCancel({
           onClick={onCancel}
           label={tCommon("actions.cancel")}
           halfWidth
+          disabled={loading}
         />
         <Button
+          type="submit"
           onClick={onConfirm}
           label={label}
           primary

--- a/src/app/components/SatButtons/index.tsx
+++ b/src/app/components/SatButtons/index.tsx
@@ -4,9 +4,10 @@ import Button from "../Button";
 
 type Props = {
   onClick: (amount: string) => void;
+  disabled?: boolean;
 };
 
-function SatButtons({ onClick }: Props) {
+function SatButtons({ onClick, disabled }: Props) {
   return (
     <div className="flex gap-2 mt-2">
       <Button
@@ -14,24 +15,28 @@ function SatButtons({ onClick }: Props) {
         label="100 ⚡"
         onClick={() => onClick("100")}
         fullWidth
+        disabled={disabled}
       />
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="1K ⚡"
         onClick={() => onClick("1000")}
         fullWidth
+        disabled={disabled}
       />
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="5K ⚡"
         onClick={() => onClick("5000")}
         fullWidth
+        disabled={disabled}
       />
       <Button
         icon={<SatoshiV2Icon className="w-4 h-4" />}
         label="10K ⚡"
         onClick={() => onClick("10000")}
         fullWidth
+        disabled={disabled}
       />
     </div>
   );

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -326,6 +326,11 @@ function LNURLPay() {
     );
   }
 
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    confirm();
+  }
+
   return (
     <>
       <div className="flex flex-col grow overflow-hidden">
@@ -341,92 +346,97 @@ function LNURLPay() {
                   description={getRecipient()}
                   image={navState.origin?.icon || getImage()}
                 />
-
-                <div className="my-4">
-                  <dl>
-                    <>
-                      {formattedMetadata(details.metadata).map(
-                        ([dt, dd], i) => (
-                          <Fragment key={`element-${i}`}>
-                            <Dt>{dt}</Dt>
-                            <Dd>{dd}</Dd>
-                          </Fragment>
-                        )
-                      )}
-                      {details.minSendable === details.maxSendable && (
+                <form onSubmit={handleSubmit}>
+                  <fieldset disabled={loadingConfirm}>
+                    <div className="my-4">
+                      <dl>
                         <>
-                          <Dt>{t("amount.label")}</Dt>
-                          <Dd>{`${+details.minSendable / 1000} ${tCommon(
-                            "sats"
-                          )}`}</Dd>
+                          {formattedMetadata(details.metadata).map(
+                            ([dt, dd], i) => (
+                              <Fragment key={`element-${i}`}>
+                                <Dt>{dt}</Dt>
+                                <Dd>{dd}</Dd>
+                              </Fragment>
+                            )
+                          )}
+                          {details.minSendable === details.maxSendable && (
+                            <>
+                              <Dt>{t("amount.label")}</Dt>
+                              <Dd>{`${+details.minSendable / 1000} ${tCommon(
+                                "sats"
+                              )}`}</Dd>
+                            </>
+                          )}
                         </>
+                      </dl>
+                      {details && details.minSendable !== details.maxSendable && (
+                        <div>
+                          <DualCurrencyField
+                            id="amount"
+                            label={t("amount.label")}
+                            min={+details.minSendable / 1000}
+                            max={+details.maxSendable / 1000}
+                            value={valueSat}
+                            onChange={(e) => setValueSat(e.target.value)}
+                            fiatValue={fiatValue}
+                          />
+                          <SatButtons
+                            onClick={setValueSat}
+                            disabled={loadingConfirm}
+                          />
+                        </div>
                       )}
-                    </>
-                  </dl>
-                  {details && details.minSendable !== details.maxSendable && (
-                    <div>
-                      <DualCurrencyField
-                        id="amount"
-                        label={t("amount.label")}
-                        min={+details.minSendable / 1000}
-                        max={+details.maxSendable / 1000}
-                        value={valueSat}
-                        onChange={(e) => setValueSat(e.target.value)}
-                        fiatValue={fiatValue}
-                      />
-                      <SatButtons onClick={setValueSat} />
+                      {details &&
+                        typeof details?.commentAllowed === "number" &&
+                        details?.commentAllowed > 0 && (
+                          <div className="mt-4">
+                            <TextField
+                              id="comment"
+                              label={t("comment.label")}
+                              placeholder={tCommon("optional")}
+                              onChange={(e) => {
+                                setComment(e.target.value);
+                              }}
+                            />
+                          </div>
+                        )}
+                      {details && details?.payerData?.name && (
+                        <div className="mt-4">
+                          <TextField
+                            id="name"
+                            label={t("name.label")}
+                            placeholder={tCommon("optional")}
+                            value={userName}
+                            onChange={(e) => {
+                              setUserName(e.target.value);
+                            }}
+                          />
+                        </div>
+                      )}
+                      {details && details?.payerData?.email && (
+                        <div className="mt-4">
+                          <TextField
+                            id="email"
+                            label={t("email.label")}
+                            placeholder={tCommon("optional")}
+                            value={userEmail}
+                            onChange={(e) => {
+                              setUserEmail(e.target.value);
+                            }}
+                          />
+                        </div>
+                      )}
                     </div>
-                  )}
-                  {details &&
-                    typeof details?.commentAllowed === "number" &&
-                    details?.commentAllowed > 0 && (
-                      <div className="mt-4">
-                        <TextField
-                          id="comment"
-                          label={t("comment.label")}
-                          placeholder={tCommon("optional")}
-                          onChange={(e) => {
-                            setComment(e.target.value);
-                          }}
-                        />
-                      </div>
-                    )}
-                  {details && details?.payerData?.name && (
-                    <div className="mt-4">
-                      <TextField
-                        id="name"
-                        label={t("name.label")}
-                        placeholder={tCommon("optional")}
-                        value={userName}
-                        onChange={(e) => {
-                          setUserName(e.target.value);
-                        }}
-                      />
-                    </div>
-                  )}
-                  {details && details?.payerData?.email && (
-                    <div className="mt-4">
-                      <TextField
-                        id="email"
-                        label={t("email.label")}
-                        placeholder={tCommon("optional")}
-                        value={userEmail}
-                        onChange={(e) => {
-                          setUserEmail(e.target.value);
-                        }}
+                    <div className="pt-2 border-t border-gray-200 dark:border-white/10">
+                      <ConfirmOrCancel
+                        label={tCommon("actions.confirm")}
+                        loading={loadingConfirm}
+                        disabled={loadingConfirm || !valueSat}
+                        onCancel={reject}
                       />
                     </div>
-                  )}
-                </div>
-                <div className="pt-2 border-t border-gray-200 dark:border-white/10">
-                  <ConfirmOrCancel
-                    label={tCommon("actions.confirm")}
-                    loading={loadingConfirm}
-                    disabled={loadingConfirm || !valueSat}
-                    onConfirm={confirm}
-                    onCancel={reject}
-                  />
-                </div>
+                  </fieldset>
+                </form>
               </Container>
             </div>
           </>


### PR DESCRIPTION
### Describe the changes you have made in this PR

_On tapping Confirm, while loading **Amount, Comment, Name, Email, Buttons, Cancel button** should be disabled_

### Link this PR to an issue [optional]

Fixes _#1572_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

On tapping Confirm all these options get disabled as they should be, as details have already been specified.
![image](https://user-images.githubusercontent.com/67408018/194410081-512c502e-7993-4734-9f24-b40212787b34.png)
![image](https://user-images.githubusercontent.com/67408018/194411726-a524b4dd-b571-44b8-b344-4fc8f815e04b.png)

### How has this been tested?

_Open [this ](https://www.youtube.com/c/KoreacomK) on your browser, tap on getAlby extension, click Send Satoshis, now on the next window after adding Amount, Comment, Name, and Email, and click on Confirm all these fields should be disabled. It's working as it should be as specified in issue._

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
