### PR TITLE
refactor: store currency rate in settings ref

### DIFF
--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -7,7 +7,7 @@ import * as SettingsContext from "~/app/context/SettingsContext";
 import type { Props } from "./index";
 import AllowanceMenu from "./index";
 
-const mockGetFiatValue = jest.fn(() => "$1,22");
+const mockGetFiatValue = jest.fn(() => Promise.resolve("$1,22"));
 
 jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -38,8 +38,12 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
 
   useEffect(() => {
     if (budget !== "" && showFiat) {
-      const res = getFiatValue(budget);
-      setFiatAmount(res);
+      const getFiat = async () => {
+        const res = await getFiatValue(budget);
+        setFiatAmount(res);
+      };
+
+      getFiat();
     }
   }, [budget, showFiat, getFiatValue]);
 

--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -74,8 +74,8 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
   const setAccountId = (id: string) => setAccount({ id });
 
   const updateFiatValue = useCallback(
-    (balance: string | number) => {
-      const fiat = getFiatValue(balance);
+    async (balance: string | number) => {
+      const fiat = await getFiatValue(balance);
       setFiatBalance(fiat);
     },
     [getFiatValue]

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -13,7 +13,7 @@ interface SettingsContextType {
   settings: SettingsStorage;
   updateSetting: (setting: Setting) => void;
   isLoading: boolean;
-  getFiatValue: (amount: number | string) => string;
+  getFiatValue: (amount: number | string) => Promise<string>;
 }
 
 type Setting = Partial<SettingsStorage>;

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -92,7 +92,7 @@ export const SettingsProvider = ({
           `SettingsProvider: getFiatValue with currency ${settings.currency} failed. (${e.message})`
         );
 
-      return "Error";
+      return "Fiat Error";
     }
   };
 

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -87,12 +87,8 @@ export const SettingsProvider = ({
       return value;
     } catch (e) {
       console.error(e);
-      if (e instanceof Error)
-        toast.error(
-          `SettingsProvider: getFiatValue with currency ${settings.currency} failed. (${e.message})`
-        );
 
-      return "Fiat Error";
+      return "??"; // show the user that something went wrong
     }
   };
 

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { getTheme } from "~/app/utils";
 import { CURRENCIES } from "~/common/constants";
 import api from "~/common/lib/api";
-import { getFiatValue as getFiatValueFunc } from "~/common/utils/currencyConvert";
+import { getFiatValue as getFiatValueUtil } from "~/common/utils/currencyConvert";
 import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
 import type { SettingsStorage } from "~/types";
 
@@ -76,14 +76,24 @@ export const SettingsProvider = ({
   };
 
   const getFiatValue = async (amount: number | string) => {
-    const rate = await getCurrencyRate();
-    const value = await getFiatValueFunc({
-      amount,
-      rate,
-      currency: settings.currency,
-    });
+    try {
+      const rate = await getCurrencyRate();
+      const value = getFiatValueUtil({
+        amount,
+        rate,
+        currency: settings.currency,
+      });
 
-    return value;
+      return value;
+    } catch (e) {
+      console.error(e);
+      if (e instanceof Error)
+        toast.error(
+          `SettingsProvider: getFiatValue with currency ${settings.currency} failed. (${e.message})`
+        );
+
+      return "Error";
+    }
   };
 
   // update locale on every change

--- a/src/app/screens/ConfirmKeysend/index.test.tsx
+++ b/src/app/screens/ConfirmKeysend/index.test.tsx
@@ -13,10 +13,10 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   updateSetting: jest.fn(),
   getFiatValue: jest
     .fn()
-    .mockImplementationOnce(() => "$0.00")
-    .mockImplementationOnce(() => "$0.00")
-    .mockImplementationOnce(() => "$0.01")
-    .mockImplementationOnce(() => "$0.05"),
+    .mockImplementationOnce(() => Promise.resolve("$0.00"))
+    .mockImplementationOnce(() => Promise.resolve("$0.00"))
+    .mockImplementationOnce(() => Promise.resolve("$0.01"))
+    .mockImplementationOnce(() => Promise.resolve("$0.05")),
 });
 
 const mockOrigin: OriginData = {

--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -47,17 +47,19 @@ function ConfirmKeysend() {
   const [successMessage, setSuccessMessage] = useState("");
 
   useEffect(() => {
-    if (showFiat && amount) {
-      const res = getFiatValue(amount);
-      setFiatAmount(res);
-    }
+    (async () => {
+      if (showFiat && amount) {
+        const res = await getFiatValue(amount);
+        setFiatAmount(res);
+      }
+    })();
   }, [amount, showFiat, getFiatValue]);
 
   useEffect(() => {
-    if (showFiat) {
-      const res = getFiatValue(budget);
+    (async () => {
+      const res = await getFiatValue(budget);
       setFiatBudgetAmount(res);
-    }
+    })();
   }, [budget, showFiat, getFiatValue]);
 
   async function confirm() {

--- a/src/app/screens/ConfirmPayment/index.test.tsx
+++ b/src/app/screens/ConfirmPayment/index.test.tsx
@@ -55,7 +55,7 @@ describe("ConfirmPayment", () => {
       settings: { ...mockSettings },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => "$0.01"),
+      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     await act(async () => {
@@ -86,7 +86,7 @@ describe("ConfirmPayment", () => {
       settings: { ...mockSettings, showFiat: false },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => "$0.01"),
+      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     const user = userEvent.setup();
@@ -121,7 +121,7 @@ describe("ConfirmPayment", () => {
       settings: { ...mockSettings },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => "$0.01"),
+      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     await act(async () => {

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -47,17 +47,21 @@ function ConfirmPayment() {
   const [fiatBudgetAmount, setFiatBudgetAmount] = useState("");
 
   useEffect(() => {
-    if (showFiat && invoice.satoshis) {
-      const res = getFiatValue(invoice.satoshis);
-      setFiatAmount(res);
-    }
+    (async () => {
+      if (showFiat && invoice.satoshis) {
+        const res = await getFiatValue(invoice.satoshis);
+        setFiatAmount(res);
+      }
+    })();
   }, [invoice.satoshis, showFiat, getFiatValue]);
 
   useEffect(() => {
-    if (showFiat && budget) {
-      const res = getFiatValue(budget);
-      setFiatBudgetAmount(res);
-    }
+    (async () => {
+      if (showFiat && budget) {
+        const res = await getFiatValue(budget);
+        setFiatBudgetAmount(res);
+      }
+    })();
   }, [budget, showFiat, getFiatValue]);
 
   const [rememberMe, setRememberMe] = useState(false);

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -127,9 +127,9 @@ function Home() {
         ),
       }));
 
-      for (const payment of payments) {
+      for await (const payment of payments) {
         const totalAmountFiat = settings.showFiat
-          ? getFiatValue(payment.totalAmount)
+          ? await getFiatValue(payment.totalAmount)
           : "";
         payment.totalAmountFiat = totalAmountFiat;
       }
@@ -172,7 +172,7 @@ function Home() {
 
     for (const invoice of invoices) {
       const totalAmountFiat = settings.showFiat
-        ? getFiatValue(invoice.totalAmount)
+        ? await getFiatValue(invoice.totalAmount)
         : "";
       invoice.totalAmountFiat = totalAmountFiat;
     }

--- a/src/app/screens/LNURLPay/index.test.tsx
+++ b/src/app/screens/LNURLPay/index.test.tsx
@@ -6,7 +6,7 @@ import type { LNURLDetails, OriginData } from "~/types";
 
 import LNURLPay from "./index";
 
-const mockGetFiatValue = jest.fn(() => "$1,22");
+const mockGetFiatValue = jest.fn(() => Promise.resolve("$1,22"));
 
 jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -64,10 +64,12 @@ function LNURLPay() {
   >();
 
   useEffect(() => {
-    if (valueSat !== "" && showFiat) {
-      const res = getFiatValue(valueSat);
+    const getFiat = async () => {
+      const res = await getFiatValue(valueSat);
       setFiatValue(res);
-    }
+    };
+
+    getFiat();
   }, [valueSat, showFiat, getFiatValue]);
 
   useEffect(() => {

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -44,8 +44,10 @@ function LNURLWithdraw() {
 
   useEffect(() => {
     if (valueSat !== "" && showFiat) {
-      const res = getFiatValue(valueSat);
-      setFiatValue(res);
+      (async () => {
+        const res = await getFiatValue(valueSat);
+        setFiatValue(res);
+      })();
     }
   }, [valueSat, showFiat, getFiatValue]);
 

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -83,9 +83,9 @@ function Publisher() {
             ),
           };
         });
-        for (const payment of payments) {
+        for await (const payment of payments) {
           const totalAmountFiat = settings.showFiat
-            ? getFiatValue(payment.totalAmount)
+            ? await getFiatValue(payment.totalAmount)
             : "";
           payment.totalAmountFiat = totalAmountFiat;
         }

--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -63,8 +63,10 @@ function Receive() {
 
   useEffect(() => {
     if (formData.amount !== "" && showFiat) {
-      const res = getFiatValue(formData.amount);
-      setFiatAmount(res);
+      (async () => {
+        const res = await getFiatValue(formData.amount);
+        setFiatAmount(res);
+      })();
     }
   }, [formData, showFiat, getFiatValue]);
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

This is a refactoring which resulted from out the discussion in PR https://github.com/getAlby/lightning-browser-extension/pull/1614

- store latest currency rate in SettingContext ref instead of state to prevent a re-render
- when `getFiatValue` is called => always check if the currency in the state matches with the currency in the ref, and update otherwise
- => this ensures that the fiat value is calculated with the correct rate
- => this ensures that the latest currency rate is called from the background script only once when the currency changed 
- Also wrap `getFiatValue` in a try/catch block and display an error when a sat to fiat conversion failed

Unfortunately this reverted a few commits from [this PR](https://github.com/getAlby/lightning-browser-extension/pull/1643/files) again (sorry @escapedcat 🌷 ) 


### FIXES
- fixes https://github.com/getAlby/lightning-browser-extension/issues/1608
- and fixes bug from [this comment](https://github.com/getAlby/lightning-browser-extension/pull/1614#discussion_r997733183):

>  This results in a similar problem when changing the currency on the Settings Page:
> => the fiatValue within the AccountMenu needs several steps to show the correct new value because the currencyRate gets updated after getFiatValue is called
> => "$38.76" (initial value) => change to CNY => "CN¥38.76" (correct currency, wrong value) => "CN¥79.65" (correct currency, correct value)

### Screenshots
Try/Catch Toast Error

<img width="895" alt="toast" src="https://user-images.githubusercontent.com/11243967/197172560-1557c375-88d8-4b81-9d19-b8244492bc7a.png">



### Link this PR to an issue [optional]

Fixes #1608

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

- checking how the `AccountMenu` renders the fiatValue


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
