### PR TITLE
fix: overflow of website title

### DIFF
--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -59,7 +59,7 @@ export default function PublisherCard({
       >
         <h2
           className={
-            "text-xl font-semibold dark:text-white overflow-hidden text-ellipsis " +
+            "text-xl font-semibold dark:text-white overflow-hidden text-ellipsis whitespace-nowrap " +
             (isSmall ? "my-1" : "my-2")
           }
         >

--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -58,6 +58,7 @@ export default function PublisherCard({
         }
       >
         <h2
+          title={title}
           className={
             "text-xl font-semibold dark:text-white overflow-hidden text-ellipsis whitespace-nowrap " +
             (isSmall ? "my-1" : "my-2")


### PR DESCRIPTION
### Describe the changes you have made in this PR

Long website names / titles currently allow the publisher card to grow indefinitely: (and shift important UI elements out of the view at the bottom)

![image](https://user-images.githubusercontent.com/100827540/205057566-7ee0370a-293f-46c1-9775-e6800360ac7b.png)

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

![image](https://user-images.githubusercontent.com/100827540/205057761-9facf4cd-e23b-43ab-8ddf-0aa468bb1aed.png)