### PR TITLE
feat(db): add permissions for allowances

### DIFF
--- a/src/extension/background-script/actions/allowances/__tests__/add.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/add.test.ts
@@ -18,6 +18,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 500,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
 ];
 
@@ -63,6 +64,7 @@ describe("add allowance", () => {
       tag: "",
       totalBudget: 200,
       id: 4,
+      permissions: [],
     });
   });
 });

--- a/src/extension/background-script/actions/allowances/__tests__/delete.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/delete.test.ts
@@ -16,6 +16,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 500,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
   {
     enabled: false,
@@ -29,6 +30,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 200,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
 ];
 
@@ -74,6 +76,7 @@ describe("delete allowance", () => {
         totalBudget: 500,
         createdAt: "123456",
         tag: "",
+        permissions: [],
       },
     ]);
   });

--- a/src/extension/background-script/actions/allowances/__tests__/enable.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/enable.test.ts
@@ -34,6 +34,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 500,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
   {
     enabled: false,
@@ -47,6 +48,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 200,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
 ];
 

--- a/src/extension/background-script/actions/allowances/__tests__/get.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/get.test.ts
@@ -49,6 +49,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 5000,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
   {
     enabled: true,
@@ -62,6 +63,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 200,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
 ];
 

--- a/src/extension/background-script/actions/allowances/__tests__/getById.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/getById.test.ts
@@ -49,6 +49,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 5000,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
   {
     enabled: true,
@@ -62,6 +63,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 200,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
 ];
 

--- a/src/extension/background-script/actions/allowances/__tests__/list.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/list.test.ts
@@ -54,6 +54,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 500,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
   {
     enabled: true,
@@ -67,6 +68,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 200,
     createdAt: "1487076708000",
     tag: "",
+    permissions: [],
   },
 ];
 

--- a/src/extension/background-script/actions/allowances/__tests__/update.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/update.test.ts
@@ -16,6 +16,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 500,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
   {
     enabled: false,
@@ -29,6 +30,7 @@ const mockAllowances: DbAllowance[] = [
     totalBudget: 200,
     createdAt: "123456",
     tag: "",
+    permissions: [],
   },
 ];
 

--- a/src/extension/background-script/actions/allowances/add.ts
+++ b/src/extension/background-script/actions/allowances/add.ts
@@ -35,6 +35,7 @@ const add = async (message: MessageAllowanceAdd) => {
       remainingBudget: totalBudget,
       tag: "",
       totalBudget: totalBudget,
+      permissions: [],
     };
     await db.allowances.add(dbAllowance);
   }

--- a/src/extension/background-script/actions/allowances/delete.ts
+++ b/src/extension/background-script/actions/allowances/delete.ts
@@ -3,9 +3,15 @@ import type { MessageAllowanceDelete } from "~/types";
 
 const deleteAllowance = async (message: MessageAllowanceDelete) => {
   const id = message.args.id;
+
   if (!id) return { error: "id is missing" };
+
   await db.allowances.delete(id);
+
+  // Delete related permissions here too ?
+
   await db.saveToStorage();
+
   return { data: true };
 };
 

--- a/src/extension/background-script/actions/allowances/enable.ts
+++ b/src/extension/background-script/actions/allowances/enable.ts
@@ -54,6 +54,7 @@ const enable = async (
             createdAt: Date.now().toString(),
             lnurlAuth: false,
             tag: "",
+            permissions: [],
           });
         }
         await db.saveToStorage();

