### PR TITLE
fix: highlight menu icon dots

### DIFF
--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -148,7 +148,7 @@ function AccountsScreen() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <Menu as="div" className="relative">
-                      <Menu.Button className="ml-auto flex items-center text-gray-700 hover:text-black transition-color duration-200 dark:hover:text-white">
+                      <Menu.Button className="ml-auto flex items-center transition-color duration-200 rounded border-2 border-gray-500 hover:border-black dark:hover:border-white text-gray-500 hover:text-black dark:hover:text-white">
                         <EllipsisIcon className="h-6 w-6 rotate-90" />
                       </Menu.Button>
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

Highlights the menu button using a border

### Link this PR to an issue [optional]

Fixes #1656

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

Normal:
<img width="49" alt="Screenshot 2022-11-07 at 3 59 20 PM" src="https://user-images.githubusercontent.com/64399555/200289017-9f409e5b-c873-4751-a724-cd34a80a2c6d.png">
Normal (On hover):
<img width="47" alt="Screenshot 2022-11-07 at 3 59 29 PM" src="https://user-images.githubusercontent.com/64399555/200289028-97d7a80e-7766-49bb-9dc6-7b1495b422f8.png">
Dark:
<img width="49" alt="Screenshot 2022-11-07 at 3 59 44 PM" src="https://user-images.githubusercontent.com/64399555/200289033-a3993188-5a5b-4ebe-a980-c201b4fa8c46.png">
Dark (On hover):
<img width="50" alt="Screenshot 2022-11-07 at 3 59 51 PM" src="https://user-images.githubusercontent.com/64399555/200289038-40b477a1-cb4a-4423-8668-bf581896e8da.png">

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
