### PR TITLE
fix: input placeholder got cut (send) #1517

### DIFF
--- a/src/app/screens/Send/index.test.tsx
+++ b/src/app/screens/Send/index.test.tsx
@@ -26,33 +26,25 @@ describe("Send", () => {
       </MemoryRouter>
     );
 
-    expect(
-      await screen.getByLabelText("Invoice, Lightning Address or LNURL")
-    ).toBeInTheDocument();
+    expect(await screen.getByLabelText("Recipient")).toBeInTheDocument();
 
     await act(async () => {
       await user.type(
-        screen.getByLabelText("Invoice, Lightning Address or LNURL"),
+        screen.getByLabelText("Recipient"),
         "    sampleinvoice  "
       );
     });
 
-    expect(
-      screen.getByLabelText("Invoice, Lightning Address or LNURL")
-    ).toHaveValue("sampleinvoice");
+    expect(screen.getByLabelText("Recipient")).toHaveValue("sampleinvoice");
 
     await act(async () => {
-      await user.clear(
-        screen.getByLabelText("Invoice, Lightning Address or LNURL")
-      );
+      await user.clear(screen.getByLabelText("Recipient"));
       await user.type(
-        screen.getByLabelText("Invoice, Lightning Address or LNURL"),
+        screen.getByLabelText("Recipient"),
         "lightning:test@getalby.com"
       );
     });
 
-    expect(
-      screen.getByLabelText("Invoice, Lightning Address or LNURL")
-    ).toHaveValue("test@getalby.com");
+    expect(screen.getByLabelText("Recipient")).toHaveValue("test@getalby.com");
   });
 });

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -170,7 +170,7 @@ function Send() {
             <TextField
               id="invoice"
               label={t("input.label")}
-              placeholder={t("input.placeholder")}
+              hint={t("input.hint")}
               value={invoice}
               disabled={loading}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -451,8 +451,8 @@
         "title": "Waiting to scan"
       },
       "input": {
-        "label": "Invoice, Lightning Address or LNURL",
-        "placeholder": "Paste invoice, lnurl or lightning address"
+        "label": "Recipient",
+        "hint": "Invoice, Lightning Address or LNURL"
       }
     },
     "lnurlpay": {


### PR DESCRIPTION
### Describe the changes you have made in this PR

_Fixed Send UX: Too long input placeholder is being cut off
On tapping Send UX, the input field is having placeholder which is cut off in Portuguese. So added hint text and updated placeholder text_

### Link this PR to an issue [optional]

Fixes _#1517_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes

_Checkout below comments_

### How has this been tested?

_Tests are passing locally, final image attached below_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
