### PR TITLE
feat: add btcmap to the website directory

### DIFF
--- a/src/app/screens/Publishers/websites.json
+++ b/src/app/screens/Publishers/websites.json
@@ -98,7 +98,7 @@
       {
         "title": "BTC Map",
         "subtitle": "Easily find places to spend sats anywhere on the planet",
-        "logo": "https://btcmap.org/images/logo.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/btcmap-logo.svg",
         "url": "https://btcmap.org/"
       }
     ]

--- a/src/app/screens/Publishers/websites.json
+++ b/src/app/screens/Publishers/websites.json
@@ -94,6 +94,12 @@
         "subtitle": "Collection of stores and websites accepting bitcoin",
         "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightning-network-stores_thumbnail.svg",
         "url": "https://lightningnetworkstores.com/"
+      },
+      {
+        "title": "BTC Map",
+        "subtitle": "Easily find places to spend sats anywhere on the planet",
+        "logo": "https://btcmap.org/images/logo.svg",
+        "url": "https://btcmap.org/"
       }
     ]
   },


### PR DESCRIPTION
### Describe the changes you have made in this PR
I added the new website [BTC Map](https://btcmap.org) to the Websites directory under the Shopping category. BTC Map has just launched a lightning tipping feature for map contributors and there will be more lightning integration in the future that will be compatible with Alby users.

I noticed that for the other logo assets on this page you are using an Alby CDN to serve the images. I have included a URL to the BTC Map logo which can be left as-is or can be downloaded and added to the asset server with the others.

Thanks!! 🙂 

### Link this PR to an issue [optional]

### Type of change
- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]
![image](https://user-images.githubusercontent.com/85003930/194723007-ae61dc4e-3690-4762-87d4-bcd6935555cd.png)

### How has this been tested?
I ran this locally.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
