### PR TITLE
refactor: remove act warnings for allowance-menu & lnurl-pay

### DIFF
--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -66,13 +66,13 @@ describe("AllowanceMenu", () => {
 
     await screen.findByText("Edit Allowance");
 
-    // update fiat value
-    await act(async () => {
+    // update fiat value when modal is open
+    await waitFor(() =>
       expect(mockGetFiatValue).toHaveBeenCalledWith(
         defaultProps.allowance.totalBudget.toString()
-      );
-      expect(mockGetFiatValue).toHaveBeenCalledTimes(1);
-    });
+      )
+    );
+    await waitFor(() => expect(mockGetFiatValue).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       await user.clear(screen.getByLabelText("New budget"));

--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -67,12 +67,10 @@ describe("AllowanceMenu", () => {
     await screen.findByText("Edit Allowance");
 
     // update fiat value when modal is open
-    await waitFor(() =>
-      expect(mockGetFiatValue).toHaveBeenCalledWith(
-        defaultProps.allowance.totalBudget.toString()
-      )
+    expect(mockGetFiatValue).toHaveBeenCalledWith(
+      defaultProps.allowance.totalBudget.toString()
     );
-    await waitFor(() => expect(mockGetFiatValue).toHaveBeenCalledTimes(1));
+    expect(mockGetFiatValue).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await user.clear(screen.getByLabelText("New budget"));

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -30,7 +30,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   const showFiat = !isLoadingSettings && settings.showFiat;
 
   const [modalIsOpen, setIsOpen] = useState(false);
-  const [budget, setBudget] = useState("0");
+  const [budget, setBudget] = useState("");
   const [lnurlAuth, setLnurlAuth] = useState(false);
   const [fiatAmount, setFiatAmount] = useState("");
   const { t } = useTranslation("components", { keyPrefix: "allowance_menu" });
@@ -38,10 +38,12 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
 
   useEffect(() => {
     if (budget !== "" && showFiat) {
-      (async () => {
+      const getFiat = async () => {
         const res = await getFiatValue(budget);
         setFiatAmount(res);
-      })();
+      };
+
+      getFiat();
     }
   }, [budget, showFiat, getFiatValue]);
 

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -64,11 +64,13 @@ function LNURLPay() {
   >();
 
   useEffect(() => {
-    if (showFiat) {
-      (async () => {
+    if (valueSat !== "" && showFiat) {
+      const getFiat = async () => {
         const res = await getFiatValue(valueSat);
         setFiatValue(res);
-      })();
+      };
+
+      getFiat();
     }
   }, [valueSat, showFiat, getFiatValue]);
 


### PR DESCRIPTION
### Describe the changes you have made in this PR
A quick fix for the test warnings (e.g. [here](https://github.com/getAlby/lightning-browser-extension/actions/runs/3219301525)):

- properly mock `getFiatValue`
- fix: initial value for "budget" in component AllowanceMenu
- fix: call `getFiatValue` only if sat value is defined
- test how many times `getFiatValue` was called

**Test run:** The warnings are gone => https://github.com/getAlby/lightning-browser-extension/actions/runs/3220138671

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Simply by running yarn test:unit only.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
