### PR TITLE
fix(lnurlpay): description overflow

### DIFF
--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -32,7 +32,9 @@ const Dt = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="mb-4 text-gray-600 dark:text-neutral-500">{children}</dd>
+  <dd className="mb-4 text-gray-600 dark:text-neutral-500 break-all">
+    {children}
+  </dd>
 );
 
 function LNURLPay() {
@@ -358,7 +360,7 @@ function LNURLPay() {
                 <form onSubmit={handleSubmit}>
                   <fieldset disabled={loadingConfirm}>
                     <div className="my-4">
-                      <dl>
+                      <dl className="overflow-hidden">
                         <>
                           {formattedMetadata(details.metadata).map(
                             ([dt, dd], i) => (


### PR DESCRIPTION
### Describe the changes you have made in this PR

Breaks text instead of overflowing in lnurlpay screen.


[I wonder why we aren't using Content Message here (similar to Keysend) like this:]
❌ Not the actual change
<img width="398" alt="Screenshot 2022-12-01 at 1 48 03 PM" src="https://user-images.githubusercontent.com/64399555/205003597-5846f09d-62e8-483d-98b8-34db80882559.png">

### Link this PR to an issue [optional]

Fixes #1786

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]
✅ Actual Change
<img width="398" alt="Screenshot 2022-12-01 at 1 55 47 PM" src="https://user-images.githubusercontent.com/64399555/205003373-5e5b2f33-c126-4891-b33c-ff0f8b944bcb.png">

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
