### PR TITLE
fix: fiat value 0 due to slow connection

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -32,6 +32,9 @@ function AccountMenu({ showOptions = true }: Props) {
   const navigate = useNavigate();
   const { accounts, getAccounts } = useAccounts();
   const [loading, setLoading] = useState(false);
+  const fiatBalValue = Number(
+    balancesDecorated.fiatBalance.replace(/[^0-9.]+/g, "")
+  );
 
   // update title
   const title =
@@ -93,7 +96,11 @@ function AccountMenu({ showOptions = true }: Props) {
             </span>
             {!!balancesDecorated.fiatBalance && (
               <span className="text-xs text-gray-600 dark:text-neutral-400">
-                ~{balancesDecorated.fiatBalance}
+                ~
+                {balancesDecorated.satsBalance !== "0 sats" &&
+                fiatBalValue === Number("0.00")
+                  ? "..."
+                  : balancesDecorated.fiatBalance}
               </span>
             )}
           </p>


### PR DESCRIPTION
### Describe the changes you have made in this PR

_During loading due to a slow connection, fiatBalance is shown ~$0, so "..." will be shown when the user has some satsBalance but due to a network issue, fiatBalance is not fetched properly._

### Link this PR to an issue [optional]

Fixes #1608

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

_As mentioned in the issue issue only reproduces due to [slow connection](https://github.com/getAlby/lightning-browser-extension/issues/1608#issuecomment-1276286733), so I tested by hard coding values._

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
