### PR TITLE
chore: relax node version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "= 14",
+    "node": ">= 14",
     "yarn": ">= 1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
we don't really require v14 and I find the fixed dependency annoying (because I run multiple node versions)

tests currently fail because of citadel somehow on other versions but I don't think the version needs to be locked in the package.json because of that. (we need to remove the citadel sdk dependency) but this