### PR TITLE
fix(connectors): lnbits incoming payments shows outgoing ones as well

### DIFF
--- a/src/extension/background-script/connectors/lnbits.ts
+++ b/src/extension/background-script/connectors/lnbits.ts
@@ -96,7 +96,7 @@ class LnBits implements Connector {
         data: {
           checking_id: string;
           pending: boolean;
-          amount: string;
+          amount: number;
           fee: number;
           memo: string;
           time: number;
@@ -108,19 +108,20 @@ class LnBits implements Connector {
           webhook_status: string;
         }[]
       ) => {
-        const invoices: ConnectorInvoice[] = data.map(
-          (invoice, index): ConnectorInvoice => {
+        const invoices: ConnectorInvoice[] = data
+          .filter((invoice) => invoice.amount > 0)
+          .map((invoice, index): ConnectorInvoice => {
             return {
               id: `${invoice.checking_id}-${index}`,
               memo: invoice.memo,
               preimage: invoice.preimage,
               settled: !invoice.pending,
               settleDate: invoice.time * 1000,
-              totalAmount: `${parseInt(invoice.amount) / 1000}`,
+              totalAmount: `${invoice.amount / 1000}`,
               type: "received",
             };
-          }
-        );
+          });
+
         return {
           data: {
             invoices,


### PR DESCRIPTION
### Describe the changes you have made in this PR

lnbits `payments` api shows outgoing and incoming payments. Negative ones are outgoing and need to be filtered out for our incoming txs.

### Link this PR to an issue [optional]

Fixes #1631

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

![image](https://user-images.githubusercontent.com/1016218/196625337-0a68d657-b58c-4326-b37b-d972e45f9e2e.png)


### How has this been tested?

Manually by sendign sats back and forth