--- a/src/extension/background-script/actions/permissions/__tests__/add.test.ts
+++ b/src/extension/background-script/actions/permissions/__tests__/add.test.ts
@@ -36,10 +36,6 @@ afterEach(() => {
 });
 
 describe("add permission", () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   test("adds permission method to allowance and saves permissions", async () => {
     const message: MessagePermissionAdd = {
       application: "LBE",

--- a/src/extension/background-script/actions/permissions/__tests__/add.test.ts
+++ b/src/extension/background-script/actions/permissions/__tests__/add.test.ts
@@ -1,0 +1,83 @@
+import db from "~/extension/background-script/db";
+import type { DbAllowance, MessagePermissionAdd } from "~/types";
+
+import addPermission from "../add";
+
+Date.now = jest.fn(() => 1487076708000);
+
+const stackerNews = {
+  host: "stacker.news",
+  imageURL: "https://stacker.news/apple-touch-icon.png",
+  name: "Stacker News",
+};
+
+const mockAllowances: DbAllowance[] = [
+  {
+    ...stackerNews,
+    enabled: true,
+    id: 3,
+    lastPaymentAt: 1667291232423,
+    lnurlAuth: true,
+    remainingBudget: 500,
+    totalBudget: 500,
+    createdAt: "1667291216372",
+    tag: "",
+    permissions: ["the-request-method-1"],
+  },
+];
+
+beforeEach(async () => {
+  // fill the DB first
+  await db.allowances.bulkAdd(mockAllowances);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("add permission", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("adds permission method to allowance and saves permissions", async () => {
+    const message: MessagePermissionAdd = {
+      application: "LBE",
+      prompt: true,
+      action: "addPermission",
+      origin: {
+        internal: true,
+      },
+      args: {
+        host: stackerNews.host,
+        method: "the-request-method-2",
+        enabled: true,
+        blocked: false,
+      },
+    };
+
+    await addPermission(message);
+
+    const dbAllowances = await db.allowances.toArray();
+    const dbPermissions = await db.permissions.toArray();
+
+    expect(dbAllowances).toEqual([
+      {
+        ...mockAllowances[0],
+        permissions: ["the-request-method-1", "the-request-method-2"],
+      },
+    ]);
+
+    expect(dbPermissions).toStrictEqual([
+      {
+        id: 1,
+        allowanceId: 3,
+        createdAt: "1487076708000",
+        host: "stacker.news",
+        method: "the-request-method-2",
+        blocked: false,
+        enabled: true,
+      },
+    ]);
+  });
+});

--- a/src/extension/background-script/actions/permissions/__tests__/delete.test.ts
+++ b/src/extension/background-script/actions/permissions/__tests__/delete.test.ts
@@ -59,10 +59,6 @@ afterEach(() => {
 });
 
 describe("delete permission", () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   test("removes permission method from allowance and deletes permission", async () => {
     const message: MessagePermissionDelete = {
       application: "LBE",

--- a/src/extension/background-script/actions/permissions/__tests__/delete.test.ts
+++ b/src/extension/background-script/actions/permissions/__tests__/delete.test.ts
@@ -1,0 +1,94 @@
+import db from "~/extension/background-script/db";
+import type { DbAllowance, MessagePermissionDelete } from "~/types";
+
+import deletePermission from "../delete";
+
+const mockNow = 1487076708000;
+Date.now = jest.fn(() => mockNow);
+
+const stackerNews = {
+  host: "stacker.news",
+  imageURL: "https://stacker.news/apple-touch-icon.png",
+  name: "Stacker News",
+};
+
+const mockAllowances: DbAllowance[] = [
+  {
+    ...stackerNews,
+    enabled: true,
+    id: 3,
+    lastPaymentAt: 1667291232423,
+    lnurlAuth: true,
+    remainingBudget: 500,
+    totalBudget: 500,
+    createdAt: "1667291216372",
+    tag: "",
+    permissions: ["the-request-method-1", "the-request-method-2"],
+  },
+];
+
+const mockPermissions = [
+  {
+    id: 1,
+    allowanceId: 3,
+    createdAt: "1667291216372",
+    host: stackerNews.host,
+    method: "the-request-method-1",
+    blocked: false,
+    enabled: true,
+  },
+  {
+    id: 2,
+    allowanceId: 3,
+    createdAt: "1667291216372",
+    host: stackerNews.host,
+    method: "the-request-method-2",
+    blocked: false,
+    enabled: true,
+  },
+];
+
+beforeEach(async () => {
+  // fill the DB first
+  await db.allowances.bulkAdd(mockAllowances);
+  await db.permissions.bulkAdd(mockPermissions);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("delete permission", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("removes permission method from allowance and deletes permission", async () => {
+    const message: MessagePermissionDelete = {
+      application: "LBE",
+      prompt: true,
+      action: "deletePermission",
+      origin: {
+        internal: true,
+      },
+      args: {
+        host: stackerNews.host,
+        method: "the-request-method-2",
+      },
+    };
+
+    await deletePermission(message);
+
+    const dbAllowances = await db.allowances.toArray();
+    const dbPermissions = await db.permissions.toArray();
+
+    expect(dbAllowances).toEqual([
+      {
+        ...mockAllowances[0],
+        permissions: ["the-request-method-1"],
+      },
+    ]);
+
+    expect(dbPermissions).toStrictEqual([mockPermissions[0]]);
+  });
+});

--- a/src/extension/background-script/actions/permissions/add.ts
+++ b/src/extension/background-script/actions/permissions/add.ts
@@ -1,0 +1,41 @@
+import type { MessagePermissionAdd } from "~/types";
+
+import db from "../../db";
+
+const addPermission = async (message: MessagePermissionAdd) => {
+  const { host, method, enabled, blocked } = message.args;
+
+  const matchingAllowance = await db.allowances
+    .where("host")
+    .equalsIgnoreCase(host)
+    .first();
+
+  if (!matchingAllowance?.id) {
+    return { error: "No Allowance set for this host" };
+  }
+
+  // check if permissions exist or add fallback, needed for migrations
+  const formerPermissions = matchingAllowance.permissions || [];
+  const newPermissions = [...formerPermissions, method];
+  const uniquePermissions = [...new Set(newPermissions)]; // remove dublicates
+
+  // add new request method to allowance permissions
+  await db.allowances.update(matchingAllowance.id, {
+    permissions: uniquePermissions,
+  });
+
+  const added = await db.permissions.add({
+    createdAt: Date.now().toString(),
+    allowanceId: matchingAllowance.id,
+    host,
+    method,
+    enabled,
+    blocked,
+  });
+
+  await db.saveToStorage();
+
+  return { data: added };
+};
+
+export default addPermission;

--- a/src/extension/background-script/actions/permissions/delete.ts
+++ b/src/extension/background-script/actions/permissions/delete.ts
@@ -1,0 +1,37 @@
+import type { MessagePermissionDelete } from "~/types";
+
+import db from "../../db";
+
+const deletePermission = async (message: MessagePermissionDelete) => {
+  const { host, method } = message.args;
+
+  const matchingAllowance = await db.allowances
+    .where("host")
+    .equalsIgnoreCase(host)
+    .first();
+
+  if (!matchingAllowance?.id) {
+    return { error: "No Allowance set for this host" };
+  }
+
+  // remove request method from allowance permissions
+  const formerPermissions = matchingAllowance.permissions || []; // fallback needed for migration
+  const removedPermission = formerPermissions.filter((p) => p !== method);
+
+  await db.allowances.update(matchingAllowance.id, {
+    permissions: removedPermission,
+  });
+
+  // delete permission
+  const deleteCount = await db.permissions
+    .where("host")
+    .equalsIgnoreCase(host)
+    .and((p) => p.method === method)
+    .delete();
+
+  await db.saveToStorage();
+
+  return { data: !!deleteCount };
+};
+
+export default deletePermission;

--- a/src/extension/background-script/actions/permissions/get.ts
+++ b/src/extension/background-script/actions/permissions/get.ts
@@ -1,0 +1,23 @@
+import { MessagePermissionGet, DbPermission } from "~/types";
+
+import db from "../../db";
+
+const getPermission = async (
+  message: MessagePermissionGet
+): Promise<{ data: DbPermission } | { error: string }> => {
+  const { host, method } = message.args;
+
+  const permission = await db.permissions
+    .where("host")
+    .equalsIgnoreCase(host) // or rather get by allowanceID?
+    .and((p) => p.method === method)
+    .first();
+
+  if (!permission?.id) {
+    return { error: "No permission found for this method" };
+  }
+
+  return { data: permission };
+};
+
+export default getPermission;

--- a/src/extension/background-script/actions/permissions/index.ts
+++ b/src/extension/background-script/actions/permissions/index.ts
@@ -1,0 +1,5 @@
+import add from "./add";
+import deletePermission from "./delete";
+import get from "./get";
+
+export { add, get, deletePermission };

--- a/src/extension/background-script/db.ts
+++ b/src/extension/background-script/db.ts
@@ -1,12 +1,18 @@
 import Dexie from "dexie";
 import "fake-indexeddb/auto";
 import browser from "webextension-polyfill";
-import type { DbAllowance, DbPayment, DbBlocklist } from "~/types";
+import type {
+  DbAllowance,
+  DbPayment,
+  DbBlocklist,
+  DbPermission,
+} from "~/types";
 
 class DB extends Dexie {
   allowances: Dexie.Table<DbAllowance, number>;
   payments: Dexie.Table<DbPayment, number>;
   blocklist: Dexie.Table<DbBlocklist, number>;
+  permissions: Dexie.Table<DbPermission, number>;
 
   constructor() {
     super("LBE");
@@ -19,20 +25,29 @@ class DB extends Dexie {
     this.version(2).stores({
       blocklist: "++id,host,name,imageURL,isBlocked,createdAt",
     });
+    this.version(3).stores({
+      allowances:
+        "++id,&host,name,imageURL,tag,enabled,totalBudget,remainingBudget,lastPaymentAt,lnurlAuth,*permissions,createdAt",
+      permissions: "++id,allowanceId,host,method,enabled,blocked,createdAt",
+    });
     this.on("ready", this.loadFromStorage.bind(this));
     this.allowances = this.table("allowances");
     this.payments = this.table("payments");
     this.blocklist = this.table("blocklist");
+    this.permissions = this.table("permissions");
   }
 
   async saveToStorage() {
     const allowanceArray = await this.allowances.toArray();
     const paymentsArray = await this.payments.toArray();
     const blocklistArray = await this.blocklist.toArray();
+    const permissionsArray = await this.permissions.toArray();
+
     await browser.storage.local.set({
       allowances: allowanceArray,
       payments: paymentsArray,
       blocklist: blocklistArray,
+      permissions: permissionsArray,
     });
     return true;
   }
@@ -43,9 +58,11 @@ class DB extends Dexie {
   // In that case we don't do anything as this would cause conflicts and errors.
   // (this could use some DRY-up)
   async loadFromStorage() {
+    console.info(`Current DB version: ${this.verno}`);
     console.info("Loading DB data from storage");
+
     return browser.storage.local
-      .get(["allowances", "payments", "blocklist"])
+      .get(["allowances", "payments", "blocklist", "permissions"])
       .then((result) => {
         const allowancePromise = this.allowances.count().then((count) => {
           // if the DB already has entries we do not need to add the data from the browser storage. We then already have the data in the indexeddb
@@ -92,11 +109,27 @@ class DB extends Dexie {
           }
         });
 
+        const permissionsPromise = this.permissions.count().then((count) => {
+          // if the DB already has entries we do not need to add the data from the browser storage. We then already have the data in the indexeddb
+          if (count > 0) {
+            console.info(`Found ${count} permissions already in the DB`);
+            return;
+          } else if (result.permissions && result.permissions.length > 0) {
+            // adding the data from the browser storage
+            return this.permissions
+              .bulkAdd(result.permissions)
+              .catch(Dexie.BulkError, function (e) {
+                console.error("Failed to add permissions; ignoring", e);
+              });
+          }
+        });
+
         // wait for all allowances and payments to be loaded
         return Promise.all([
           allowancePromise,
           paymentsPromise,
           blocklistPromise,
+          permissionsPromise,
         ]);
       })
       .catch((e) => {

--- a/src/extension/background-script/migrations/__tests__/legacylnurlauth.test.ts
+++ b/src/extension/background-script/migrations/__tests__/legacylnurlauth.test.ts
@@ -24,6 +24,7 @@ describe("With lnurlAuth enabled allowance", () => {
       totalBudget: 500,
       createdAt: "123456",
       tag: "",
+      permissions: [],
     },
   ];
 
@@ -49,6 +50,7 @@ describe("Without lnurlAuth enabled allowance", () => {
       totalBudget: 500,
       createdAt: "123456",
       tag: "",
+      permissions: [],
     },
   ];
 
@@ -74,6 +76,7 @@ describe("Migrations already executed", () => {
       totalBudget: 500,
       createdAt: "123456",
       tag: "",
+      permissions: [],
     },
   ];
 

--- a/src/extension/background-script/router.ts
+++ b/src/extension/background-script/router.ts
@@ -6,6 +6,7 @@ import * as ln from "./actions/ln";
 import lnurl, { auth } from "./actions/lnurl";
 import * as nostr from "./actions/nostr";
 import * as payments from "./actions/payments";
+import * as permissions from "./actions/permissions";
 import * as settings from "./actions/settings";
 import * as setup from "./actions/setup";
 import * as webln from "./actions/webln";
@@ -55,6 +56,9 @@ const routes = {
     getPrivateKey: nostr.getPrivateKey,
     setPrivateKey: nostr.setPrivateKey,
   },
+  addPermission: permissions.add,
+  deletePermission: permissions.deletePermission,
+  getPermission: permissions.get,
 
   // Public calls are accessible from inpage scripts
   public: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,6 +179,32 @@ export interface MessageAccountAll extends MessageDefault {
   action: "getAccounts";
 }
 
+export interface MessagePermissionAdd extends MessageDefault {
+  args: {
+    host: string;
+    method: string;
+    enabled: boolean;
+    blocked: boolean;
+  };
+  action: "addPermission";
+}
+
+export interface MessagePermissionDelete extends MessageDefault {
+  args: {
+    host: string;
+    method: string;
+  };
+  action: "deletePermission";
+}
+
+export interface MessagePermissionGet extends MessageDefault {
+  args: {
+    host: string;
+    method: string;
+  };
+  action: "getPermission";
+}
+
 export interface MessageBlocklistAdd extends MessageDefault {
   args: {
     host: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -467,6 +467,16 @@ export interface DbPayment {
   totalFees: number;
 }
 
+export interface DbPermission {
+  id?: number;
+  createdAt: string;
+  allowanceId: number;
+  host: string;
+  method: string;
+  enabled: boolean;
+  blocked: boolean;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Payment extends Omit<DbPayment, "id"> {
   id: number;
@@ -523,6 +533,7 @@ export interface DbAllowance {
   remainingBudget: number;
   tag: string;
   totalBudget: number;
+  permissions: DbPermission["method"][];
 }
 export interface Allowance extends Omit<DbAllowance, "id"> {
   id: number;


### PR DESCRIPTION
### Describe the changes you have made in this PR

This is the first step of the meta ticket https://github.com/getAlby/meta/issues/230
which extends the DB with a new table "permissions"  
and extends allowances with an "permissions" array.

The DB needs to have a new version for these changes.
See https://dexie.org/docs/Tutorial/Design#database-versioning
and https://dexie.org/docs/Dexie/Dexie.version()

### Notes

The permissions for an allowance are a MultiEntry Index (array).
This comes with some browser limitation.
https://dexie.org/docs/MultiEntry-Index

> Not working in:
>     Internet Explorer 10, 11
>     Non-chromium based Microsoft Edge browsers
>     Safari 8, 9.

**Is that a problem ?**


### Link this PR to an issue [optional]

Closes https://github.com/getAlby/lightning-browser-extension/issues/1692

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### How has this been tested?

Used the new permission actions and logged the DB changes
Also added a few basic unit tests.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
