### PR TITLE
fix: case insensitive bitcoin links

### DIFF
--- a/src/extension/inpage-script/index.js
+++ b/src/extension/inpage-script/index.js
@@ -43,7 +43,7 @@ if (document) {
         paymentRequest = href.replace("lightning:", "");
         link = lightningLink;
       } else if (bitcoinLinkWithLighting) {
-        href = bitcoinLinkWithLighting.getAttribute("href");
+        href = bitcoinLinkWithLighting.getAttribute("href").toLowerCase();
         link = bitcoinLinkWithLighting;
         const url = new URL(href);
         const query = new URLSearchParams(url.search);


### PR DESCRIPTION
so far we only looked for `lightning` query params and missed `LIGHTNING`

test on: https://donate.pavlenex.com/