### PR TITLE
feat: handle organization pages

### DIFF
--- a/src/extension/content-script/batteries/GitHub.ts
+++ b/src/extension/content-script/batteries/GitHub.ts
@@ -11,7 +11,10 @@ const battery = (): void => {
   if (username && repo) {
     handleRepositoryPage(username);
   } else if (username) {
-    handleProfilePage();
+    const lightningData = handleProfilePage() || handleOrganizationPage();
+    if (lightningData) {
+      setLightningData([lightningData]);
+    }
   }
 };
 
@@ -39,30 +42,55 @@ function handleProfilePage() {
   );
 
   // This is not a GitHub profile
-  if (!shortBioElement) return;
+  if (!shortBioElement) return null;
 
   const address =
     parseElement(".Layout-sidebar .h-card") ||
     parseElement(".Layout-main article");
 
-  if (!address) return;
+  if (!address) return null;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: address,
-      ...getOriginData(),
-      description: shortBioElement?.innerText ?? "",
-      name:
-        document.querySelector<HTMLHeadingElement>(
-          '.Layout-sidebar .h-card [itemprop="name"]'
-        )?.innerText ?? "",
-      icon:
-        document.querySelector<HTMLImageElement>(
-          `.Layout-sidebar .h-card img.avatar-user`
-        )?.src ?? "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: address,
+    ...getOriginData(),
+    description: shortBioElement?.innerText ?? "",
+    name:
+      document.querySelector<HTMLHeadingElement>(
+        '.Layout-sidebar .h-card [itemprop="name"]'
+      )?.innerText ?? "",
+    icon:
+      document.querySelector<HTMLImageElement>(
+        `.Layout-sidebar .h-card img.avatar-user`
+      )?.src ?? "",
+  };
+}
+
+function handleOrganizationPage() {
+  const orgName = document.querySelector<HTMLHeadingElement>(
+    ".pagehead.orghead h1"
+  );
+  const shortBioElement = document.querySelector<HTMLElement>(
+    ".pagehead.orghead h1+div"
+  );
+
+  if (!orgName) return null;
+
+  const address =
+    parseElement(".pagehead.orghead h1+div") || parseElement("article");
+
+  if (!address) return null;
+
+  return {
+    method: "lnurl",
+    address: address,
+    ...getOriginData(),
+    description: shortBioElement?.innerText ?? "",
+    name: orgName.innerText,
+    icon:
+      document.querySelector<HTMLImageElement>(`.pagehead.orghead img.avatar`)
+        ?.src ?? "",
+  };
 }
 
 function handleRepositoryPage(username: string) {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Handles both org pages and profile pages separately.

### Link this PR to an issue [optional]

Fixes #1709

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

1) Org Page 2. Profile Page
<p>
<img src="https://user-images.githubusercontent.com/64399555/200311288-348b57c8-f333-4613-908e-b94231d57250.png" width="49.5%" />
<img src="https://user-images.githubusercontent.com/64399555/200311301-c0c2d50a-f0ed-447c-bbc2-03038fc969c9.png" width="49.5%"/>
</p>

### How has this been tested?

Tested manually in @dipien and @im-adithya

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
