### PR TITLE
feat(confirmorcancel): focus the submit button

### DIFF
--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -1,6 +1,7 @@
+import { forwardRef } from "react";
+import type { Ref } from "react";
+import Loading from "~/app/components/Loading";
 import { classNames } from "~/app/utils/index";
-
-import Loading from "../Loading";
 
 export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   fullWidth?: boolean;
@@ -13,44 +14,55 @@ export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   direction?: "row" | "column";
 };
 
-export default function Button({
-  type = "button",
-  label,
-  onClick,
-  disabled,
-  direction = "row",
-  icon,
-  fullWidth = false,
-  halfWidth = false,
-  primary = false,
-  loading = false,
-}: Props) {
-  return (
-    <button
-      type={type}
-      className={classNames(
-        direction === "row" ? "flex-row" : "flex-col",
-        fullWidth && "w-full",
-        halfWidth && "w-1/2 first:mr-2 last:ml-2",
-        fullWidth || halfWidth ? "px-0 py-2" : "px-7 py-2",
-        primary
-          ? "bg-orange-bitcoin text-white border border-transparent"
-          : `bg-white text-gray-700 dark:bg-surface-02dp dark:text-neutral-200 dark:border-neutral-800`,
-        primary && !disabled && "hover:bg-orange-bitcoin-700",
-        !primary && !disabled && "hover:bg-gray-50 dark:hover:bg-surface-16dp",
-        disabled ? "cursor-default opacity-60" : "cursor-pointer",
-        "inline-flex justify-center items-center font-medium rounded-md shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
-      )}
-      onClick={onClick}
-      disabled={disabled}
-    >
-      {loading && (
-        <div className={direction === "row" ? "mr-2" : ""}>
-          <Loading color={primary ? "white" : "black"} />
-        </div>
-      )}
-      {icon}
-      {label}
-    </button>
-  );
-}
+const Button = forwardRef(
+  (
+    {
+      type = "button",
+      label,
+      onClick,
+      disabled,
+      direction = "row",
+      icon,
+      fullWidth = false,
+      halfWidth = false,
+      primary = false,
+      loading = false,
+    }: Props,
+    ref: Ref<HTMLButtonElement>
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={classNames(
+          direction === "row" ? "flex-row" : "flex-col",
+          fullWidth && "w-full",
+          halfWidth && "w-1/2 first:mr-2 last:ml-2",
+          fullWidth || halfWidth ? "px-0 py-2" : "px-7 py-2",
+          primary
+            ? "bg-orange-bitcoin text-white border border-transparent"
+            : `bg-white text-gray-700 dark:bg-surface-02dp dark:text-neutral-200 dark:border-neutral-800`,
+          primary && !disabled && "hover:bg-orange-bitcoin-700",
+          !primary &&
+            !disabled &&
+            "hover:bg-gray-50 dark:hover:bg-surface-16dp",
+          disabled ? "cursor-default opacity-60" : "cursor-pointer",
+          "inline-flex justify-center items-center font-medium rounded-md shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
+        )}
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {loading && (
+          <div className={direction === "row" ? "mr-2" : ""}>
+            <Loading color={primary ? "white" : "black"} />
+          </div>
+        )}
+        {icon}
+        {label}
+      </button>
+    );
+  }
+);
+Button.displayName = "Button";
+
+export default Button;

--- a/src/app/components/ConfirmOrCancel/index.tsx
+++ b/src/app/components/ConfirmOrCancel/index.tsx
@@ -1,9 +1,9 @@
-import { MouseEventHandler } from "react";
+import { useRef, useEffect } from "react";
+import type { MouseEventHandler } from "react";
 import { useTranslation } from "react-i18next";
+import Button from "~/app/components/Button";
 import i18n from "~/i18n/i18nConfig";
 import { commonI18nNamespace } from "~/i18n/namespaces";
-
-import Button from "../Button";
 
 export type Props = {
   disabled?: boolean;
@@ -21,6 +21,11 @@ export default function ConfirmOrCancel({
   onCancel,
 }: Props) {
   const { t: tCommon } = useTranslation("common");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    buttonRef?.current?.focus();
+  }, []);
 
   return (
     <div className="pt-2 pb-4">
@@ -33,6 +38,7 @@ export default function ConfirmOrCancel({
         />
         <Button
           type="submit"
+          ref={buttonRef}
           onClick={onConfirm}
           label={label}
           primary


### PR DESCRIPTION
### Describe the changes you have made in this PR

Focus CTA in prompt to make confirmation faster.  
Especially for usecases like nostr-chats where you need to confirm multiple times.


### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

![image](https://user-images.githubusercontent.com/1016218/196700073-6a61b749-68ce-41bf-a730-abd175e3ff89.png)
### How has this been tested?

Manually