### PR TITLE
feat: add support for lsat

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@runcitadel/sdk": "^0.3.8",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "alby-tools": "^1.0.0",
     "axios": "^0.27.2",
     "bech32": "^2.0.0",
     "bolt11": "^1.4.0",

--- a/src/extension/inpage-script/index.js
+++ b/src/extension/inpage-script/index.js
@@ -8,9 +8,7 @@ if (document) {
   // this is just to make double sure we load it
   if (!window.webln) {
     window.webln = new WebLNProvider();
-  }
-  if (!window.alby) {
-    window.alby = alby;
+    window.alby = alby; // nomally also loaded onstart
   }
 
   const readyEvent = new Event("webln:ready");

--- a/src/extension/inpage-script/index.js
+++ b/src/extension/inpage-script/index.js
@@ -1,3 +1,4 @@
+import * as alby from "alby-tools";
 import { ABORT_PROMPT_ERROR, USER_REJECTED_ERROR } from "~/common/constants";
 
 import WebLNProvider from "../ln/webln";
@@ -7,6 +8,9 @@ if (document) {
   // this is just to make double sure we load it
   if (!window.webln) {
     window.webln = new WebLNProvider();
+  }
+  if (!window.alby) {
+    window.alby = alby;
   }
 
   const readyEvent = new Event("webln:ready");

--- a/src/extension/inpage-script/webln.js
+++ b/src/extension/inpage-script/webln.js
@@ -1,5 +1,8 @@
+import * as alby from "alby-tools";
+
 import WebLNProvider from "../ln/webln";
 
 if (document) {
   window.webln = new WebLNProvider();
+  window.alby = alby;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5006,6 +5006,13 @@ ajv@^8.11.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+alby-tools@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/alby-tools/-/alby-tools-1.0.0.tgz#c128aed9dca88571dc291d2fb6979584654b7de0"
+  integrity sha512-gcsqTXkzSYC/yWWeI27eHZVItIrYqZ/MQtPLLEpDhjAl/dV+FcgnisyySlBZ4sjNGf3jdVOkrwe4HQdGFW4HJg==
+  dependencies:
+    cross-fetch "^3.1.5"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz"
@@ -7053,7 +7060,7 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@3.1.5:
+cross-fetch@3.1.5, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
### Describe the changes you have made in this PR

This exposes lsat functions to web apps. Making it easy to do the lsat handshake.

```js
window.alby.fetchWithLsat(url, fetchOptions, options);
```
fetchOptions: options passed to `fetch`
options: 
  store: a storage object to save the lsat tokens e.g. window.localStorage
  webln: a webln object if window.webln should not be used (not relevant in the Alby case)

### Link this PR to an issue [optional]

#9 

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
