### PR TITLE
fix: disable input fields on Create Invoice #1659

### DIFF
--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -211,40 +211,42 @@ function Receive() {
           }}
           className="h-full"
         >
-          <Container justifyBetween maxWidth="sm">
-            <div className="py-4">
-              <div className="mb-4">
-                <DualCurrencyField
-                  id="amount"
-                  min={0}
-                  label={t("amount.label")}
-                  placeholder={t("amount.placeholder")}
-                  fiatValue={fiatAmount}
-                  onChange={handleChange}
-                  autoFocus
-                />
-              </div>
+          <fieldset disabled={loading}>
+            <Container justifyBetween maxWidth="sm">
+              <div className="py-4">
+                <div className="mb-4">
+                  <DualCurrencyField
+                    id="amount"
+                    min={0}
+                    label={t("amount.label")}
+                    placeholder={t("amount.placeholder")}
+                    fiatValue={fiatAmount}
+                    onChange={handleChange}
+                    autoFocus
+                  />
+                </div>
 
+                <div className="mb-4">
+                  <TextField
+                    id="description"
+                    label={t("description.label")}
+                    placeholder={t("description.placeholder")}
+                    onChange={handleChange}
+                  />
+                </div>
+              </div>
               <div className="mb-4">
-                <TextField
-                  id="description"
-                  label={t("description.label")}
-                  placeholder={t("description.placeholder")}
-                  onChange={handleChange}
+                <Button
+                  type="submit"
+                  label={t("actions.create_invoice")}
+                  fullWidth
+                  primary
+                  loading={loading}
+                  disabled={loading}
                 />
               </div>
-            </div>
-            <div className="mb-4">
-              <Button
-                type="submit"
-                label={t("actions.create_invoice")}
-                fullWidth
-                primary
-                loading={loading}
-                disabled={loading}
-              />
-            </div>
-          </Container>
+            </Container>
+          </fieldset>
         </form>
       )}
     </div>


### PR DESCRIPTION
### Describe the changes you have made in this PR

_In Recieve tab, on tapping Create Invoice while loading Amount, & Description fields should be disabled. _

### Link this PR to an issue [optional]

Fixes #1659 

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

_Add screenshots to make your changes easier to understand. You can also add a video here._

### How has this been tested?

_Go to receive tab, and mention Amount and Description. On clicking Create Invoice while loading input fields are disabled as it should be. Previously it can be edited while loading._

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
