### PR TITLE
feat: format sats and fiat with current locale

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,6 +10,22 @@ import { server } from "./tests/unit/helpers/server";
 // fix "This script should only be loaded in a browser extension." e.g. https://github.com/mozilla/webextension-polyfill/issues/218
 if (!chrome.runtime.id) chrome.runtime.id = "history-delete";
 
+// getTheme checks for matchMedia, which is not included in JSDOM
+// see https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
 beforeAll(() => {
   // Enable the mocking in tests.
   server.listen();

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -95,7 +95,7 @@ function AccountMenu({ showOptions = true }: Props) {
               {balancesDecorated.satsBalance}
             </span>
             {!!balancesDecorated.fiatBalance && (
-              <span className="text-xs text-gray-600 dark:text-neutral-400">
+              <span className="text-xs text-gray-600 dark:text-neutral-400 ml-2">
                 ~{balancesDecorated.fiatBalance}
               </span>
             )}

--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -13,7 +13,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: mockGetFiatValue,
+  getFormattedFiat: mockGetFiatValue,
 });
 
 jest.mock("~/common/lib/utils");

--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -14,6 +14,8 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   isLoading: false,
   updateSetting: jest.fn(),
   getFormattedFiat: mockGetFiatValue,
+  getFormattedNumber: jest.fn(),
+  getFormattedSats: jest.fn(),
 });
 
 jest.mock("~/common/lib/utils");

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -25,7 +25,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -39,13 +39,13 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   useEffect(() => {
     if (budget !== "" && showFiat) {
       const getFiat = async () => {
-        const res = await getFiatValue(budget);
+        const res = await getFormattedFiat(budget);
         setFiatAmount(res);
       };
 
       getFiat();
     }
-  }, [budget, showFiat, getFiatValue]);
+  }, [budget, showFiat, getFormattedFiat]);
 
   function openModal() {
     setBudget(allowance.totalBudget.toString());

--- a/src/app/components/PaymentSummary/index.test.tsx
+++ b/src/app/components/PaymentSummary/index.test.tsx
@@ -2,7 +2,16 @@ import PaymentSummary, { Props } from "@components/PaymentSummary";
 import { render, screen } from "@testing-library/react";
 import { I18nextProvider } from "react-i18next";
 import { BrowserRouter } from "react-router-dom";
+import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import i18n from "~/../tests/unit/helpers/i18n";
+import * as SettingsContext from "~/app/context/SettingsContext";
+
+jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+  settings: mockSettings,
+  isLoading: false,
+  updateSetting: jest.fn(),
+  getFiatValue: jest.fn(),
+});
 
 const defaultProps = {
   amount: "1234",
@@ -22,7 +31,7 @@ describe("PaymentSummary", () => {
   test("renders correctly with default props", () => {
     renderComponent();
 
-    expect(screen.getByText("1234 sats")).toBeDefined();
+    expect(screen.getByText("1,234 sats")).toBeDefined();
     expect(screen.queryByText("Description")).toBeNull();
     expect(screen.queryByTestId("fiat_amount")).toBeNull();
   });
@@ -32,7 +41,7 @@ describe("PaymentSummary", () => {
       description: "The lovely description",
     });
 
-    expect(screen.getByText("1234 sats")).toBeDefined();
+    expect(screen.getByText("1,234 sats")).toBeDefined();
     expect(screen.getByText("Description")).toBeDefined();
     expect(screen.getByText("The lovely description")).toBeDefined();
   });

--- a/src/app/components/PaymentSummary/index.test.tsx
+++ b/src/app/components/PaymentSummary/index.test.tsx
@@ -1,16 +1,19 @@
 import PaymentSummary, { Props } from "@components/PaymentSummary";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { I18nextProvider } from "react-i18next";
 import { BrowserRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import i18n from "~/../tests/unit/helpers/i18n";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
+// calls in SettingsProvider
+jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
+  return {
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
+  };
 });
 
 const defaultProps = {
@@ -19,25 +22,30 @@ const defaultProps = {
 };
 
 describe("PaymentSummary", () => {
-  const renderComponent = (props?: Partial<Props>) =>
-    render(
-      <BrowserRouter>
-        <I18nextProvider i18n={i18n}>
-          <PaymentSummary {...defaultProps} {...props} />
-        </I18nextProvider>
-      </BrowserRouter>
-    );
+  const renderComponent = async (props?: Partial<Props>) => {
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <SettingsProvider>
+              <PaymentSummary {...defaultProps} {...props} />
+            </SettingsProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+    });
+  };
 
-  test("renders correctly with default props", () => {
-    renderComponent();
+  test("renders correctly with default props", async () => {
+    await renderComponent();
 
     expect(screen.getByText("1,234 sats")).toBeDefined();
     expect(screen.queryByText("Description")).toBeNull();
     expect(screen.queryByTestId("fiat_amount")).toBeNull();
   });
 
-  test("renders with description", () => {
-    renderComponent({
+  test("renders with description", async () => {
+    await renderComponent({
       description: "The lovely description",
     });
 
@@ -46,8 +54,8 @@ describe("PaymentSummary", () => {
     expect(screen.getByText("The lovely description")).toBeDefined();
   });
 
-  test("renders with fiat amount", () => {
-    renderComponent({
+  test("renders with fiat amount", async () => {
+    await renderComponent({
       fiatAmount: "$0,02",
     });
 

--- a/src/app/components/PaymentSummary/index.test.tsx
+++ b/src/app/components/PaymentSummary/index.test.tsx
@@ -10,7 +10,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 const defaultProps = {

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "~/app/context/SettingsContext";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 export type Props = {
   amount: string | number;
@@ -17,13 +16,13 @@ const PaymentSummary: FC<Props> = ({
   fiatAmount,
 }) => {
   const { t: tCommon } = useTranslation("common");
-  const { settings } = useSettings();
+  const { getFormattedSats } = useSettings();
 
   return (
     <dl className="mb-0">
       <dt className="font-medium dark:text-white">{tCommon("amount")}</dt>
       <dd className="text-gray-500 dark:text-neutral-400">
-        {getFormattedSats({ amount, locale: settings.locale })}
+        {getFormattedSats(amount)}
         {!!fiatAmount && (
           <span className="text-gray-400" data-testid="fiat_amount">
             {" "}

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "~/app/context/SettingsContext";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 export type Props = {
   amount: string | number;
@@ -23,7 +23,7 @@ const PaymentSummary: FC<Props> = ({
     <dl className="mb-0">
       <dt className="font-medium dark:text-white">{tCommon("amount")}</dt>
       <dd className="text-gray-500 dark:text-neutral-400">
-        {getSatValue({ amount, locale: settings.locale })}
+        {getFormattedSats({ amount, locale: settings.locale })}
         {!!fiatAmount && (
           <span className="text-gray-400" data-testid="fiat_amount">
             {" "}

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -1,8 +1,10 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
+import { useSettings } from "~/app/context/SettingsContext";
+import { getSatValue } from "~/common/utils/currencyConvert";
 
 export type Props = {
-  amount: string | React.ReactNode;
+  amount: string | number;
   amountAlt?: string;
   description?: string | React.ReactNode;
   fiatAmount: string;
@@ -15,11 +17,13 @@ const PaymentSummary: FC<Props> = ({
   fiatAmount,
 }) => {
   const { t: tCommon } = useTranslation("common");
+  const { settings } = useSettings();
+
   return (
     <dl className="mb-0">
       <dt className="font-medium dark:text-white">{tCommon("amount")}</dt>
       <dd className="text-gray-500 dark:text-neutral-400">
-        {amount} {tCommon("sats", { count: amount as number })}
+        {getSatValue({ amount, locale: settings.locale })}
         {!!fiatAmount && (
           <span className="text-gray-400" data-testid="fiat_amount">
             {" "}

--- a/src/app/components/PublishersTable/index.tsx
+++ b/src/app/components/PublishersTable/index.tsx
@@ -2,7 +2,7 @@ import { CaretRightIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "~/app/context/SettingsContext";
 import {
-  getSatValue,
+  getFormattedSats,
   getFormattedNumber,
 } from "~/common/utils/currencyConvert";
 import { Publisher } from "~/types";
@@ -70,7 +70,7 @@ export default function PublishersTable({
                       {tComponents("payments")}{" "}
                       {publisher.paymentsAmount > 0 && (
                         <span>
-                          {getSatValue({
+                          {getFormattedSats({
                             amount: publisher.paymentsAmount,
                             locale: settings.locale,
                           })}

--- a/src/app/components/PublishersTable/index.tsx
+++ b/src/app/components/PublishersTable/index.tsx
@@ -1,5 +1,10 @@
 import { CaretRightIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { useTranslation } from "react-i18next";
+import { useSettings } from "~/app/context/SettingsContext";
+import {
+  getSatValue,
+  getFormattedNumber,
+} from "~/common/utils/currencyConvert";
 import { Publisher } from "~/types";
 
 import Badge from "../Badge";
@@ -17,6 +22,7 @@ export default function PublishersTable({
   publishers,
   navigateToPublisher,
 }: Props) {
+  const { settings } = useSettings();
   const { t: tComponents } = useTranslation("components", {
     keyPrefix: "publishers_table",
   });
@@ -64,9 +70,10 @@ export default function PublishersTable({
                       {tComponents("payments")}{" "}
                       {publisher.paymentsAmount > 0 && (
                         <span>
-                          ({publisher.paymentsAmount}{" "}
-                          {tCommon("sats", { count: publisher.paymentsAmount })}
-                          )
+                          {getSatValue({
+                            amount: publisher.paymentsAmount,
+                            locale: settings.locale,
+                          })}
                         </span>
                       )}
                     </div>
@@ -77,7 +84,15 @@ export default function PublishersTable({
                 {publisher.totalBudget > 0 && (
                   <div className="ml-40">
                     <p className="text-lg text-gray-500 mb-0 dark:text-neutral-400">
-                      {publisher.usedBudget} / {publisher.totalBudget}{" "}
+                      {getFormattedNumber({
+                        amount: publisher.usedBudget,
+                        locale: settings.locale,
+                      })}{" "}
+                      /{" "}
+                      {getFormattedNumber({
+                        amount: publisher.totalBudget,
+                        locale: settings.locale,
+                      })}{" "}
                       {tCommon("sats", { count: publisher.usedBudget })}{" "}
                       {tComponents("used")}
                     </p>

--- a/src/app/components/PublishersTable/index.tsx
+++ b/src/app/components/PublishersTable/index.tsx
@@ -1,10 +1,6 @@
 import { CaretRightIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "~/app/context/SettingsContext";
-import {
-  getFormattedSats,
-  getFormattedNumber,
-} from "~/common/utils/currencyConvert";
 import { Publisher } from "~/types";
 
 import Badge from "../Badge";
@@ -22,7 +18,7 @@ export default function PublishersTable({
   publishers,
   navigateToPublisher,
 }: Props) {
-  const { settings } = useSettings();
+  const { getFormattedSats, getFormattedNumber } = useSettings();
   const { t: tComponents } = useTranslation("components", {
     keyPrefix: "publishers_table",
   });
@@ -70,10 +66,7 @@ export default function PublishersTable({
                       {tComponents("payments")}{" "}
                       {publisher.paymentsAmount > 0 && (
                         <span>
-                          {getFormattedSats({
-                            amount: publisher.paymentsAmount,
-                            locale: settings.locale,
-                          })}
+                          {getFormattedSats(publisher.paymentsAmount)}
                         </span>
                       )}
                     </div>
@@ -84,15 +77,8 @@ export default function PublishersTable({
                 {publisher.totalBudget > 0 && (
                   <div className="ml-40">
                     <p className="text-lg text-gray-500 mb-0 dark:text-neutral-400">
-                      {getFormattedNumber({
-                        amount: publisher.usedBudget,
-                        locale: settings.locale,
-                      })}{" "}
-                      /{" "}
-                      {getFormattedNumber({
-                        amount: publisher.totalBudget,
-                        locale: settings.locale,
-                      })}{" "}
+                      {getFormattedNumber(publisher.usedBudget)} /{" "}
+                      {getFormattedNumber(publisher.totalBudget)}{" "}
                       {tCommon("sats", { count: publisher.usedBudget })}{" "}
                       {tComponents("used")}
                     </p>

--- a/src/app/components/TransactionsTable/index.test.tsx
+++ b/src/app/components/TransactionsTable/index.test.tsx
@@ -5,16 +5,18 @@ import { I18nextProvider } from "react-i18next";
 import { BrowserRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import i18n from "~/../tests/unit/helpers/i18n";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 
 import TransactionsTable from ".";
 import type { Props } from ".";
 
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
+jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
+  return {
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
+  };
 });
 
 const transactions: Props = {
@@ -106,15 +108,17 @@ describe("TransactionsTable", () => {
     render(
       <BrowserRouter>
         <I18nextProvider i18n={i18n}>
-          <TransactionsTable {...transactions} />
+          <SettingsProvider>
+            <TransactionsTable {...transactions} />
+          </SettingsProvider>
         </I18nextProvider>
       </BrowserRouter>
     );
 
     expect(screen.getByText("Alby")).toBeInTheDocument();
     expect(screen.getByText(/5 days ago/)).toBeInTheDocument();
-    expect(screen.getByText(/-1,234,000 sats/)).toBeInTheDocument();
-    expect(screen.getByText(/~\$241.02/)).toBeInTheDocument();
+    expect(await screen.findByText(/-1,234,000 sats/)).toBeInTheDocument();
+    expect(await screen.findByText(/~\$241.02/)).toBeInTheDocument();
 
     const disclosureButton = screen.getByRole("button");
 
@@ -130,15 +134,17 @@ describe("TransactionsTable", () => {
     render(
       <BrowserRouter>
         <I18nextProvider i18n={i18n}>
-          <TransactionsTable {...invoices} />
+          <SettingsProvider>
+            <TransactionsTable {...invoices} />
+          </SettingsProvider>
         </I18nextProvider>
       </BrowserRouter>
     );
 
-    expect(screen.getByText("lambo lambo")).toBeInTheDocument();
-    expect(screen.getByText(/4 days ago/)).toBeInTheDocument();
-    expect(screen.getByText(/\+66,666 sats/)).toBeInTheDocument();
-    expect(screen.getByText(/~\$13.02/)).toBeInTheDocument();
+    expect(await screen.findByText("lambo lambo")).toBeInTheDocument();
+    expect(await screen.findByText(/4 days ago/)).toBeInTheDocument();
+    expect(await screen.findByText(/\+66,666 sats/)).toBeInTheDocument();
+    expect(await screen.findByText(/~\$13.02/)).toBeInTheDocument();
 
     const disclosureButtons = screen.queryByRole("button");
     expect(disclosureButtons).not.toBeInTheDocument();
@@ -150,15 +156,17 @@ describe("TransactionsTable", () => {
     render(
       <BrowserRouter>
         <I18nextProvider i18n={i18n}>
-          <TransactionsTable {...invoicesWithBoostagram} />
+          <SettingsProvider>
+            <TransactionsTable {...invoicesWithBoostagram} />
+          </SettingsProvider>
         </I18nextProvider>
       </BrowserRouter>
     );
 
     expect(screen.getByText("dumplings")).toBeInTheDocument();
     expect(screen.getByText(/5 days ago/)).toBeInTheDocument();
-    expect(screen.getByText(/\+88,888 sats/)).toBeInTheDocument();
-    expect(screen.getByText(/~\$17.36/)).toBeInTheDocument();
+    expect(await screen.findByText(/\+88,888 sats/)).toBeInTheDocument();
+    expect(await screen.findByText(/~\$17.36/)).toBeInTheDocument();
 
     const disclosureButtons = screen.getAllByRole("button");
     expect(disclosureButtons).toHaveLength(1);

--- a/src/app/components/TransactionsTable/index.test.tsx
+++ b/src/app/components/TransactionsTable/index.test.tsx
@@ -3,10 +3,19 @@ import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { I18nextProvider } from "react-i18next";
 import { BrowserRouter } from "react-router-dom";
+import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import i18n from "~/../tests/unit/helpers/i18n";
+import * as SettingsContext from "~/app/context/SettingsContext";
 
 import TransactionsTable from ".";
 import type { Props } from ".";
+
+jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+  settings: mockSettings,
+  isLoading: false,
+  updateSetting: jest.fn(),
+  getFiatValue: jest.fn(),
+});
 
 const transactions: Props = {
   transactions: [
@@ -104,7 +113,7 @@ describe("TransactionsTable", () => {
 
     expect(screen.getByText("Alby")).toBeInTheDocument();
     expect(screen.getByText(/5 days ago/)).toBeInTheDocument();
-    expect(screen.getByText(/-1234000 sats/)).toBeInTheDocument();
+    expect(screen.getByText(/-1,234,000 sats/)).toBeInTheDocument();
     expect(screen.getByText(/~\$241.02/)).toBeInTheDocument();
 
     const disclosureButton = screen.getByRole("button");
@@ -128,7 +137,7 @@ describe("TransactionsTable", () => {
 
     expect(screen.getByText("lambo lambo")).toBeInTheDocument();
     expect(screen.getByText(/4 days ago/)).toBeInTheDocument();
-    expect(screen.getByText(/\+66666 sats/)).toBeInTheDocument();
+    expect(screen.getByText(/\+66,666 sats/)).toBeInTheDocument();
     expect(screen.getByText(/~\$13.02/)).toBeInTheDocument();
 
     const disclosureButtons = screen.queryByRole("button");
@@ -148,7 +157,7 @@ describe("TransactionsTable", () => {
 
     expect(screen.getByText("dumplings")).toBeInTheDocument();
     expect(screen.getByText(/5 days ago/)).toBeInTheDocument();
-    expect(screen.getByText(/\+88888 sats/)).toBeInTheDocument();
+    expect(screen.getByText(/\+88,888 sats/)).toBeInTheDocument();
     expect(screen.getByText(/~\$17.36/)).toBeInTheDocument();
 
     const disclosureButtons = screen.getAllByRole("button");

--- a/src/app/components/TransactionsTable/index.test.tsx
+++ b/src/app/components/TransactionsTable/index.test.tsx
@@ -14,7 +14,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 const transactions: Props = {

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -3,7 +3,7 @@ import { Disclosure } from "@headlessui/react";
 import { useTranslation } from "react-i18next";
 import Button from "~/app/components/Button";
 import { useSettings } from "~/app/context/SettingsContext";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 import { Transaction } from "~/types";
 
 import Badge from "../Badge";
@@ -66,7 +66,7 @@ export default function TransactionsTable({ transactions }: Props) {
                           {[tx.type && "sent", "sending"].includes(tx.type)
                             ? "-"
                             : "+"}
-                          {getSatValue({
+                          {getFormattedSats({
                             amount: tx.totalAmount,
                             locale: settings.locale,
                           })}
@@ -131,7 +131,7 @@ export default function TransactionsTable({ transactions }: Props) {
                                 {tComponents("transactionsTable.fee")}
                               </span>
                               <br />
-                              {getSatValue({
+                              {getFormattedSats({
                                 amount: tx.totalFees,
                                 locale: settings.locale,
                               })}

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -2,6 +2,8 @@ import { CaretDownIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { Disclosure } from "@headlessui/react";
 import { useTranslation } from "react-i18next";
 import Button from "~/app/components/Button";
+import { useSettings } from "~/app/context/SettingsContext";
+import { getSatValue } from "~/common/utils/currencyConvert";
 import { Transaction } from "~/types";
 
 import Badge from "../Badge";
@@ -11,7 +13,7 @@ export type Props = {
 };
 
 export default function TransactionsTable({ transactions }: Props) {
-  const { t: tCommon } = useTranslation("common");
+  const { settings } = useSettings();
   const { t: tComponents } = useTranslation("components");
 
   return (
@@ -64,8 +66,10 @@ export default function TransactionsTable({ transactions }: Props) {
                           {[tx.type && "sent", "sending"].includes(tx.type)
                             ? "-"
                             : "+"}
-                          {tx.totalAmount}{" "}
-                          {tCommon("sats", { count: tx.totalAmount as number })}
+                          {getSatValue({
+                            amount: tx.totalAmount,
+                            locale: settings.locale,
+                          })}
                         </p>
                         {!!tx.totalAmountFiat && (
                           <p className="text-xs text-gray-600 dark:text-neutral-400">
@@ -127,8 +131,10 @@ export default function TransactionsTable({ transactions }: Props) {
                                 {tComponents("transactionsTable.fee")}
                               </span>
                               <br />
-                              {tx.totalFees}{" "}
-                              {tCommon("sats", { count: tx.totalFees })}
+                              {getSatValue({
+                                amount: tx.totalFees,
+                                locale: settings.locale,
+                              })}
                             </p>
                           )}
                           {tx.location && (

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -3,7 +3,6 @@ import { Disclosure } from "@headlessui/react";
 import { useTranslation } from "react-i18next";
 import Button from "~/app/components/Button";
 import { useSettings } from "~/app/context/SettingsContext";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 import { Transaction } from "~/types";
 
 import Badge from "../Badge";
@@ -13,7 +12,7 @@ export type Props = {
 };
 
 export default function TransactionsTable({ transactions }: Props) {
-  const { settings } = useSettings();
+  const { getFormattedSats } = useSettings();
   const { t: tComponents } = useTranslation("components");
 
   return (
@@ -66,10 +65,7 @@ export default function TransactionsTable({ transactions }: Props) {
                           {[tx.type && "sent", "sending"].includes(tx.type)
                             ? "-"
                             : "+"}
-                          {getFormattedSats({
-                            amount: tx.totalAmount,
-                            locale: settings.locale,
-                          })}
+                          {getFormattedSats(tx.totalAmount)}
                         </p>
                         {!!tx.totalAmountFiat && (
                           <p className="text-xs text-gray-600 dark:text-neutral-400">
@@ -131,10 +127,7 @@ export default function TransactionsTable({ transactions }: Props) {
                                 {tComponents("transactionsTable.fee")}
                               </span>
                               <br />
-                              {getFormattedSats({
-                                amount: tx.totalFees,
-                                locale: settings.locale,
-                              })}
+                              {getFormattedSats(tx.totalFees)}
                             </p>
                           )}
                           {tx.location && (

--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -81,14 +81,22 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
     [getFiatValue]
   );
 
+  const updateSatValue = (amount: number) => {
+    const sats = getSatValue({
+      amount,
+      locale: settings.locale,
+    });
+    setSatBalance(sats);
+  };
+
   const fetchAccountInfo = async (options?: { accountId?: string }) => {
     const id = options?.accountId || account?.id;
     if (!id) return;
 
-    const callback = async (account: AccountInfo) => {
+    const callback = (account: AccountInfo) => {
       setAccount(account);
-      const sats = await getSatValue(account.balance);
-      setSatBalance(sats);
+
+      updateSatValue(account.balance);
 
       if (!isLoadingSettings && settings.showFiat) {
         updateFiatValue(account.balance);
@@ -137,6 +145,12 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
       setFiatBalance("");
     }
   }, [showFiat, account?.balance, updateFiatValue]);
+
+  // Listen to language change
+  useEffect(() => {
+    !!account?.balance && updateSatValue(account?.balance);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.locale]);
 
   const value = {
     account,

--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -9,7 +9,7 @@ import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 import type { AccountInfo } from "~/types";
 
 interface AccountContextType {
@@ -82,7 +82,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
   );
 
   const updateSatValue = (amount: number) => {
-    const sats = getSatValue({
+    const sats = getFormattedSats({
       amount,
       locale: settings.locale,
     });

--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -9,7 +9,6 @@ import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 import type { AccountInfo } from "~/types";
 
 interface AccountContextType {
@@ -45,6 +44,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
     isLoading: isLoadingSettings,
     settings,
     getFormattedFiat,
+    getFormattedSats,
   } = useSettings();
 
   const [account, setAccount] = useState<AccountContextType["account"]>(null);
@@ -82,10 +82,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
   );
 
   const updateSatValue = (amount: number) => {
-    const sats = getFormattedSats({
-      amount,
-      locale: settings.locale,
-    });
+    const sats = getFormattedSats(amount);
     setSatBalance(sats);
   };
 

--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -44,7 +44,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
 
   const [account, setAccount] = useState<AccountContextType["account"]>(null);
@@ -75,10 +75,10 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
 
   const updateFiatValue = useCallback(
     async (balance: string | number) => {
-      const fiat = await getFiatValue(balance);
+      const fiat = await getFormattedFiat(balance);
       setFiatBalance(fiat);
     },
-    [getFiatValue]
+    [getFormattedFiat]
   );
 
   const updateSatValue = (amount: number) => {

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { getTheme } from "~/app/utils";
 import { CURRENCIES } from "~/common/constants";
 import api from "~/common/lib/api";
-import { getFiatValue as getFiatValueUtil } from "~/common/utils/currencyConvert";
+import { getFormattedFiat as getFormattedFiatUtil } from "~/common/utils/currencyConvert";
 import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
 import type { SettingsStorage } from "~/types";
 
@@ -13,7 +13,7 @@ interface SettingsContextType {
   settings: SettingsStorage;
   updateSetting: (setting: Setting) => void;
   isLoading: boolean;
-  getFiatValue: (amount: number | string) => Promise<string>;
+  getFormattedFiat: (amount: number | string) => Promise<string>;
 }
 
 type Setting = Partial<SettingsStorage>;
@@ -75,10 +75,10 @@ export const SettingsProvider = ({
     return currencyRate.current.rate;
   };
 
-  const getFiatValue = async (amount: number | string) => {
+  const getFormattedFiat = async (amount: number | string) => {
     try {
       const rate = await getCurrencyRate();
-      const value = getFiatValueUtil({
+      const value = getFormattedFiatUtil({
         amount,
         rate,
         currency: settings.currency,
@@ -110,7 +110,7 @@ export const SettingsProvider = ({
   }, [settings.theme]);
 
   const value = {
-    getFiatValue,
+    getFormattedFiat,
     settings,
     updateSetting,
     isLoading,

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -82,6 +82,7 @@ export const SettingsProvider = ({
         amount,
         rate,
         currency: settings.currency,
+        locale: settings.locale,
       });
 
       return value;

--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -5,7 +5,11 @@ import { toast } from "react-toastify";
 import { getTheme } from "~/app/utils";
 import { CURRENCIES } from "~/common/constants";
 import api from "~/common/lib/api";
-import { getFormattedFiat as getFormattedFiatUtil } from "~/common/utils/currencyConvert";
+import {
+  getFormattedFiat as getFormattedFiatUtil,
+  getFormattedSats as getFormattedSatsUtil,
+  getFormattedNumber as getFormattedNumberUtil,
+} from "~/common/utils/currencyConvert";
 import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
 import type { SettingsStorage } from "~/types";
 
@@ -14,6 +18,8 @@ interface SettingsContextType {
   updateSetting: (setting: Setting) => void;
   isLoading: boolean;
   getFormattedFiat: (amount: number | string) => Promise<string>;
+  getFormattedSats: (amount: number | string) => string;
+  getFormattedNumber: (amount: number | string) => string;
 }
 
 type Setting = Partial<SettingsStorage>;
@@ -93,6 +99,14 @@ export const SettingsProvider = ({
     }
   };
 
+  const getFormattedSats = (amount: number | string) => {
+    return getFormattedSatsUtil({ amount, locale: settings.locale });
+  };
+
+  const getFormattedNumber = (amount: number | string) => {
+    return getFormattedNumberUtil({ amount, locale: settings.locale });
+  };
+
   // update locale on every change
   useEffect(() => {
     i18n.changeLanguage(settings.locale);
@@ -111,6 +125,8 @@ export const SettingsProvider = ({
 
   const value = {
     getFormattedFiat,
+    getFormattedSats,
+    getFormattedNumber,
     settings,
     updateSetting,
     isLoading,

--- a/src/app/screens/ConfirmKeysend/index.test.tsx
+++ b/src/app/screens/ConfirmKeysend/index.test.tsx
@@ -11,6 +11,8 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
+  getFormattedNumber: jest.fn(),
+  getFormattedSats: jest.fn(() => "21 sats"),
   getFormattedFiat: jest
     .fn()
     .mockImplementationOnce(() => Promise.resolve("$0.00"))

--- a/src/app/screens/ConfirmKeysend/index.test.tsx
+++ b/src/app/screens/ConfirmKeysend/index.test.tsx
@@ -11,7 +11,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest
+  getFormattedFiat: jest
     .fn()
     .mockImplementationOnce(() => Promise.resolve("$0.00"))
     .mockImplementationOnce(() => Promise.resolve("$0.00"))

--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -31,7 +31,7 @@ function ConfirmKeysend() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -49,18 +49,18 @@ function ConfirmKeysend() {
   useEffect(() => {
     (async () => {
       if (showFiat && amount) {
-        const res = await getFiatValue(amount);
+        const res = await getFormattedFiat(amount);
         setFiatAmount(res);
       }
     })();
-  }, [amount, showFiat, getFiatValue]);
+  }, [amount, showFiat, getFormattedFiat]);
 
   useEffect(() => {
     (async () => {
-      const res = await getFiatValue(budget);
+      const res = await getFormattedFiat(budget);
       setFiatBudgetAmount(res);
     })();
-  }, [budget, showFiat, getFiatValue]);
+  }, [budget, showFiat, getFormattedFiat]);
 
   async function confirm() {
     if (rememberMe && budget) {

--- a/src/app/screens/ConfirmPayment/index.test.tsx
+++ b/src/app/screens/ConfirmPayment/index.test.tsx
@@ -38,6 +38,15 @@ jest.mock("~/app/hooks/useNavigationState", () => {
   };
 });
 
+jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+  settings: { ...mockSettings },
+  isLoading: false,
+  updateSetting: jest.fn(),
+  getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
+  getFormattedNumber: jest.fn(),
+  getFormattedSats: jest.fn(() => "25 sats"),
+});
+
 describe("ConfirmPayment", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -51,13 +60,6 @@ describe("ConfirmPayment", () => {
       },
     };
 
-    jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-      settings: { ...mockSettings },
-      isLoading: false,
-      updateSetting: jest.fn(),
-      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
-    });
-
     await act(async () => {
       render(
         <MemoryRouter>
@@ -68,7 +70,7 @@ describe("ConfirmPayment", () => {
 
     expect(await screen.findByText("Amount")).toBeInTheDocument();
     expect(await screen.findByText("Description")).toBeInTheDocument();
-    expect(screen.getByText("(~$0.01)")).toBeInTheDocument();
+    expect(await screen.findByText("(~$0.01)")).toBeInTheDocument();
     expect(
       await screen.findByLabelText("Remember and set a budget")
     ).toBeInTheDocument();
@@ -82,11 +84,13 @@ describe("ConfirmPayment", () => {
       },
     };
 
-    jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+    jest.spyOn(SettingsContext, "useSettings").mockReturnValueOnce({
       settings: { ...mockSettings, showFiat: false },
       isLoading: false,
       updateSetting: jest.fn(),
       getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
+      getFormattedNumber: jest.fn(() => "25 sats"),
+      getFormattedSats: jest.fn(),
     });
 
     const user = userEvent.setup();
@@ -99,14 +103,15 @@ describe("ConfirmPayment", () => {
       );
     });
 
-    expect(screen.getByText("25 sats")).toBeInTheDocument();
+    const satoshis = lightningPayReq.decode(paymentRequest).satoshis || 0;
+
+    expect(await screen.findByText(`${satoshis} sats`)).toBeInTheDocument();
 
     await act(() => {
       user.click(screen.getByText("Remember and set a budget"));
     });
 
     const input = await screen.findByLabelText("Budget");
-    const satoshis = lightningPayReq.decode(paymentRequest).satoshis || 0;
     expect(input).toHaveValue(satoshis * 10);
   });
 
@@ -116,13 +121,6 @@ describe("ConfirmPayment", () => {
         paymentRequest,
       },
     };
-
-    jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-      settings: { ...mockSettings },
-      isLoading: false,
-      updateSetting: jest.fn(),
-      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
-    });
 
     await act(async () => {
       render(

--- a/src/app/screens/ConfirmPayment/index.test.tsx
+++ b/src/app/screens/ConfirmPayment/index.test.tsx
@@ -55,7 +55,7 @@ describe("ConfirmPayment", () => {
       settings: { ...mockSettings },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
+      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     await act(async () => {
@@ -86,7 +86,7 @@ describe("ConfirmPayment", () => {
       settings: { ...mockSettings, showFiat: false },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
+      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     const user = userEvent.setup();
@@ -121,7 +121,7 @@ describe("ConfirmPayment", () => {
       settings: { ...mockSettings },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
+      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     await act(async () => {

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -17,13 +17,13 @@ import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 function ConfirmPayment() {
   const {
     isLoading: isLoadingSettings,
     settings,
     getFormattedFiat,
+    getFormattedSats,
   } = useSettings();
 
   const showFiat = !isLoadingSettings && settings.showFiat;
@@ -49,10 +49,7 @@ function ConfirmPayment() {
   const [fiatAmount, setFiatAmount] = useState("");
   const [fiatBudgetAmount, setFiatBudgetAmount] = useState("");
 
-  const formattedInvoiceSats = getFormattedSats({
-    amount: invoice.satoshis || 0,
-    locale: settings.locale,
-  });
+  const formattedInvoiceSats = getFormattedSats(invoice.satoshis || 0);
 
   useEffect(() => {
     (async () => {

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -23,7 +23,7 @@ function ConfirmPayment() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
 
   const showFiat = !isLoadingSettings && settings.showFiat;
@@ -57,20 +57,20 @@ function ConfirmPayment() {
   useEffect(() => {
     (async () => {
       if (showFiat && invoice.satoshis) {
-        const res = await getFiatValue(invoice.satoshis);
+        const res = await getFormattedFiat(invoice.satoshis);
         setFiatAmount(res);
       }
     })();
-  }, [invoice.satoshis, showFiat, getFiatValue]);
+  }, [invoice.satoshis, showFiat, getFormattedFiat]);
 
   useEffect(() => {
     (async () => {
       if (showFiat && budget) {
-        const res = await getFiatValue(budget);
+        const res = await getFormattedFiat(budget);
         setFiatBudgetAmount(res);
       }
     })();
-  }, [budget, showFiat, getFiatValue]);
+  }, [budget, showFiat, getFormattedFiat]);
 
   const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -17,7 +17,7 @@ import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 function ConfirmPayment() {
   const {
@@ -49,7 +49,7 @@ function ConfirmPayment() {
   const [fiatAmount, setFiatAmount] = useState("");
   const [fiatBudgetAmount, setFiatBudgetAmount] = useState("");
 
-  const formattedInvoiceSats = getSatValue({
+  const formattedInvoiceSats = getFormattedSats({
     amount: invoice.satoshis || 0,
     locale: settings.locale,
   });

--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -13,7 +13,6 @@ import { Trans, useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import { PublisherLnData } from "~/app/screens/Home/PublisherLnData";
-import { getFormattedNumber } from "~/common/utils/currencyConvert";
 import type { Allowance, Transaction, Battery } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -31,6 +30,7 @@ const AllowanceView: FC<Props> = (props) => {
     isLoading: isLoadingSettings,
     settings,
     getFormattedFiat,
+    getFormattedNumber,
   } = useSettings();
 
   const [payments, setPayments] = useState<Transaction[] | null>(null);
@@ -114,13 +114,9 @@ const AllowanceView: FC<Props> = (props) => {
             </dt>
             <dd className="flex items-center mb-0 text-sm font-medium dark:text-neutral-400">
               {+props.allowance.totalBudget > 0
-                ? `${getFormattedNumber({
-                    amount: props.allowance.usedBudget,
-                    locale: settings.locale,
-                  })} / ${getFormattedNumber({
-                    amount: props.allowance.totalBudget,
-                    locale: settings.locale,
-                  })} `
+                ? `${getFormattedNumber(
+                    props.allowance.usedBudget
+                  )} / ${getFormattedNumber(props.allowance.totalBudget)} `
                 : "0 / 0 "}
               {t("allowance_view.sats_used")}
               <div className="ml-3 w-24">

--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -13,6 +13,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import { PublisherLnData } from "~/app/screens/Home/PublisherLnData";
+import { getSatValue } from "~/common/utils/currencyConvert";
 import type { Allowance, Transaction, Battery } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -107,7 +108,13 @@ const AllowanceView: FC<Props> = (props) => {
             </dt>
             <dd className="flex items-center mb-0 text-sm font-medium dark:text-neutral-400">
               {+props.allowance.totalBudget > 0
-                ? `${props.allowance.usedBudget} / ${props.allowance.totalBudget} `
+                ? `${getSatValue({
+                    amount: props.allowance.usedBudget,
+                    locale: settings.locale,
+                  })} / ${getSatValue({
+                    amount: props.allowance.totalBudget,
+                    locale: settings.locale,
+                  })} `
                 : "0 / 0 "}
               {t("allowance_view.sats_used")}
               <div className="ml-3 w-24">

--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -13,7 +13,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import { PublisherLnData } from "~/app/screens/Home/PublisherLnData";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedNumber } from "~/common/utils/currencyConvert";
 import type { Allowance, Transaction, Battery } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -108,10 +108,10 @@ const AllowanceView: FC<Props> = (props) => {
             </dt>
             <dd className="flex items-center mb-0 text-sm font-medium dark:text-neutral-400">
               {+props.allowance.totalBudget > 0
-                ? `${getSatValue({
+                ? `${getFormattedNumber({
                     amount: props.allowance.usedBudget,
                     locale: settings.locale,
-                  })} / ${getSatValue({
+                  })} / ${getFormattedNumber({
                     amount: props.allowance.totalBudget,
                     locale: settings.locale,
                   })} `

--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -30,7 +30,7 @@ const AllowanceView: FC<Props> = (props) => {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
 
   const [payments, setPayments] = useState<Transaction[] | null>(null);
@@ -60,7 +60,7 @@ const AllowanceView: FC<Props> = (props) => {
         // attach fiatAmount if enabled
         for (const payment of payments) {
           const totalAmountFiat = showFiat
-            ? await getFiatValue(payment.totalAmount)
+            ? await getFormattedFiat(payment.totalAmount)
             : "";
           payment.totalAmountFiat = totalAmountFiat;
         }
@@ -75,7 +75,13 @@ const AllowanceView: FC<Props> = (props) => {
     };
 
     !payments && !isLoadingSettings && getPayments();
-  }, [props.allowance, isLoadingSettings, payments, getFiatValue, showFiat]);
+  }, [
+    props.allowance,
+    isLoadingSettings,
+    payments,
+    getFormattedFiat,
+    showFiat,
+  ]);
 
   return (
     <div className="overflow-y-auto no-scrollbar h-full">

--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -56,7 +56,7 @@ const DefaultView: FC<Props> = (props) => {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
 
   const showFiat = !isLoadingSettings && settings.showFiat;
@@ -88,7 +88,7 @@ const DefaultView: FC<Props> = (props) => {
         // attach fiatAmount if enabled
         for (const payment of payments) {
           const totalAmountFiat = showFiat
-            ? await getFiatValue(payment.totalAmount)
+            ? await getFormattedFiat(payment.totalAmount)
             : "";
           payment.totalAmountFiat = totalAmountFiat;
         }
@@ -102,7 +102,7 @@ const DefaultView: FC<Props> = (props) => {
     };
 
     !payments && !isLoadingSettings && getPayments();
-  }, [isLoadingSettings, payments, getFiatValue, showFiat]);
+  }, [isLoadingSettings, payments, getFormattedFiat, showFiat]);
 
   const unblock = async () => {
     try {
@@ -152,7 +152,7 @@ const DefaultView: FC<Props> = (props) => {
 
     for (const invoice of invoices) {
       const totalAmountFiat = settings.showFiat
-        ? await getFiatValue(invoice.totalAmount)
+        ? await getFormattedFiat(invoice.totalAmount)
         : "";
       invoice.totalAmountFiat = totalAmountFiat;
     }

--- a/src/app/screens/Keysend/index.test.tsx
+++ b/src/app/screens/Keysend/index.test.tsx
@@ -43,7 +43,7 @@ describe("Keysend", () => {
       settings: { ...mockSettings },
       isLoading: false,
       updateSetting: jest.fn(),
-      getFiatValue: jest.fn(() => Promise.resolve("$0.01")),
+      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
     });
 
     await act(async () => {

--- a/src/app/screens/Keysend/index.test.tsx
+++ b/src/app/screens/Keysend/index.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import type { OriginData } from "~/types";
 
 import Keysend from "./index";
@@ -37,20 +37,24 @@ jest.mock("~/app/hooks/useNavigationState", () => {
   };
 });
 
+jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
+  return {
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
+  };
+});
+
 describe("Keysend", () => {
   test("renders with fiat", async () => {
-    jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-      settings: { ...mockSettings },
-      isLoading: false,
-      updateSetting: jest.fn(),
-      getFormattedFiat: jest.fn(() => Promise.resolve("$0.01")),
-    });
-
     await act(async () => {
       render(
-        <MemoryRouter>
-          <Keysend />
-        </MemoryRouter>
+        <SettingsProvider>
+          <MemoryRouter>
+            <Keysend />
+          </MemoryRouter>
+        </SettingsProvider>
       );
     });
 

--- a/src/app/screens/Keysend/index.tsx
+++ b/src/app/screens/Keysend/index.tsx
@@ -22,7 +22,7 @@ function Keysend() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
   const navState = useNavigationState();
@@ -41,11 +41,11 @@ function Keysend() {
   useEffect(() => {
     (async () => {
       if (showFiat && amount) {
-        const res = await getFiatValue(amount);
+        const res = await getFormattedFiat(amount);
         setFiatAmount(res);
       }
     })();
-  }, [amount, showFiat, getFiatValue]);
+  }, [amount, showFiat, getFormattedFiat]);
 
   async function confirm() {
     try {

--- a/src/app/screens/LNURLChannel/index.test.tsx
+++ b/src/app/screens/LNURLChannel/index.test.tsx
@@ -1,16 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import type { LNURLDetails, OriginData } from "~/types";
 
 import LNURLChannel from "./index";
 
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
+jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
+  return {
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
+  };
 });
 
 const mockDetails: LNURLDetails = {
@@ -61,16 +63,18 @@ describe("LNURLChannel", () => {
   test("renders via Send (popup)", async () => {
     render(
       <MemoryRouter>
-        <LNURLChannel />
+        <SettingsProvider>
+          <LNURLChannel />
+        </SettingsProvider>
       </MemoryRouter>
     );
 
-    expect(await screen.getByText("Channel Request")).toBeInTheDocument();
+    expect(await screen.findByText("Channel Request")).toBeInTheDocument();
     expect(
-      await screen.getByText("Request a channel from the node:")
+      await screen.findByText("Request a channel from the node:")
     ).toBeInTheDocument();
     expect(
-      await screen.getByText(
+      await screen.findByText(
         "0331f80652fb840239df8dc99205792bba2e559a05469915804c08420230e23c7c@74.108.13.152:9735"
       )
     ).toBeInTheDocument();

--- a/src/app/screens/LNURLChannel/index.test.tsx
+++ b/src/app/screens/LNURLChannel/index.test.tsx
@@ -10,7 +10,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 const mockDetails: LNURLDetails = {

--- a/src/app/screens/LNURLPay/index.test.tsx
+++ b/src/app/screens/LNURLPay/index.test.tsx
@@ -12,7 +12,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: mockGetFiatValue,
+  getFormattedFiat: mockGetFiatValue,
 });
 
 const mockDetails: LNURLDetails = {

--- a/src/app/screens/LNURLPay/index.test.tsx
+++ b/src/app/screens/LNURLPay/index.test.tsx
@@ -13,6 +13,8 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   isLoading: false,
   updateSetting: jest.fn(),
   getFormattedFiat: mockGetFiatValue,
+  getFormattedNumber: jest.fn(),
+  getFormattedSats: jest.fn(),
 });
 
 const mockDetails: LNURLDetails = {

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -19,6 +19,7 @@ import { USER_REJECTED_ERROR } from "~/common/constants";
 import lnurl from "~/common/lib/lnurl";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
+import { getSatValue } from "~/common/utils/currencyConvert";
 import type {
   LNURLError,
   LNURLPaymentInfo,
@@ -311,9 +312,10 @@ function LNURLPay() {
           <ResultCard
             isSuccess
             message={tCommon("success_message", {
-              amount: `${valueSat} ${tCommon("sats", {
-                count: parseInt(valueSat),
-              })}`,
+              amount: getSatValue({
+                amount: valueSat,
+                locale: settings.locale,
+              }),
               fiatAmount: showFiat ? ` (${fiatValue})` : ``,
               destination: navState.origin?.name || getRecipient(),
             })}
@@ -372,11 +374,14 @@ function LNURLPay() {
                           {details.minSendable === details.maxSendable && (
                             <>
                               <Dt>{t("amount.label")}</Dt>
-                              <Dd>{`${Math.floor(
-                                +details.minSendable / 1000
-                              )} ${tCommon("sats", {
-                                count: Math.floor(+details.minSendable / 1000),
-                              })}`}</Dd>
+                              <Dd>
+                                {getSatValue({
+                                  amount: Math.floor(
+                                    +details.minSendable / 1000
+                                  ),
+                                  locale: settings.locale,
+                                })}
+                              </Dd>
                             </>
                           )}
                         </>

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -19,7 +19,7 @@ import { USER_REJECTED_ERROR } from "~/common/constants";
 import lnurl from "~/common/lib/lnurl";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 import type {
   LNURLError,
   LNURLPaymentInfo,
@@ -312,7 +312,7 @@ function LNURLPay() {
           <ResultCard
             isSuccess
             message={tCommon("success_message", {
-              amount: getSatValue({
+              amount: getFormattedSats({
                 amount: valueSat,
                 locale: settings.locale,
               }),
@@ -375,7 +375,7 @@ function LNURLPay() {
                             <>
                               <Dt>{t("amount.label")}</Dt>
                               <Dd>
-                                {getSatValue({
+                                {getFormattedSats({
                                   amount: Math.floor(
                                     +details.minSendable / 1000
                                   ),

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -19,7 +19,6 @@ import { USER_REJECTED_ERROR } from "~/common/constants";
 import lnurl from "~/common/lib/lnurl";
 import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 import type {
   LNURLError,
   LNURLPaymentInfo,
@@ -43,6 +42,7 @@ function LNURLPay() {
     isLoading: isLoadingSettings,
     settings,
     getFormattedFiat,
+    getFormattedSats,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -312,10 +312,7 @@ function LNURLPay() {
           <ResultCard
             isSuccess
             message={tCommon("success_message", {
-              amount: getFormattedSats({
-                amount: valueSat,
-                locale: settings.locale,
-              }),
+              amount: getFormattedSats(valueSat),
               fiatAmount: showFiat ? ` (${fiatValue})` : ``,
               destination: navState.origin?.name || getRecipient(),
             })}
@@ -375,12 +372,9 @@ function LNURLPay() {
                             <>
                               <Dt>{t("amount.label")}</Dt>
                               <Dd>
-                                {getFormattedSats({
-                                  amount: Math.floor(
-                                    +details.minSendable / 1000
-                                  ),
-                                  locale: settings.locale,
-                                })}
+                                {getFormattedSats(
+                                  Math.floor(+details.minSendable / 1000)
+                                )}
                               </Dd>
                             </>
                           )}

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -42,7 +42,7 @@ function LNURLPay() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -68,12 +68,12 @@ function LNURLPay() {
 
   useEffect(() => {
     const getFiat = async () => {
-      const res = await getFiatValue(valueSat);
+      const res = await getFormattedFiat(valueSat);
       setFiatValue(res);
     };
 
     getFiat();
-  }, [valueSat, showFiat, getFiatValue]);
+  }, [valueSat, showFiat, getFormattedFiat]);
 
   useEffect(() => {
     !!settings.userName && setUserName(settings.userName);

--- a/src/app/screens/LNURLWithdraw/index.test.tsx
+++ b/src/app/screens/LNURLWithdraw/index.test.tsx
@@ -14,7 +14,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 const mockDetailsFiatJef: LNURLWithdrawServiceResponse = {

--- a/src/app/screens/LNURLWithdraw/index.test.tsx
+++ b/src/app/screens/LNURLWithdraw/index.test.tsx
@@ -3,19 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { makeInvoice } from "~/common/lib/api";
 import type { LNURLWithdrawServiceResponse, OriginData } from "~/types";
 
 import LNURLWithdraw from "./index";
-
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
-});
 
 const mockDetailsFiatJef: LNURLWithdrawServiceResponse = {
   tag: "withdrawRequest",
@@ -72,13 +65,15 @@ jest.mock("~/app/hooks/useNavigationState", () => ({
   })),
 }));
 
-jest.mock("~/common/lib/api", () => ({
-  getSettings: jest.fn(() => ({
-    currency: "USD",
-    exchange: "coindesk",
-  })),
-  makeInvoice: jest.fn(() => ({})),
-}));
+jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
+  return {
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
+    makeInvoice: jest.fn(),
+  };
+});
 
 describe("LNURLWithdraw", () => {
   afterEach(() => {
@@ -89,7 +84,9 @@ describe("LNURLWithdraw", () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <LNURLWithdraw />
+          <SettingsProvider>
+            <LNURLWithdraw />
+          </SettingsProvider>
         </MemoryRouter>
       );
     });
@@ -104,7 +101,9 @@ describe("LNURLWithdraw", () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <LNURLWithdraw />
+          <SettingsProvider>
+            <LNURLWithdraw />
+          </SettingsProvider>
         </MemoryRouter>
       );
     });
@@ -133,7 +132,9 @@ describe("LNURLWithdraw", () => {
 
     render(
       <MemoryRouter>
-        <LNURLWithdraw />
+        <SettingsProvider>
+          <LNURLWithdraw />
+        </SettingsProvider>
       </MemoryRouter>
     );
 

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -15,6 +15,7 @@ import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
+import { getSatValue } from "~/common/utils/currencyConvert";
 import type { LNURLWithdrawServiceResponse } from "~/types";
 
 function LNURLWithdraw() {
@@ -71,7 +72,10 @@ function LNURLWithdraw() {
       if (response.data.status.toUpperCase() === "OK") {
         setSuccessMessage(
           t("success", {
-            amount: `${valueSat} SATS ${showFiat ? `(${fiatValue})` : ``}`,
+            amount: `${getSatValue({
+              amount: valueSat,
+              locale: settings.locale,
+            })} ${showFiat ? `(${fiatValue})` : ``}`,
             sender: origin ? origin.name : details.domain,
           })
         );
@@ -99,9 +103,10 @@ function LNURLWithdraw() {
         <>
           <ContentMessage
             heading={t("content_message.heading")}
-            content={`${Math.floor(minWithdrawable / 1000)} ${tCommon("sats", {
-              count: Math.floor(minWithdrawable / 1000),
-            })}`}
+            content={getSatValue({
+              amount: Math.floor(minWithdrawable / 1000),
+              locale: settings.locale,
+            })}
           />
 
           {errorMessage && <p className="mt-1 text-red-500">{errorMessage}</p>}

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -27,7 +27,7 @@ function LNURLWithdraw() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -46,11 +46,11 @@ function LNURLWithdraw() {
   useEffect(() => {
     if (valueSat !== "" && showFiat) {
       (async () => {
-        const res = await getFiatValue(valueSat);
+        const res = await getFormattedFiat(valueSat);
         setFiatValue(res);
       })();
     }
-  }, [valueSat, showFiat, getFiatValue]);
+  }, [valueSat, showFiat, getFormattedFiat]);
 
   async function confirm() {
     try {

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -15,7 +15,6 @@ import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 import type { LNURLWithdrawServiceResponse } from "~/types";
 
 function LNURLWithdraw() {
@@ -28,6 +27,7 @@ function LNURLWithdraw() {
     isLoading: isLoadingSettings,
     settings,
     getFormattedFiat,
+    getFormattedSats,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -72,10 +72,9 @@ function LNURLWithdraw() {
       if (response.data.status.toUpperCase() === "OK") {
         setSuccessMessage(
           t("success", {
-            amount: `${getFormattedSats({
-              amount: valueSat,
-              locale: settings.locale,
-            })} ${showFiat ? `(${fiatValue})` : ``}`,
+            amount: `${getFormattedSats(valueSat)} ${
+              showFiat ? `(${fiatValue})` : ``
+            }`,
             sender: origin ? origin.name : details.domain,
           })
         );
@@ -103,10 +102,7 @@ function LNURLWithdraw() {
         <>
           <ContentMessage
             heading={t("content_message.heading")}
-            content={getFormattedSats({
-              amount: Math.floor(minWithdrawable / 1000),
-              locale: settings.locale,
-            })}
+            content={getFormattedSats(Math.floor(minWithdrawable / 1000))}
           />
 
           {errorMessage && <p className="mt-1 text-red-500">{errorMessage}</p>}

--- a/src/app/screens/LNURLWithdraw/index.tsx
+++ b/src/app/screens/LNURLWithdraw/index.tsx
@@ -15,7 +15,7 @@ import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 import type { LNURLWithdrawServiceResponse } from "~/types";
 
 function LNURLWithdraw() {
@@ -72,7 +72,7 @@ function LNURLWithdraw() {
       if (response.data.status.toUpperCase() === "OK") {
         setSuccessMessage(
           t("success", {
-            amount: `${getSatValue({
+            amount: `${getFormattedSats({
               amount: valueSat,
               locale: settings.locale,
             })} ${showFiat ? `(${fiatValue})` : ``}`,
@@ -103,7 +103,7 @@ function LNURLWithdraw() {
         <>
           <ContentMessage
             heading={t("content_message.heading")}
-            content={getSatValue({
+            content={getFormattedSats({
               amount: Math.floor(minWithdrawable / 1000),
               locale: settings.locale,
             })}

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -7,7 +7,6 @@ import { useNavigate } from "react-router-dom";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 export default function TestConnection() {
   const [accountInfo, setAccountInfo] = useState<{
@@ -18,7 +17,7 @@ export default function TestConnection() {
   const [errorMessage, setErrorMessage] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const { settings } = useSettings();
+  const { getFormattedSats } = useSettings();
 
   const { t } = useTranslation("translation", {
     keyPrefix: "welcome.test_connection",
@@ -105,10 +104,7 @@ export default function TestConnection() {
                   alias={`${accountInfo.name} - ${accountInfo.alias}`}
                   satoshis={
                     typeof accountInfo.balance === "number"
-                      ? getFormattedSats({
-                          amount: accountInfo.balance,
-                          locale: settings.locale,
-                        })
+                      ? getFormattedSats(accountInfo.balance)
                       : ""
                   }
                 />

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 export default function TestConnection() {
   const [accountInfo, setAccountInfo] = useState<{
@@ -105,7 +105,7 @@ export default function TestConnection() {
                   alias={`${accountInfo.name} - ${accountInfo.alias}`}
                   satoshis={
                     typeof accountInfo.balance === "number"
-                      ? getSatValue({
+                      ? getFormattedSats({
                           amount: accountInfo.balance,
                           locale: settings.locale,
                         })

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -4,8 +4,10 @@ import Loading from "@components/Loading";
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
+import { getSatValue } from "~/common/utils/currencyConvert";
 
 export default function TestConnection() {
   const [accountInfo, setAccountInfo] = useState<{
@@ -15,6 +17,9 @@ export default function TestConnection() {
   }>();
   const [errorMessage, setErrorMessage] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const { settings } = useSettings();
+
   const { t } = useTranslation("translation", {
     keyPrefix: "welcome.test_connection",
   });
@@ -100,9 +105,10 @@ export default function TestConnection() {
                   alias={`${accountInfo.name} - ${accountInfo.alias}`}
                   satoshis={
                     typeof accountInfo.balance === "number"
-                      ? `${accountInfo.balance} ${tCommon("sats", {
-                          count: accountInfo.balance,
-                        })}`
+                      ? getSatValue({
+                          amount: accountInfo.balance,
+                          locale: settings.locale,
+                        })
                       : ""
                   }
                 />

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -9,7 +9,7 @@ import { useAccounts } from "~/app/context/AccountsContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { getSatValue } from "~/common/utils/currencyConvert";
+import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 export default function TestConnection() {
   const { settings } = useSettings();
@@ -122,7 +122,7 @@ export default function TestConnection() {
                     alias={`${accountInfo.name} - ${accountInfo.alias}`}
                     satoshis={
                       typeof accountInfo.balance === "number"
-                        ? getSatValue({
+                        ? getFormattedSats({
                             amount: accountInfo.balance,
                             locale: settings.locale,
                           })

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -6,12 +6,16 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
+import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
+import { getSatValue } from "~/common/utils/currencyConvert";
 
 export default function TestConnection() {
+  const { settings } = useSettings();
   const auth = useAccount();
   const { getAccounts } = useAccounts();
+
   const [accountInfo, setAccountInfo] = useState<{
     alias: string;
     name: string;
@@ -118,9 +122,10 @@ export default function TestConnection() {
                     alias={`${accountInfo.name} - ${accountInfo.alias}`}
                     satoshis={
                       typeof accountInfo.balance === "number"
-                        ? `${accountInfo.balance} ${tCommon("sats", {
-                            count: accountInfo.balance,
-                          })}`
+                        ? getSatValue({
+                            amount: accountInfo.balance,
+                            locale: settings.locale,
+                          })
                         : ""
                     }
                   />

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -9,10 +9,9 @@ import { useAccounts } from "~/app/context/AccountsContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 import utils from "~/common/lib/utils";
-import { getFormattedSats } from "~/common/utils/currencyConvert";
 
 export default function TestConnection() {
-  const { settings } = useSettings();
+  const { getFormattedSats } = useSettings();
   const auth = useAccount();
   const { getAccounts } = useAccounts();
 
@@ -122,10 +121,7 @@ export default function TestConnection() {
                     alias={`${accountInfo.name} - ${accountInfo.alias}`}
                     satoshis={
                       typeof accountInfo.balance === "number"
-                        ? getFormattedSats({
-                            amount: accountInfo.balance,
-                            locale: settings.locale,
-                          })
+                        ? getFormattedSats(accountInfo.balance)
                         : ""
                     }
                   />

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -11,7 +11,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import utils from "~/common/lib/utils";
-import { getFormattedNumber } from "~/common/utils/currencyConvert";
 import type { Allowance, Transaction } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -24,6 +23,7 @@ function Publisher() {
     isLoading: isLoadingSettings,
     settings,
     getFormattedFiat,
+    getFormattedNumber,
   } = useSettings();
 
   const hasFetchedData = useRef(false);
@@ -92,15 +92,8 @@ function Publisher() {
               </dt>
 
               <dd className="flex items-center font-bold text-xl dark:text-neutral-400">
-                {getFormattedNumber({
-                  amount: allowance.usedBudget,
-                  locale: settings.locale,
-                })}{" "}
-                /{" "}
-                {getFormattedNumber({
-                  amount: allowance.totalBudget,
-                  locale: settings.locale,
-                })}{" "}
+                {getFormattedNumber(allowance.usedBudget)} /{" "}
+                {getFormattedNumber(allowance.totalBudget)}{" "}
                 {t("publisher.allowance.used_budget")}
                 <div className="ml-3 w-24">
                   <Progressbar percentage={allowance.percentage} />

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -23,7 +23,7 @@ function Publisher() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
 
   const hasFetchedData = useRef(false);
@@ -51,7 +51,7 @@ function Publisher() {
 
         for (const payment of payments) {
           const totalAmountFiat = settings.showFiat
-            ? await getFiatValue(payment.totalAmount)
+            ? await getFormattedFiat(payment.totalAmount)
             : "";
           payment.totalAmountFiat = totalAmountFiat;
         }
@@ -61,7 +61,7 @@ function Publisher() {
       console.error(e);
       if (e instanceof Error) toast.error(`Error: ${e.message}`);
     }
-  }, [id, settings.showFiat, getFiatValue]);
+  }, [id, settings.showFiat, getFormattedFiat]);
 
   useEffect(() => {
     // Run once.

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import utils from "~/common/lib/utils";
+import { getFormattedNumber } from "~/common/utils/currencyConvert";
 import type { Allowance, Transaction } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -91,7 +92,15 @@ function Publisher() {
               </dt>
 
               <dd className="flex items-center font-bold text-xl dark:text-neutral-400">
-                {allowance.usedBudget} / {allowance.totalBudget}{" "}
+                {getFormattedNumber({
+                  amount: allowance.usedBudget,
+                  locale: settings.locale,
+                })}{" "}
+                /{" "}
+                {getFormattedNumber({
+                  amount: allowance.totalBudget,
+                  locale: settings.locale,
+                })}{" "}
                 {t("publisher.allowance.used_budget")}
                 <div className="ml-3 w-24">
                   <Progressbar percentage={allowance.percentage} />

--- a/src/app/screens/Publishers/index.test.tsx
+++ b/src/app/screens/Publishers/index.test.tsx
@@ -3,16 +3,18 @@ import { I18nextProvider } from "react-i18next";
 import { MemoryRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import i18n from "~/../tests/unit/helpers/i18n";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 
 import { AccountsProvider } from "../../context/AccountsContext";
 import Publishers from "./index";
 
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
+jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
+  return {
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
+  };
 });
 
 jest.mock("~/common/lib/utils", () => {
@@ -41,13 +43,15 @@ jest.mock("~/common/lib/utils", () => {
 describe("Publishers", () => {
   test("renders active allowance", async () => {
     render(
-      <AccountsProvider>
-        <I18nextProvider i18n={i18n}>
-          <MemoryRouter>
-            <Publishers />
-          </MemoryRouter>
-        </I18nextProvider>
-      </AccountsProvider>
+      <SettingsProvider>
+        <AccountsProvider>
+          <I18nextProvider i18n={i18n}>
+            <MemoryRouter>
+              <Publishers />
+            </MemoryRouter>
+          </I18nextProvider>
+        </AccountsProvider>
+      </SettingsProvider>
     );
 
     expect(await screen.findByText("Your ⚡️ Websites")).toBeInTheDocument();

--- a/src/app/screens/Publishers/index.test.tsx
+++ b/src/app/screens/Publishers/index.test.tsx
@@ -1,10 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import { I18nextProvider } from "react-i18next";
 import { MemoryRouter } from "react-router-dom";
+import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
 import i18n from "~/../tests/unit/helpers/i18n";
+import * as SettingsContext from "~/app/context/SettingsContext";
 
 import { AccountsProvider } from "../../context/AccountsContext";
 import Publishers from "./index";
+
+jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
+  settings: mockSettings,
+  isLoading: false,
+  updateSetting: jest.fn(),
+  getFiatValue: jest.fn(),
+});
 
 jest.mock("~/common/lib/utils", () => {
   return {
@@ -22,7 +31,7 @@ jest.mock("~/common/lib/utils", () => {
           usedBudget: 100,
           percentage: "0",
           paymentsCount: 1,
-          paymentsAmount: "0100",
+          paymentsAmount: 3000,
         },
       ],
     })),
@@ -44,5 +53,9 @@ describe("Publishers", () => {
     expect(await screen.findByText("Your ⚡️ Websites")).toBeInTheDocument();
     expect(await screen.findByText("DALL·E 2")).toBeInTheDocument();
     expect(await screen.findByText("ACTIVE")).toBeInTheDocument();
+    expect(
+      await screen.findByText("100 / 98,756 sats used")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("3,000 sats")).toBeInTheDocument();
   });
 });

--- a/src/app/screens/Publishers/index.test.tsx
+++ b/src/app/screens/Publishers/index.test.tsx
@@ -12,7 +12,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 jest.mock("~/common/lib/utils", () => {

--- a/src/app/screens/Receive/index.test.tsx
+++ b/src/app/screens/Receive/index.test.tsx
@@ -2,24 +2,17 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
-import * as SettingsContext from "~/app/context/SettingsContext";
+import { SettingsProvider } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
 
 import Receive from "./index";
 
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
-});
-
 jest.mock("~/common/lib/api", () => {
+  const original = jest.requireActual("~/common/lib/api");
   return {
-    getSettings: jest.fn(() => ({
-      currency: "USD",
-      exchange: "coindesk",
-    })),
+    ...original,
+    getSettings: jest.fn(() => Promise.resolve(mockSettings)),
+    getCurrencyRate: jest.fn(() => Promise.resolve({ rate: 11 })),
     makeInvoice: jest.fn(),
   };
 });
@@ -34,7 +27,9 @@ describe("Receive", () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <Receive />
+          <SettingsProvider>
+            <Receive />
+          </SettingsProvider>
         </MemoryRouter>
       );
     });

--- a/src/app/screens/Receive/index.test.tsx
+++ b/src/app/screens/Receive/index.test.tsx
@@ -11,7 +11,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 jest.mock("~/common/lib/api", () => {

--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -31,7 +31,7 @@ function Receive() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFiatValue,
+    getFormattedFiat,
   } = useSettings();
   const showFiat = !isLoadingSettings && settings.showFiat;
 
@@ -64,11 +64,11 @@ function Receive() {
   useEffect(() => {
     if (formData.amount !== "" && showFiat) {
       (async () => {
-        const res = await getFiatValue(formData.amount);
+        const res = await getFormattedFiat(formData.amount);
         setFiatAmount(res);
       })();
     }
-  }, [formData, showFiat, getFiatValue]);
+  }, [formData, showFiat, getFormattedFiat]);
 
   function handleChange(
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>

--- a/src/app/screens/Send/index.test.tsx
+++ b/src/app/screens/Send/index.test.tsx
@@ -10,7 +10,7 @@ jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
   settings: mockSettings,
   isLoading: false,
   updateSetting: jest.fn(),
-  getFiatValue: jest.fn(),
+  getFormattedFiat: jest.fn(),
 });
 
 describe("Send", () => {

--- a/src/app/screens/Send/index.test.tsx
+++ b/src/app/screens/Send/index.test.tsx
@@ -1,17 +1,8 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
-import * as SettingsContext from "~/app/context/SettingsContext";
 
 import Send from "./index";
-
-jest.spyOn(SettingsContext, "useSettings").mockReturnValue({
-  settings: mockSettings,
-  isLoading: false,
-  updateSetting: jest.fn(),
-  getFormattedFiat: jest.fn(),
-});
 
 describe("Send", () => {
   afterEach(() => {

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -73,6 +73,17 @@ describe("Currency coversion utils", () => {
 
       expect(result).toBe("37.026,96\xa0US$");
     });
+
+    test("falls back to english", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["USD"],
+        locale: "",
+      });
+
+      expect(result).toBe("$37,026.96");
+    });
   });
 
   describe("getFormattedNumber", () => {
@@ -87,6 +98,12 @@ describe("Currency coversion utils", () => {
 
       expect(result).toBe("9.999.999");
     });
+
+    test("falls back to english", async () => {
+      const result = getFormattedNumber({ amount: 9999999, locale: "" });
+
+      expect(result).toBe("9,999,999");
+    });
   });
 
   describe("getSatValue", () => {
@@ -100,6 +117,12 @@ describe("Currency coversion utils", () => {
       const result = getSatValue({ amount: 123456789, locale: "es" });
 
       expect(result).toBe("123.456.789 sats");
+    });
+
+    test("falls back to english", async () => {
+      const result = getSatValue({ amount: 123456789, locale: "" });
+
+      expect(result).toBe("123,456,789 sats");
     });
   });
 });

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -1,15 +1,15 @@
 import { CURRENCIES } from "~/common/constants";
 
 import {
-  getFiatValue,
+  getFormattedFiat,
   getFormattedNumber,
   getSatValue,
 } from "../currencyConvert";
 
 describe("Currency coversion utils", () => {
-  describe("getFiatValue", () => {
+  describe("getFormattedFiat", () => {
     test("formats correctly for USD in english language", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["USD"],
@@ -20,7 +20,7 @@ describe("Currency coversion utils", () => {
     });
 
     test("formats correctly for USD in italian language", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["USD"],
@@ -31,7 +31,7 @@ describe("Currency coversion utils", () => {
     });
 
     test("formats correctly for EUR in swedish language", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["EUR"],
@@ -42,7 +42,7 @@ describe("Currency coversion utils", () => {
     });
 
     test("formats correctly for EUR in brazilian portugese language", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["EUR"],
@@ -53,7 +53,7 @@ describe("Currency coversion utils", () => {
     });
 
     test("formats correctly for EUR in spanish language", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["EUR"],
@@ -64,7 +64,7 @@ describe("Currency coversion utils", () => {
     });
 
     test("formats correctly for USD in spanish language", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["USD"],
@@ -75,7 +75,7 @@ describe("Currency coversion utils", () => {
     });
 
     test("falls back to english", () => {
-      const result = getFiatValue({
+      const result = getFormattedFiat({
         amount: 123456789,
         rate: 0.00029991836,
         currency: CURRENCIES["USD"],

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -3,14 +3,72 @@ import { CURRENCIES } from "~/common/constants";
 import { getFiatValue, getSatValue } from "../currencyConvert";
 
 describe("Currency coversion utils", () => {
-  test("getFiatValue", () => {
-    const result = getFiatValue({
-      amount: 123456789,
-      rate: 0.00029991836,
-      currency: CURRENCIES["USD"],
+  describe("getFiatValue", () => {
+    test("formats correctly for USD in english language", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["USD"],
+        locale: "en",
+      });
+
+      expect(result).toBe("$37,026.96");
     });
 
-    expect(result).toBe("$37,026.96");
+    test("formats correctly for USD in italian language", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["USD"],
+        locale: "it",
+      });
+
+      expect(result).toBe("37.026,96\xa0USD");
+    });
+
+    test("formats correctly for EUR in swedish language", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["EUR"],
+        locale: "sv",
+      });
+
+      expect(result).toBe("37\xa0026,96\xa0€"); // Intl.NumberFormat uses a non-breaking space
+    });
+
+    test("formats correctly for EUR in brazilian portugese language", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["EUR"],
+        locale: "pt-BR",
+      });
+
+      expect(result).toBe("€\xa037.026,96");
+    });
+
+    test("formats correctly for EUR in spanish language", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["EUR"],
+        locale: "es",
+      });
+
+      expect(result).toBe("37.026,96\xa0€");
+    });
+
+    test("formats correctly for USD in spanish language", () => {
+      const result = getFiatValue({
+        amount: 123456789,
+        rate: 0.00029991836,
+        currency: CURRENCIES["USD"],
+        locale: "es",
+      });
+
+      expect(result).toBe("37.026,96\xa0US$");
+    });
   });
 
   test("getSatValue", async () => {

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -3,7 +3,7 @@ import { CURRENCIES } from "~/common/constants";
 import {
   getFormattedFiat,
   getFormattedNumber,
-  getSatValue,
+  getFormattedSats,
 } from "../currencyConvert";
 
 describe("Currency coversion utils", () => {
@@ -106,21 +106,21 @@ describe("Currency coversion utils", () => {
     });
   });
 
-  describe("getSatValue", () => {
+  describe("getFormattedSats", () => {
     test("formats correctly for english", async () => {
-      const result = getSatValue({ amount: 123456789, locale: "en" });
+      const result = getFormattedSats({ amount: 123456789, locale: "en" });
 
       expect(result).toBe("123,456,789 sats");
     });
 
     test("formats correctly for spanish", async () => {
-      const result = getSatValue({ amount: 123456789, locale: "es" });
+      const result = getFormattedSats({ amount: 123456789, locale: "es" });
 
       expect(result).toBe("123.456.789 sats");
     });
 
     test("falls back to english", async () => {
-      const result = getSatValue({ amount: 123456789, locale: "" });
+      const result = getFormattedSats({ amount: 123456789, locale: "" });
 
       expect(result).toBe("123,456,789 sats");
     });

--- a/src/common/utils/__tests__/currencyConvert.test.ts
+++ b/src/common/utils/__tests__/currencyConvert.test.ts
@@ -1,6 +1,10 @@
 import { CURRENCIES } from "~/common/constants";
 
-import { getFiatValue, getSatValue } from "../currencyConvert";
+import {
+  getFiatValue,
+  getFormattedNumber,
+  getSatValue,
+} from "../currencyConvert";
 
 describe("Currency coversion utils", () => {
   describe("getFiatValue", () => {
@@ -71,9 +75,31 @@ describe("Currency coversion utils", () => {
     });
   });
 
-  test("getSatValue", async () => {
-    const result = getSatValue(123456789);
+  describe("getFormattedNumber", () => {
+    test("formats correctly for english", async () => {
+      const result = getFormattedNumber({ amount: 9999999, locale: "en" });
 
-    expect(result).toBe("123456789 sats");
+      expect(result).toBe("9,999,999");
+    });
+
+    test("formats correctly for spanish", async () => {
+      const result = getFormattedNumber({ amount: 9999999, locale: "es" });
+
+      expect(result).toBe("9.999.999");
+    });
+  });
+
+  describe("getSatValue", () => {
+    test("formats correctly for english", async () => {
+      const result = getSatValue({ amount: 123456789, locale: "en" });
+
+      expect(result).toBe("123,456,789 sats");
+    });
+
+    test("formats correctly for spanish", async () => {
+      const result = getSatValue({ amount: 123456789, locale: "es" });
+
+      expect(result).toBe("123.456.789 sats");
+    });
   });
 });

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -13,9 +13,9 @@ export const getFiatValue = (params: {
 }) => {
   const fiatValue = Number(params.amount) * params.rate;
 
-  return new Intl.NumberFormat(params.locale, {
+  return new Intl.NumberFormat(params.locale || "en", {
     style: "currency",
-    currency: params.currency || "en",
+    currency: params.currency,
   }).format(fiatValue);
 };
 

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -5,7 +5,7 @@ import i18n from "~/i18n/i18nConfig";
 
 import type { CURRENCIES } from "../constants";
 
-export const getFiatValue = (params: {
+export const getFormattedFiat = (params: {
   amount: number | string;
   rate: number;
   currency: CURRENCIES;

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -28,7 +28,7 @@ export const getFormattedNumber = (params: {
   );
 };
 
-export const getSatValue = (params: {
+export const getFormattedSats = (params: {
   amount: number | string;
   locale: string;
 }) => {

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -5,21 +5,18 @@ import i18n from "~/i18n/i18nConfig";
 
 import type { CURRENCIES } from "../constants";
 
-export const getFiatValue = ({
-  amount,
-  rate,
-  currency,
-}: {
+export const getFiatValue = (params: {
   amount: number | string;
   rate: number;
   currency: CURRENCIES;
+  locale: string;
 }) => {
-  const fiatValue = Number(amount) * rate;
+  const fiatValue = Number(params.amount) * params.rate;
 
-  return fiatValue.toLocaleString("en", {
+  return new Intl.NumberFormat(params.locale, {
     style: "currency",
-    currency,
-  });
+    currency: params.currency || "en",
+  }).format(fiatValue);
 };
 
 export const getSatValue = (balance: number) =>

--- a/src/common/utils/currencyConvert.ts
+++ b/src/common/utils/currencyConvert.ts
@@ -19,5 +19,23 @@ export const getFiatValue = (params: {
   }).format(fiatValue);
 };
 
-export const getSatValue = (balance: number) =>
-  `${balance} ${i18n.t("sats", { count: balance, ns: "common" })}`;
+export const getFormattedNumber = (params: {
+  amount: number | string;
+  locale: string;
+}) => {
+  return new Intl.NumberFormat(params.locale || "en").format(
+    Number(params.amount)
+  );
+};
+
+export const getSatValue = (params: {
+  amount: number | string;
+  locale: string;
+}) => {
+  const formattedNumber = getFormattedNumber(params);
+
+  return `${formattedNumber} ${i18n.t("sats", {
+    count: Number(params.amount),
+    ns: "common",
+  })}`;
+};

--- a/src/extension/background-script/events/__test__/notifications.test.ts
+++ b/src/extension/background-script/events/__test__/notifications.test.ts
@@ -25,7 +25,7 @@ const settings: SettingsStorage = {
   exchange: "coindesk",
   isUsingLegacyLnurlAuthKey: false,
   legacyLnurlAuth: false,
-  locale: "",
+  locale: "en",
   showFiat: true,
   theme: "",
   userEmail: "",

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -26,7 +26,7 @@ const paymentSuccessNotification = async (
   const paymentAmount = total_amt - total_fees;
 
   const { settings } = state.getState();
-  const { showFiat, currency } = settings;
+  const { showFiat, currency, locale } = settings;
 
   if (showFiat) {
     const rate = await getCurrencyRateWithCache(currency);
@@ -35,6 +35,7 @@ const paymentSuccessNotification = async (
       amount: paymentAmount,
       rate,
       currency,
+      locale,
     });
   }
 

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -1,5 +1,5 @@
 import utils from "~/common/lib/utils";
-import { getFiatValue } from "~/common/utils/currencyConvert";
+import { getFormattedFiat } from "~/common/utils/currencyConvert";
 import { getCurrencyRateWithCache } from "~/extension/background-script/actions/cache/getCurrencyRate";
 import state from "~/extension/background-script/state";
 import i18n from "~/i18n/i18nConfig";
@@ -31,7 +31,7 @@ const paymentSuccessNotification = async (
   if (showFiat) {
     const rate = await getCurrencyRateWithCache(currency);
 
-    paymentAmountFiatLocale = getFiatValue({
+    paymentAmountFiatLocale = getFormattedFiat({
       amount: paymentAmount,
       rate,
       currency,

--- a/src/i18n/i18nConfig.ts
+++ b/src/i18n/i18nConfig.ts
@@ -14,7 +14,7 @@ import sv from "~/i18n/locales/sv/translation.json";
 export const supportedLocales = [
   { locale: "en", label: "English" },
   { locale: "es", label: "Español" },
-  { locale: "pt_BR", label: "Português (Brasil)" },
+  { locale: "pt-BR", label: "Português (Brasil)" },
   { locale: "sv", label: "Svenska" },
   { locale: "it", label: "Italiano" },
 ];


### PR DESCRIPTION
### Describe the changes you have made in this PR

This PR does:
- passes current locale to `getFormattedFiat` 
- passes current locale to `getFormattedNumber` 
- passes current locale to `getFormattedSats` 
- moves these helpers to SettingsContext
- renders components in tests with SettingsProvider where possible to test the correct number formatting
- add jest global matchMedia config to render tests with SettingsProvider

**Please follow the commit history if you have problems comparing the diff.**

Please checkout this PR yourself and check if I missed a spot. 🙏 

## NOTEs

~I am still thinking of moving `getFormattedNumber` and `getFormattedSats` to the SettingsContext.
(Same as `getFormattedFiat`) **WDYT?**~
=> done ✅ 

### Link this PR to an issue [optional]

Closes https://github.com/getAlby/lightning-browser-extension/issues/1022

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

<img width="742" alt="fomatted" src="https://user-images.githubusercontent.com/11243967/201914246-24e8327a-fb68-415d-a175-89c68cb76d6b.png">


### How has this been tested?
- added more tests
- checked UI 

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
