### PR TITLE
fix(lnurlpay): avoid send-start screen being cut-off by focusing #1641

### DIFF
--- a/src/app/components/ConfirmOrCancel/index.tsx
+++ b/src/app/components/ConfirmOrCancel/index.tsx
@@ -11,6 +11,7 @@ export type Props = {
   label?: string;
   onConfirm?: MouseEventHandler;
   onCancel: MouseEventHandler;
+  isFocused?: boolean;
 };
 
 export default function ConfirmOrCancel({
@@ -19,13 +20,14 @@ export default function ConfirmOrCancel({
   label = i18n.t("actions.confirm", commonI18nNamespace) as string,
   onConfirm,
   onCancel,
+  isFocused = true,
 }: Props) {
   const { t: tCommon } = useTranslation("common");
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    buttonRef?.current?.focus();
-  }, []);
+    isFocused && buttonRef?.current?.focus();
+  }, [isFocused]);
 
   return (
     <div className="pt-2 pb-4">

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -429,6 +429,7 @@ function LNURLPay() {
                     </div>
                     <div className="pt-2 border-t border-gray-200 dark:border-white/10">
                       <ConfirmOrCancel
+                        isFocused={false}
                         label={tCommon("actions.confirm")}
                         loading={loadingConfirm}
                         disabled={loadingConfirm || !valueSat}


### PR DESCRIPTION
### Describe the changes you have made in this PR

Avoid setting focus for LNURLPay screen so it's not being cut-off


### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Manually