### PR TITLE
fix: amount-input changes value on scroll

### DIFF
--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -66,7 +66,11 @@ export default function DualCurrencyField({
     const ignoreScroll = (evt: globalThis.WheelEvent) => {
       evt.preventDefault();
     };
-    inputEl.current && inputEl.current.addEventListener("wheel", ignoreScroll);
+    const elem = inputEl.current;
+    elem && elem.addEventListener("wheel", ignoreScroll);
+    return () => {
+      elem && elem.removeEventListener("wheel", ignoreScroll);
+    };
   }, [inputEl]);
 
   return (

--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -61,13 +61,12 @@ export default function DualCurrencyField({
     />
   );
 
-  // run effect on input mount to ignoreScroll event
+  // run effect on input mount to ignore wheel/scroll event
   useEffect(() => {
-    if (inputEl.current == null) return;
     const ignoreScroll = (evt: globalThis.WheelEvent) => {
       evt.preventDefault();
     };
-    inputEl.current.addEventListener("wheel", ignoreScroll);
+    inputEl.current && inputEl.current.addEventListener("wheel", ignoreScroll);
   }, [inputEl]);
 
   return (

--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { classNames } from "~/app/utils";
 
 export type Props = {
@@ -60,6 +60,15 @@ export default function DualCurrencyField({
       max={max}
     />
   );
+
+  // run effect on input mount to ignoreScroll event
+  useEffect(() => {
+    if (inputEl.current == null) return;
+    const ignoreScroll = (evt: globalThis.WheelEvent) => {
+      evt.preventDefault();
+    };
+    inputEl.current.addEventListener("wheel", ignoreScroll);
+  }, [inputEl]);
 
   return (
     <div className="relative block m-0">


### PR DESCRIPTION
### Describe the changes you have made in this PR

I have added a "wheel" event listener on input and on callback of the event just preventing the fired event.

### Link this PR to an issue [optional]

Fixes #1593 

### Type of change

(Remove other not matching types)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

### How has this been tested?

I opened up the extension in Chrom and after login went to Receive tab, In amount-input entered some numbers and tried to scroll up & down to change the value, but it not changing. 

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
