### PR TITLE
fix: close text to switch (settings) #1596

### DIFF
--- a/src/app/components/Setting/index.tsx
+++ b/src/app/components/Setting/index.tsx
@@ -11,7 +11,7 @@ function Setting({ title, subtitle, children }: Props) {
         <span className="text-gray-900 dark:text-white font-medium">
           {title}
         </span>
-        <p className="text-gray-500 dark:text-neutral-500 text-sm">
+        <p className="text-gray-500 mr-1 dark:text-neutral-500 text-sm">
           {subtitle}
         </p>
       </div>


### PR DESCRIPTION
### Describe the changes you have made in this PR

_In the settings tab, when opting for Portuguese Brasil, LNURL-Auth antigo subtitle is very close to the toggle button._
Change language to Portuguese Brasil on settings


### Link this PR to an issue [optional]

Fixes _#1596_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

**Updated Image**
![image](https://user-images.githubusercontent.com/67408018/195134141-1efc33d7-c705-4e0b-922a-82b281aabd1c.png)

**Old Image**
![image](https://user-images.githubusercontent.com/67408018/195134184-7960edec-53a0-4314-b92d-20b45fd25fa2.png)

### How has this been tested?

_✅ Unit Tests_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
