### PR TITLE
fix(nostr): return fully signed nostr event

### DIFF
--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -14,6 +14,7 @@ import { ToastContainer } from "react-toastify";
 import Providers from "~/app/context/Providers";
 import RequireAuth from "~/app/router/RequireAuth";
 import NostrConfirmGetPublicKey from "~/app/screens/Nostr/ConfirmGetPublicKey";
+import NostrConfirmSignMessage from "~/app/screens/Nostr/ConfirmSignMessage";
 import type { NavigationState, OriginData } from "~/types";
 
 // Parse out the parameters from the querystring.
@@ -69,6 +70,10 @@ function Prompt() {
             <Route
               path="public/nostr/confirmGetPublicKey"
               element={<NostrConfirmGetPublicKey />}
+            />
+            <Route
+              path="public/nostr/confirmSignMessage"
+              element={<NostrConfirmSignMessage />}
             />
 
             <Route path="lnurlAuth" element={<LNURLAuth />} />

--- a/src/app/screens/Nostr/ConfirmSignMessage.tsx
+++ b/src/app/screens/Nostr/ConfirmSignMessage.tsx
@@ -12,6 +12,7 @@ import ScreenHeader from "~/app/components/ScreenHeader";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
+import { Event } from "~/extension/ln/nostr/types";
 import type { OriginData } from "~/types";
 
 function ConfirmSignMessage() {
@@ -22,9 +23,8 @@ function ConfirmSignMessage() {
   });
   const navigate = useNavigate();
 
-  const message = navState.args?.message as string;
+  const event = navState.args?.event as Event;
   const origin = navState.origin as OriginData;
-  //const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
 
@@ -71,28 +71,8 @@ function ConfirmSignMessage() {
             />
             <ContentMessage
               heading={t("content", { host: origin.host })}
-              content={message}
+              content={event.content}
             />
-            {/*
-              <div className="mb-8">
-                <div className="flex items-center">
-                  <Checkbox
-                    id="remember_me"
-                    name="remember_me"
-                    checked={rememberMe}
-                    onChange={(event) => {
-                      setRememberMe(event.target.checked);
-                    }}
-                  />
-                  <label
-                    htmlFor="remember_me"
-                    className="ml-2 block text-sm text-gray-900 font-medium dark:text-white"
-                  >
-                    Remember and auto sign in the future
-                  </label>
-                </div>
-              </div>
-            */}
           </div>
           <ConfirmOrCancel
             disabled={loading}

--- a/src/app/screens/Nostr/ConfirmSignMessage.tsx
+++ b/src/app/screens/Nostr/ConfirmSignMessage.tsx
@@ -1,0 +1,118 @@
+//import Checkbox from "../../components/Form/Checkbox";
+import ConfirmOrCancel from "@components/ConfirmOrCancel";
+import Container from "@components/Container";
+import ContentMessage from "@components/ContentMessage";
+import PublisherCard from "@components/PublisherCard";
+import SuccessMessage from "@components/SuccessMessage";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import ScreenHeader from "~/app/components/ScreenHeader";
+import { useNavigationState } from "~/app/hooks/useNavigationState";
+import { USER_REJECTED_ERROR } from "~/common/constants";
+import msg from "~/common/lib/msg";
+import type { OriginData } from "~/types";
+
+function ConfirmSignMessage() {
+  const navState = useNavigationState();
+  const { t: tCommon } = useTranslation("common");
+  const { t } = useTranslation("translation", {
+    keyPrefix: "confirm_sign_message",
+  });
+  const navigate = useNavigate();
+
+  const message = navState.args?.message as string;
+  const origin = navState.origin as OriginData;
+  //const [rememberMe, setRememberMe] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+
+  // TODO: refactor: the success message and loading will not be displayed because after the reply the prompt is closed.
+  async function confirm() {
+    try {
+      setLoading(true);
+      msg.reply({
+        confirm: true,
+      });
+      setSuccessMessage(tCommon("success"));
+    } catch (e) {
+      console.error(e);
+      if (e instanceof Error) toast.error(`${tCommon("error")}: ${e.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function reject(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    msg.error(USER_REJECTED_ERROR);
+  }
+
+  function close(e: React.MouseEvent<HTMLButtonElement>) {
+    if (navState.isPrompt) {
+      window.close();
+    } else {
+      e.preventDefault();
+      navigate(-1);
+    }
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
+      <ScreenHeader title={t("title")} />
+      {!successMessage ? (
+        <Container justifyBetween maxWidth="sm">
+          <div>
+            <PublisherCard
+              title={origin.name}
+              image={origin.icon}
+              url={origin.host}
+            />
+            <ContentMessage
+              heading={t("content", { host: origin.host })}
+              content={message}
+            />
+            {/*
+              <div className="mb-8">
+                <div className="flex items-center">
+                  <Checkbox
+                    id="remember_me"
+                    name="remember_me"
+                    checked={rememberMe}
+                    onChange={(event) => {
+                      setRememberMe(event.target.checked);
+                    }}
+                  />
+                  <label
+                    htmlFor="remember_me"
+                    className="ml-2 block text-sm text-gray-900 font-medium dark:text-white"
+                  >
+                    Remember and auto sign in the future
+                  </label>
+                </div>
+              </div>
+            */}
+          </div>
+          <ConfirmOrCancel
+            disabled={loading}
+            loading={loading}
+            onConfirm={confirm}
+            onCancel={reject}
+          />
+        </Container>
+      ) : (
+        <Container maxWidth="sm">
+          <PublisherCard
+            title={origin.name}
+            image={origin.icon}
+            url={origin.host}
+          />
+          <SuccessMessage message={successMessage} onClose={close} />
+        </Container>
+      )}
+    </div>
+  );
+}
+
+export default ConfirmSignMessage;

--- a/src/extension/background-script/actions/nostr/signEventOrPrompt.ts
+++ b/src/extension/background-script/actions/nostr/signEventOrPrompt.ts
@@ -17,9 +17,6 @@ const signEventOrPrompt = async (message: MessageSignEvent) => {
     };
   }
 
-  // Set the message as the user needs to see the event details
-  message.args.message = JSON.stringify(message.args.event);
-
   try {
     const response = await utils.openPrompt<{
       confirm: boolean;
@@ -31,9 +28,10 @@ const signEventOrPrompt = async (message: MessageSignEvent) => {
       throw new Error("User rejected");
     }
 
-    const event = message.args.event;
-
-    const signedEvent = await state.getState().getNostr().signEvent(event);
+    const signedEvent = await state
+      .getState()
+      .getNostr()
+      .signEvent(message.args.event);
 
     return { data: signedEvent };
   } catch (e) {

--- a/src/extension/background-script/nostr/index.ts
+++ b/src/extension/background-script/nostr/index.ts
@@ -31,9 +31,10 @@ class Nostr {
     await state.getState().saveToStorage();
   }
 
-  async signEvent(event: Event): Promise<string> {
+  async signEvent(event: Event): Promise<Event> {
     const signature = await signEvent(event, this.getPrivateKey());
-    return signature;
+    event.sig = signature;
+    return event;
   }
 }
 

--- a/src/extension/ln/nostr/types.ts
+++ b/src/extension/ln/nostr/types.ts
@@ -5,6 +5,7 @@ export type Event = {
   content: string;
   tags: string[];
   created_at: number;
+  sig?: string;
 };
 
 export enum EventKind {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,7 @@ export type NavigationState = {
     amount?: string;
     customRecords?: Record<string, string>;
     message?: string;
+    event?: Event;
   };
   isPrompt?: true; // only passed via Prompt.tsx
   action: string;
@@ -331,7 +332,6 @@ export interface MessagePrivateKeySet extends MessageDefault {
 export interface MessageSignEvent extends MessageDefault {
   args: {
     event: Event;
-    message: string;
   };
   action: "signEvent";
 }


### PR DESCRIPTION
The [spec NIP07](https://github.com/nostr-protocol/nips/blob/master/07.md) says the full event with signature must be returned. So far we had only returned the signature.

We now also have a special ConfirmSignMessage screen for nostr events because the default ConfirmMessage screen still has some signing specific code which we don't need and want for nostr.


fixes #1687
