### PR TITLE
fix: fetch from description element

### DIFF
--- a/src/extension/content-script/batteries/Reddit.ts
+++ b/src/extension/content-script/batteries/Reddit.ts
@@ -17,7 +17,10 @@ function battery(): void {
 
   const content = descriptionElement.content.split(/:(.*)/s);
   const userName = content[0];
-  const description = content[1].slice(1);
+  const description =
+    document.querySelector<HTMLMetaElement>(
+      `h4 + a[href*='user/${userName.split("/")[1]}'] + div`
+    )?.textContent ?? content[1].slice(1);
 
   let match;
   let recipient;


### PR DESCRIPTION
### Describe the changes you have made in this PR

We've been fetching the description from meta description tag but that's gets cut when it exceeds a character limit thereby not showing the ln address in the description which is in the ending... Hence it works in https://www.reddit.com/user/derbumi but not in https://www.reddit.com/user/maxirosson

### Link this PR to an issue [optional]

Fixes #1710

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

<img width="398" alt="Screenshot 2022-11-07 at 2 23 18 PM" src="https://user-images.githubusercontent.com/64399555/200268485-c91d5a8a-a19c-4938-8939-3561e9b28a1d.png">

### How has this been tested?

Manually here: https://www.reddit.com/user/maxirosson

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
