### PR TITLE
fix: truncate account title

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -37,7 +37,7 @@ function AccountMenu({ showOptions = true }: Props) {
   const title =
     !!authAccount?.name &&
     typeof authAccount?.name === "string" &&
-    `${authAccount?.name} - ${authAccount?.alias}`.substring(0, 21);
+    `${authAccount?.name} - ${authAccount?.alias}`;
 
   useEffect(() => {
     getAccounts();
@@ -72,17 +72,20 @@ function AccountMenu({ showOptions = true }: Props) {
   }
 
   return (
-    <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-surface-12dp">
+    <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-surface-12dp max-w-full">
       <p className="flex items-center">
         <WalletIcon className="-ml-1 w-8 h-8 opacity-50 dark:text-white" />
       </p>
 
       <div
-        className={`flex-auto mx-2 py-1 ${
+        className={`flex-auto mx-2 py-1 overflow-hidden ${
           !title && !balancesDecorated ? "w-28" : ""
         }`}
       >
-        <p className="text-xs text-gray-700 dark:text-neutral-400">
+        <p
+          title={title || ""}
+          className="text-xs text-gray-700 dark:text-neutral-400 text-ellipsis overflow-hidden whitespace-nowrap"
+        >
           {title || <Skeleton />}
         </p>
 


### PR DESCRIPTION
### Describe the changes you have made in this PR
This change is about the account title. Replace JS cutting by a CSS solution. The full account title is displayed on mouse over (`title` attribute).

### Link this PR to an issue
Fixes #1567

### Type of change
- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]
**Short title**
![Screenshot 2022-10-07 at 08 49 21](https://user-images.githubusercontent.com/114179325/194492424-2aef0fc8-cecb-4fae-b0f1-eee6947d5231.png)

**Long title**
![Screenshot 2022-10-07 at 08 59 13](https://user-images.githubusercontent.com/114179325/194492433-1f236909-6684-4ecd-8197-6c049c354f0f.png)

**Long title mouse over**
![Screenshot 2022-10-07 at 08 59 27](https://user-images.githubusercontent.com/114179325/194492438-462c612f-497d-4d1e-a0d1-9b0c92d64f57.png)


### How has this been tested?
`yarn run dev:chrome`

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
