### PR TITLE
Refactor to prevent state and background script imports to the content script

### DIFF
--- a/src/app/components/AccountMenu/index.test.tsx
+++ b/src/app/components/AccountMenu/index.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
+import { I18nextProvider } from "react-i18next";
 import { BrowserRouter } from "react-router-dom";
+import i18n from "~/../tests/unit/helpers/i18n";
 import type { Accounts } from "~/types";
 
 import AccountMenu from ".";
@@ -41,7 +43,9 @@ describe("AccountMenu", () => {
   test("renders the toggle button", async () => {
     render(
       <BrowserRouter>
-        <AccountMenu {...defaultProps} />
+        <I18nextProvider i18n={i18n}>
+          <AccountMenu {...defaultProps} />
+        </I18nextProvider>
       </BrowserRouter>
     );
 
@@ -53,7 +57,9 @@ describe("AccountMenu", () => {
 
     render(
       <BrowserRouter>
-        <AccountMenu {...defaultProps} />
+        <I18nextProvider i18n={i18n}>
+          <AccountMenu {...defaultProps} />
+        </I18nextProvider>
       </BrowserRouter>
     );
 
@@ -74,7 +80,9 @@ describe("AccountMenu", () => {
 
     render(
       <BrowserRouter>
-        <AccountMenu {...defaultProps} />
+        <I18nextProvider i18n={i18n}>
+          <AccountMenu {...defaultProps} />
+        </I18nextProvider>
       </BrowserRouter>
     );
 
@@ -94,7 +102,9 @@ describe("AccountMenu", () => {
 
     render(
       <BrowserRouter>
-        <AccountMenu showOptions={false} />
+        <I18nextProvider i18n={i18n}>
+          <AccountMenu showOptions={false} />
+        </I18nextProvider>
       </BrowserRouter>
     );
 

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 
 import Menu from "../Menu";
@@ -48,7 +49,7 @@ function AccountMenu({ showOptions = true }: Props) {
     setLoading(true);
     try {
       setAccountId(accountId);
-      await utils.call("selectAccount", {
+      await msg.request("selectAccount", {
         id: accountId,
       });
       await fetchAccountInfo({ accountId });

--- a/src/app/components/AllowanceMenu/index.test.tsx
+++ b/src/app/components/AllowanceMenu/index.test.tsx
@@ -19,7 +19,7 @@ jest.mock("~/app/context/SettingsContext", () => ({
   }),
 }));
 
-jest.mock("~/common/lib/utils");
+jest.mock("~/common/lib/msg");
 
 const mockOnEdit = jest.fn();
 

--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import Modal from "react-modal";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import type { Allowance } from "~/types";
 
 import Button from "../Button";
@@ -66,7 +66,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   }
 
   async function updateAllowance() {
-    await utils.call("updateAllowance", {
+    await msg.request("updateAllowance", {
       id: allowance.id,
       totalBudget: parseInt(budget),
       lnurlAuth,
@@ -91,7 +91,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
             onClick={async () => {
               if (window.confirm(t("confirm_delete"))) {
                 try {
-                  await utils.call("deleteAllowance", {
+                  await msg.request("deleteAllowance", {
                     id: allowance.id,
                   });
                   onDelete && onDelete();

--- a/src/app/components/DevMenu/index.tsx
+++ b/src/app/components/DevMenu/index.tsx
@@ -1,10 +1,10 @@
 import { Component } from "react";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 class DevMenu extends Component {
   reset() {
-    utils.call("reset").then((response) => {
+    msg.request("reset").then((response) => {
       console.info(response);
       toast.success("Done, you can start over");
     });

--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -8,6 +8,7 @@ import {
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 import type { AccountInfo } from "~/types";
 
@@ -65,7 +66,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
   };
 
   const lock = (callback: VoidFunction) => {
-    return utils.call("lock").then(() => {
+    return msg.request("lock").then(() => {
       setAccount(null);
       callback();
     });

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -18,7 +18,7 @@ import { useNavigate } from "react-router-dom";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 import api from "~/common/lib/api";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import type { Account } from "~/types";
 
 type AccountAction = Omit<Account, "connector" | "config">;
@@ -59,7 +59,7 @@ function AccountsScreen() {
   }
 
   async function updateAccountName({ id, name }: AccountAction) {
-    await utils.call("editAccount", {
+    await msg.request("editAccount", {
       name,
       id,
     });
@@ -81,7 +81,7 @@ function AccountsScreen() {
       setExportModalIsOpen(true);
     }, 50);
     setLndHubData(
-      await utils.call("accountDecryptedDetails", {
+      await msg.request("accountDecryptedDetails", {
         name,
         id,
       })

--- a/src/app/screens/ConfirmKeysend/index.tsx
+++ b/src/app/screens/ConfirmKeysend/index.tsx
@@ -13,7 +13,6 @@ import { useSettings } from "~/app/context/SettingsContext";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 import type { OriginData } from "~/types";
 
 function ConfirmKeysend() {
@@ -68,7 +67,7 @@ function ConfirmKeysend() {
     }
     try {
       setLoading(true);
-      const payment = await utils.call(
+      const payment = await msg.request(
         "keysend",
         { destination, amount, customRecords },
         {

--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -16,7 +16,6 @@ import { useSettings } from "~/app/context/SettingsContext";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 
 function ConfirmPayment() {
   const {
@@ -80,7 +79,7 @@ function ConfirmPayment() {
 
     try {
       setLoading(true);
-      const response = await utils.call(
+      const response = await msg.request(
         "sendPayment",
         { paymentRequest: paymentRequest },
         {

--- a/src/app/screens/ConfirmSignMessage/index.tsx
+++ b/src/app/screens/ConfirmSignMessage/index.tsx
@@ -12,7 +12,6 @@ import ScreenHeader from "~/app/components/ScreenHeader";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 import type { OriginData } from "~/types";
 
 function ConfirmSignMessage() {
@@ -36,7 +35,11 @@ function ConfirmSignMessage() {
 
     try {
       setLoading(true);
-      const response = await utils.call("signMessage", { message }, { origin });
+      const response = await msg.request(
+        "signMessage",
+        { message },
+        { origin }
+      );
       msg.reply(response);
       setSuccessMessage(tCommon("success"));
     } catch (e) {

--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -8,7 +8,6 @@ import { toast } from "react-toastify";
 import ScreenHeader from "~/app/components/ScreenHeader";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 import type { OriginData } from "~/types";
 
 type Props = {
@@ -45,7 +44,7 @@ function Enable(props: Props) {
 
   async function block(event: React.MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
-    await utils.call("addBlocklist", {
+    await msg.request("addBlocklist", {
       domain: props.origin.domain,
       host: props.origin.host,
     });

--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -17,7 +17,7 @@ import { useSettings } from "~/app/context/SettingsContext";
 import { PublisherLnData } from "~/app/screens/Home/PublisherLnData";
 import { classNames } from "~/app/utils/index";
 import api from "~/common/lib/api";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import type { Battery, Transaction } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -107,7 +107,7 @@ const DefaultView: FC<Props> = (props) => {
   const unblock = async () => {
     try {
       if (props.currentUrl?.host) {
-        await utils.call("deleteBlocklist", {
+        await msg.request("deleteBlocklist", {
           host: props.currentUrl.host,
         });
       }

--- a/src/app/screens/Keysend/index.tsx
+++ b/src/app/screens/Keysend/index.tsx
@@ -16,7 +16,7 @@ import Container from "~/app/components/Container";
 import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 function Keysend() {
   const {
@@ -51,7 +51,7 @@ function Keysend() {
   async function confirm() {
     try {
       setLoading(true);
-      const payment = await utils.call(
+      const payment = await msg.request(
         "keysend",
         { destination, amount: amountSat, customRecords },
         {

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -12,7 +12,6 @@ import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 import type { LNURLAuthServiceResponse } from "~/types";
 
 function LNURLAuth() {
@@ -44,7 +43,7 @@ function LNURLAuth() {
         const allowance = await api.getAllowance(origin.host);
 
         if (allowance.lnurlAuth === false) {
-          await utils.call("updateAllowance", {
+          await msg.request("updateAllowance", {
             id: allowance.id,
             lnurlAuth: true,
           });

--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -161,7 +161,7 @@ function LNURLPay() {
       }
 
       // LN WALLET pays the invoice, no additional user confirmation is required at this point
-      const paymentResponse: PaymentResponse = await utils.call(
+      const paymentResponse: PaymentResponse = await msg.request(
         "sendPayment",
         { paymentRequest },
         {

--- a/src/app/screens/Nostr/Confirm.tsx
+++ b/src/app/screens/Nostr/Confirm.tsx
@@ -9,7 +9,6 @@ import ScreenHeader from "~/app/components/ScreenHeader";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 import { OriginData } from "~/types";
 
 function NostrConfirm() {
@@ -40,7 +39,7 @@ function NostrConfirm() {
 
   async function block(event: React.MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
-    await utils.call("addBlocklist", {
+    await msg.request("addBlocklist", {
       domain: origin.domain,
       host: origin.host,
     });

--- a/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
+++ b/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
@@ -9,7 +9,6 @@ import ScreenHeader from "~/app/components/ScreenHeader";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
-import utils from "~/common/lib/utils";
 import { OriginData } from "~/types";
 
 function NostrConfirmGetPublicKey() {
@@ -38,7 +37,7 @@ function NostrConfirmGetPublicKey() {
 
   async function block(event: React.MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
-    await utils.call("addBlocklist", {
+    await msg.request("addBlocklist", {
       domain: origin.domain,
       host: origin.host,
     });

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 const initialFormData = {
   password: "",
@@ -22,7 +22,7 @@ export default function SetPassword() {
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     try {
-      await utils.call("setPassword", { password: formData.password });
+      await msg.request("setPassword", { password: formData.password });
       navigate("/choose-connector");
     } catch (e) {
       if (e instanceof Error) {

--- a/src/app/screens/Onboard/TestConnection/index.tsx
+++ b/src/app/screens/Onboard/TestConnection/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export default function TestConnection() {
   const [accountInfo, setAccountInfo] = useState<{
@@ -27,7 +27,7 @@ export default function TestConnection() {
   const navigate = useNavigate();
 
   async function handleEdit(event: React.MouseEvent<HTMLButtonElement>) {
-    await utils.call("removeAccount");
+    await msg.request("removeAccount");
     navigate(-1);
   }
 

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -8,7 +8,7 @@ import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export default function TestConnection() {
   const { getFormattedSats } = useSettings();
@@ -30,7 +30,7 @@ export default function TestConnection() {
   const { t: tCommon } = useTranslation("common");
 
   async function handleEdit(event: React.MouseEvent<HTMLButtonElement>) {
-    await utils.call("removeAccount");
+    await msg.request("removeAccount");
     navigate(-1);
   }
 

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import type { Allowance, Transaction } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -35,7 +35,7 @@ function Publisher() {
   const fetchData = useCallback(async () => {
     try {
       if (id) {
-        const response = await utils.call<Allowance>("getAllowanceById", {
+        const response = await msg.request<Allowance>("getAllowanceById", {
           id: parseInt(id),
         });
         setAllowance(response);

--- a/src/app/screens/Publishers/index.test.tsx
+++ b/src/app/screens/Publishers/index.test.tsx
@@ -17,9 +17,9 @@ jest.mock("~/common/lib/api", () => {
   };
 });
 
-jest.mock("~/common/lib/utils", () => {
+jest.mock("~/common/lib/msg", () => {
   return {
-    call: jest.fn(() => ({
+    request: jest.fn(() => ({
       allowances: [
         {
           host: "https://openai.com/dall-e-2/",

--- a/src/app/screens/Publishers/index.tsx
+++ b/src/app/screens/Publishers/index.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import { Allowance, Badge, Publisher } from "~/types";
 
 import websites from "./websites.json";
@@ -23,7 +23,7 @@ function Publishers() {
 
   async function fetchData() {
     try {
-      const allowanceResponse = await utils.call<{
+      const allowanceResponse = await msg.request<{
         allowances: Allowance[];
       }>("listAllowances");
 

--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -20,7 +20,7 @@ import { toast } from "react-toastify";
 import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import { poll } from "~/common/utils/helpers";
 
 function Receive() {
@@ -83,7 +83,7 @@ function Receive() {
     setPollingForPayment(true);
     poll({
       fn: () =>
-        utils.call("checkPayment", { paymentHash }) as Promise<{
+        msg.request("checkPayment", { paymentHash }) as Promise<{
           paid: boolean;
         }>,
       validate: (payment) => payment.paid,

--- a/src/app/screens/Send/index.test.tsx
+++ b/src/app/screens/Send/index.test.tsx
@@ -1,6 +1,8 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { I18nextProvider } from "react-i18next";
 import { MemoryRouter } from "react-router-dom";
+import i18n from "~/../tests/unit/helpers/i18n";
 
 import Send from "./index";
 
@@ -13,7 +15,9 @@ describe("Send", () => {
     const user = userEvent.setup();
     render(
       <MemoryRouter>
-        <Send />
+        <I18nextProvider i18n={i18n}>
+          <Send />
+        </I18nextProvider>
       </MemoryRouter>
     );
 

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -20,7 +20,7 @@ import Modal from "react-modal";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import { CURRENCIES } from "~/common/constants";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 const initialFormData = {
   password: "",
@@ -38,7 +38,7 @@ function Settings() {
   const [nostrPrivateKeyVisible, setNostrPrivateKeyVisible] = useState(false);
 
   const getPrivateKeyFromStorage = async () => {
-    const priv = (await utils.call("nostr/getPrivateKey")) as string;
+    const priv = (await msg.request("nostr/getPrivateKey")) as string;
     setNostrPrivateKey(priv ?? "");
   };
 
@@ -54,7 +54,7 @@ function Settings() {
   }
 
   async function saveNostrPrivateKey(nostrPrivateKey: string) {
-    const result = await utils.call("nostr/getPrivateKey");
+    const result = await msg.request("nostr/getPrivateKey");
     const currentPrivateKey = result as unknown as string;
 
     if (nostrPrivateKey === currentPrivateKey) return;
@@ -63,7 +63,7 @@ function Settings() {
       return;
     }
 
-    await utils.call("nostr/setPrivateKey", {
+    await msg.request("nostr/setPrivateKey", {
       privateKey: nostrPrivateKey,
     });
 
@@ -74,7 +74,7 @@ function Settings() {
   }
 
   async function updateAccountPassword(password: string) {
-    await utils.call("changePassword", {
+    await msg.request("changePassword", {
       password: formData.password,
     });
     toast.success(t("change_password.success"));
@@ -480,7 +480,9 @@ function Settings() {
                 <Button
                   label={t("nostr.private_key.generate")}
                   onClick={async () => {
-                    const result = await utils.call("nostr/generatePrivateKey");
+                    const result = await msg.request(
+                      "nostr/generatePrivateKey"
+                    );
                     setNostrPrivateKey(result.privateKey as string);
                     saveNostrPrivateKey(result.privateKey as string);
                   }}

--- a/src/app/screens/Unlock/index.tsx
+++ b/src/app/screens/Unlock/index.tsx
@@ -9,6 +9,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAccount } from "~/app/context/AccountContext";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 
 function Unlock() {
@@ -36,7 +37,7 @@ function Unlock() {
 
   async function reset(event: React.MouseEvent<HTMLElement>) {
     event.preventDefault();
-    await utils.call("reset");
+    await msg.request("reset");
     utils.openPage("welcome.html");
   }
 

--- a/src/app/screens/connectors/ConnectBtcpay/index.tsx
+++ b/src/app/screens/connectors/ConnectBtcpay/index.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 const initialFormData = {
   url: "",
@@ -83,13 +83,13 @@ export default function ConnectBtcpay() {
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export default function ConnectCitadel() {
   const navigate = useNavigate();
@@ -63,12 +63,12 @@ export default function ConnectCitadel() {
       if (account.connector === "nativecitadel") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectCommando/index.tsx
+++ b/src/app/screens/connectors/ConnectCommando/index.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export default function ConnectCommando() {
   const navigate = useNavigate();
@@ -71,11 +71,11 @@ export default function ConnectCommando() {
     };
 
     try {
-      const validation = await utils.call("validateAccount", account);
+      const validation = await msg.request("validateAccount", account);
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export default function ConnectEclair() {
   const navigate = useNavigate();
@@ -44,11 +44,11 @@ export default function ConnectEclair() {
     };
 
     try {
-      const validation = await utils.call("validateAccount", account);
+      const validation = await msg.request("validateAccount", account);
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export const galoyUrls = {
   "galoy-bitcoin-beach": {
@@ -269,11 +269,11 @@ export default function ConnectGaloy(props: Props) {
     };
 
     try {
-      const validation = await utils.call("validateAccount", account);
+      const validation = await msg.request("validateAccount", account);
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export default function ConnectLnbits() {
   const navigate = useNavigate();
@@ -54,13 +54,13 @@ export default function ConnectLnbits() {
       if (account.connector === "nativelnbits") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -7,6 +7,7 @@ import { useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 
 const initialFormData = {
@@ -59,13 +60,13 @@ export default function ConnectLnd() {
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectLndHub/index.tsx
+++ b/src/app/screens/connectors/ConnectLndHub/index.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 export type Props = {
   lndHubType?: "lndhub_bluewallet" | "lndhub_go";
@@ -69,13 +69,13 @@ export default function ConnectLndHub({
       if (account.connector === "nativelndhub") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 
 const initialFormData = {
@@ -69,13 +70,13 @@ export default function ConnectMyNode() {
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 const initialFormData = Object.freeze({
   url: "",
@@ -67,13 +67,13 @@ export default function ConnectRaspiBlitz() {
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 
 const initialFormData = {
@@ -69,13 +70,13 @@ export default function ConnectStart9() {
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import msg from "~/common/lib/msg";
 import utils from "~/common/lib/utils";
 
 const initialFormData = {
@@ -69,13 +70,13 @@ export default function ConnectUmbrel() {
       if (account.connector === "nativelnd") {
         validation = { valid: true, error: "" };
       } else {
-        validation = await utils.call("validateAccount", account);
+        validation = await msg.request("validateAccount", account);
       }
 
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/app/screens/connectors/NewWallet/index.tsx
+++ b/src/app/screens/connectors/NewWallet/index.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 
 const walletCreateUrl =
   process.env.WALLET_CREATE_URL || "https://app.regtest.getalby.com/api/users";
@@ -113,11 +113,11 @@ export default function NewWallet() {
     };
 
     try {
-      const validation = await utils.call("validateAccount", account);
+      const validation = await msg.request("validateAccount", account);
       if (validation.valid) {
-        const addResult = await utils.call("addAccount", account);
+        const addResult = await msg.request("addAccount", account);
         if (addResult.accountId) {
-          await utils.call("selectAccount", {
+          await msg.request("selectAccount", {
             id: addResult.accountId,
           });
           navigate("/test-connection");

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -23,7 +23,7 @@ import {
   removeAccountFromCache,
   storeAccounts,
 } from "./cache";
-import utils from "./utils";
+import msg from "./msg";
 
 export interface AccountInfoRes {
   balance: { balance: string | number };
@@ -46,7 +46,7 @@ interface BlocklistRes {
   blocked: boolean;
 }
 
-export const getAccountInfo = () => utils.call<AccountInfoRes>("accountInfo");
+export const getAccountInfo = () => msg.request<AccountInfoRes>("accountInfo");
 
 /**
  * stale-while-revalidate get account info
@@ -84,43 +84,43 @@ export const swrGetAccountInfo = async (
       .catch(reject);
   });
 };
-export const getAccounts = () => utils.call<Accounts>("getAccounts");
-export const updateAllowance = () => utils.call<Accounts>("updateAllowance");
+export const getAccounts = () => msg.request<Accounts>("getAccounts");
+export const updateAllowance = () => msg.request<Accounts>("updateAllowance");
 export const selectAccount = (id: string) =>
-  utils.call("selectAccount", { id });
+  msg.request("selectAccount", { id });
 export const getAllowance = (host: string) =>
-  utils.call<Allowance>("getAllowance", { host });
+  msg.request<Allowance>("getAllowance", { host });
 export const getPayments = (options: { limit: number }) =>
-  utils.call<{ payments: DbPayment[] }>("getPayments", options);
-export const getSettings = () => utils.call<SettingsStorage>("getSettings");
-export const getStatus = () => utils.call<StatusRes>("status");
-export const getInfo = () => utils.call<NodeInfo>("getInfo");
+  msg.request<{ payments: DbPayment[] }>("getPayments", options);
+export const getSettings = () => msg.request<SettingsStorage>("getSettings");
+export const getStatus = () => msg.request<StatusRes>("status");
+export const getInfo = () => msg.request<NodeInfo>("getInfo");
 export const makeInvoice = ({ amount, memo }: MakeInvoiceArgs) =>
-  utils.call<MakeInvoiceResponse["data"]>("makeInvoice", { amount, memo });
+  msg.request<MakeInvoiceResponse["data"]>("makeInvoice", { amount, memo });
 export const connectPeer = ({ host, pubkey }: ConnectPeerArgs) =>
-  utils.call<ConnectPeerResponse["data"]>("connectPeer", { host, pubkey });
+  msg.request<ConnectPeerResponse["data"]>("connectPeer", { host, pubkey });
 export const setSetting = (setting: MessageSettingsSet["args"]["setting"]) =>
-  utils.call<SettingsStorage>("setSetting", {
+  msg.request<SettingsStorage>("setSetting", {
     setting,
   });
 export const removeAccount = (id: string) =>
   Promise.all([
-    utils.call("removeAccount", { id }),
+    msg.request("removeAccount", { id }),
     removeAccountFromCache(id),
   ]);
 export const unlock = (password: string) =>
-  utils.call<UnlockRes>("unlock", { password });
+  msg.request<UnlockRes>("unlock", { password });
 export const getBlocklist = (host: string) =>
-  utils.call<BlocklistRes>("getBlocklist", { host });
+  msg.request<BlocklistRes>("getBlocklist", { host });
 export const getInvoices = (options?: MessageInvoices["args"]) =>
-  utils.call<{ invoices: Invoice[] }>("getInvoices", options);
+  msg.request<{ invoices: Invoice[] }>("getInvoices", options);
 export const lnurlAuth = (
   options: MessageLnurlAuth["args"]
 ): Promise<LnurlAuthResponse> =>
-  utils.call<LnurlAuthResponse>("lnurlAuth", options);
+  msg.request<LnurlAuthResponse>("lnurlAuth", options);
 
 export const getCurrencyRate = async () =>
-  utils.call<{ rate: number }>("getCurrencyRate");
+  msg.request<{ rate: number }>("getCurrencyRate");
 
 export default {
   getAccountInfo,

--- a/src/common/lib/msg.ts
+++ b/src/common/lib/msg.ts
@@ -1,24 +1,25 @@
 import browser from "webextension-polyfill";
 
 const msg = {
-  request: (
+  request: <T = Record<string, unknown>>(
     action: string,
-    args?: { [key: string]: string | number },
-    overwrites?: { [key: string]: string }
+    args?: Record<string, unknown>,
+    overwrites?: Record<string, unknown>
   ) => {
     return browser.runtime
       .sendMessage({
         application: "LBE",
         prompt: true,
-        action,
+        action: action,
         args: args,
         origin: { internal: true },
         ...overwrites,
       })
-      .then((response) => {
+      .then((response: { data: T; error?: string }) => {
         if (response.error) {
           throw new Error(response.error);
         }
+
         return response.data;
       });
   },

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -1,43 +1,8 @@
 import browser, { Runtime } from "webextension-polyfill";
 import { ABORT_PROMPT_ERROR } from "~/common/constants";
-import state from "~/extension/background-script/state";
 import type { Invoice, OriginData, OriginDataInternal } from "~/types";
 
 const utils = {
-  call: <T = Record<string, unknown>>(
-    action: string,
-    args?: Record<string, unknown>,
-    overwrites?: Record<string, unknown>
-  ) => {
-    return browser.runtime
-      .sendMessage({
-        application: "LBE",
-        prompt: true,
-        action: action,
-        args: args,
-        origin: { internal: true },
-        ...overwrites,
-      })
-      .then((response: { data: T; error?: string }) => {
-        if (response.error) {
-          throw new Error(response.error);
-        }
-
-        return response.data;
-      });
-  },
-  notify: (options: { title: string; message: string }) => {
-    const settings = state.getState().settings;
-    if (!settings.browserNotifications) return;
-
-    const notification: browser.Notifications.CreateNotificationOptions = {
-      type: "basic",
-      iconUrl: "assets/icons/alby_icon_yellow_48x48.png",
-      ...options,
-    };
-
-    return browser.notifications.create(notification);
-  },
   base64ToHex: (str: string) => {
     const hex = [];
     for (

--- a/src/extension/background-script/actions/setup/setIcon.ts
+++ b/src/extension/background-script/actions/setup/setIcon.ts
@@ -6,6 +6,7 @@ import state from "../../state";
 // Store all tabs with their respective icon
 const tabIcons = new Map<number, string>();
 
+// duplicate also in batteries/helper
 enum ExtensionIcon {
   Default = "alby_icon_yellow",
   Tipping = "alby_icon_blue",

--- a/src/extension/background-script/events/__test__/notifications.test.ts
+++ b/src/extension/background-script/events/__test__/notifications.test.ts
@@ -1,5 +1,4 @@
 import { CURRENCIES } from "~/common/constants";
-import utils from "~/common/lib/utils";
 import state from "~/extension/background-script/state";
 import type {
   PaymentNotificationData,
@@ -7,10 +6,7 @@ import type {
   SettingsStorage,
 } from "~/types";
 
-import {
-  paymentSuccessNotification,
-  lnurlAuthSuccessNotification,
-} from "../notifications";
+import * as notifications from "../notifications";
 
 jest.mock("~/extension/background-script/actions/cache/getCurrencyRate", () => {
   return {
@@ -124,8 +120,11 @@ describe("Payment notifications", () => {
 
   test("success via lnaddress from popup", async () => {
     state.getState = jest.fn().mockReturnValue(mockState);
-    const notifySpy = jest.spyOn(utils, "notify");
-    await paymentSuccessNotification("ln.sendPayment.success", data);
+    const notifySpy = jest.spyOn(notifications, "notify");
+    await notifications.paymentSuccessNotification(
+      "ln.sendPayment.success",
+      data
+    );
 
     expect(notifySpy).toHaveBeenCalledWith({
       message: "Amount: 1 sat ($0.00)\nFee: 0 sats",
@@ -140,8 +139,11 @@ describe("Payment notifications", () => {
 
     state.getState = jest.fn().mockReturnValue(mockStateNoFiat);
 
-    const notifySpy = jest.spyOn(utils, "notify");
-    await paymentSuccessNotification("ln.sendPayment.success", data);
+    const notifySpy = jest.spyOn(notifications, "notify");
+    await notifications.paymentSuccessNotification(
+      "ln.sendPayment.success",
+      data
+    );
 
     expect(notifySpy).toHaveBeenCalledWith({
       message: "Amount: 1 sat\nFee: 0 sats",
@@ -156,8 +158,11 @@ describe("Payment notifications", () => {
 
     state.getState = jest.fn().mockReturnValue(mockStateNoFiat);
 
-    const notifySpy = jest.spyOn(utils, "notify");
-    await paymentSuccessNotification("ln.sendPayment.success", data);
+    const notifySpy = jest.spyOn(notifications, "notify");
+    await notifications.paymentSuccessNotification(
+      "ln.sendPayment.success",
+      data
+    );
 
     expect(notifySpy).toHaveBeenCalledWith({
       message: "Amount: 1 sat ($0.00)\nFee: 0 sats",
@@ -167,10 +172,10 @@ describe("Payment notifications", () => {
 
   test("success without origin skips receiver", async () => {
     state.getState = jest.fn().mockReturnValue(mockState);
-    const notifySpy = jest.spyOn(utils, "notify");
+    const notifySpy = jest.spyOn(notifications, "notify");
     const dataWitouthOrigin = { ...data };
     delete dataWitouthOrigin.origin;
-    await paymentSuccessNotification(
+    await notifications.paymentSuccessNotification(
       "ln.sendPayment.success",
       dataWitouthOrigin
     );
@@ -200,8 +205,8 @@ describe("Auth notifications", () => {
   };
 
   test("success via login from popup", async () => {
-    const notifySpy = jest.spyOn(utils, "notify");
-    lnurlAuthSuccessNotification("lnurl.auth.success", data);
+    const notifySpy = jest.spyOn(notifications, "notify");
+    notifications.lnurlAuthSuccessNotification("lnurl.auth.success", data);
 
     expect(notifySpy).toHaveBeenCalledWith({
       title: "✅ Login",
@@ -210,8 +215,8 @@ describe("Auth notifications", () => {
   });
 
   test("success via login from prompt with origin", async () => {
-    const notifySpy = jest.spyOn(utils, "notify");
-    lnurlAuthSuccessNotification("lnurl.auth.success", {
+    const notifySpy = jest.spyOn(notifications, "notify");
+    notifications.lnurlAuthSuccessNotification("lnurl.auth.success", {
       ...data,
       origin: {
         location: "https://lnurl.fiatjaf.com/",

--- a/src/extension/background-script/events/__test__/notifications.test.ts
+++ b/src/extension/background-script/events/__test__/notifications.test.ts
@@ -6,7 +6,10 @@ import type {
   SettingsStorage,
 } from "~/types";
 
+import * as helpers from "../helpers";
 import * as notifications from "../notifications";
+
+jest.mock("../helpers");
 
 jest.mock("~/extension/background-script/actions/cache/getCurrencyRate", () => {
   return {
@@ -120,7 +123,7 @@ describe("Payment notifications", () => {
 
   test("success via lnaddress from popup", async () => {
     state.getState = jest.fn().mockReturnValue(mockState);
-    const notifySpy = jest.spyOn(notifications, "notify");
+    const notifySpy = jest.spyOn(helpers, "notify");
     await notifications.paymentSuccessNotification(
       "ln.sendPayment.success",
       data
@@ -139,7 +142,7 @@ describe("Payment notifications", () => {
 
     state.getState = jest.fn().mockReturnValue(mockStateNoFiat);
 
-    const notifySpy = jest.spyOn(notifications, "notify");
+    const notifySpy = jest.spyOn(helpers, "notify");
     await notifications.paymentSuccessNotification(
       "ln.sendPayment.success",
       data
@@ -158,7 +161,7 @@ describe("Payment notifications", () => {
 
     state.getState = jest.fn().mockReturnValue(mockStateNoFiat);
 
-    const notifySpy = jest.spyOn(notifications, "notify");
+    const notifySpy = jest.spyOn(helpers, "notify");
     await notifications.paymentSuccessNotification(
       "ln.sendPayment.success",
       data
@@ -172,7 +175,7 @@ describe("Payment notifications", () => {
 
   test("success without origin skips receiver", async () => {
     state.getState = jest.fn().mockReturnValue(mockState);
-    const notifySpy = jest.spyOn(notifications, "notify");
+    const notifySpy = jest.spyOn(helpers, "notify");
     const dataWitouthOrigin = { ...data };
     delete dataWitouthOrigin.origin;
     await notifications.paymentSuccessNotification(
@@ -205,7 +208,7 @@ describe("Auth notifications", () => {
   };
 
   test("success via login from popup", async () => {
-    const notifySpy = jest.spyOn(notifications, "notify");
+    const notifySpy = jest.spyOn(helpers, "notify");
     notifications.lnurlAuthSuccessNotification("lnurl.auth.success", data);
 
     expect(notifySpy).toHaveBeenCalledWith({
@@ -215,7 +218,7 @@ describe("Auth notifications", () => {
   });
 
   test("success via login from prompt with origin", async () => {
-    const notifySpy = jest.spyOn(notifications, "notify");
+    const notifySpy = jest.spyOn(helpers, "notify");
     notifications.lnurlAuthSuccessNotification("lnurl.auth.success", {
       ...data,
       origin: {

--- a/src/extension/background-script/events/helpers.ts
+++ b/src/extension/background-script/events/helpers.ts
@@ -1,0 +1,17 @@
+import browser from "webextension-polyfill";
+import state from "~/extension/background-script/state";
+
+const notify = (options: { title: string; message: string }) => {
+  const settings = state.getState().settings;
+  if (!settings.browserNotifications) return;
+
+  const notification: browser.Notifications.CreateNotificationOptions = {
+    type: "basic",
+    iconUrl: "assets/icons/alby_icon_yellow_48x48.png",
+    ...options,
+  };
+
+  return browser.notifications.create(notification);
+};
+
+export { notify };

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -1,9 +1,22 @@
-import utils from "~/common/lib/utils";
+import browser from "webextension-polyfill";
 import { getFormattedFiat } from "~/common/utils/currencyConvert";
 import { getCurrencyRateWithCache } from "~/extension/background-script/actions/cache/getCurrencyRate";
 import state from "~/extension/background-script/state";
 import i18n from "~/i18n/i18nConfig";
 import type { PaymentNotificationData, AuthNotificationData } from "~/types";
+
+const notify = (options: { title: string; message: string }) => {
+  const settings = state.getState().settings;
+  if (!settings.browserNotifications) return;
+
+  const notification: browser.Notifications.CreateNotificationOptions = {
+    type: "basic",
+    iconUrl: "assets/icons/alby_icon_yellow_48x48.png",
+    ...options,
+  };
+
+  return browser.notifications.create(notification);
+};
 
 const paymentSuccessNotification = async (
   message: "ln.sendPayment.success",
@@ -55,7 +68,7 @@ const paymentSuccessNotification = async (
     total_fees
   )}`;
 
-  return utils.notify({
+  return notify({
     title: notificationTitle,
     message: notificationMessage,
   });
@@ -78,7 +91,7 @@ const paymentFailedNotification = (
     error = paymentResponseData.data.payment_error;
   }
 
-  return utils.notify({
+  return notify({
     title: `⚠️ Payment failed`,
     message: `Error: ${error}`,
   });
@@ -94,7 +107,7 @@ const lnurlAuthSuccessNotification = (
     title = `${title} to ${data.origin.name}`;
   }
 
-  return utils.notify({
+  return notify({
     title,
     message: `Successfully logged in to ${data.lnurlDetails.domain}`,
   });
@@ -106,13 +119,14 @@ const lnurlAuthFailedNotification = (
     error: string;
   }
 ) => {
-  return utils.notify({
+  return notify({
     title: `⚠️ Login failed`,
     message: `${data.error}`,
   });
 };
 
 export {
+  notify,
   paymentSuccessNotification,
   paymentFailedNotification,
   lnurlAuthSuccessNotification,

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -1,22 +1,10 @@
-import browser from "webextension-polyfill";
 import { getFormattedFiat } from "~/common/utils/currencyConvert";
 import { getCurrencyRateWithCache } from "~/extension/background-script/actions/cache/getCurrencyRate";
 import state from "~/extension/background-script/state";
 import i18n from "~/i18n/i18nConfig";
 import type { PaymentNotificationData, AuthNotificationData } from "~/types";
 
-const notify = (options: { title: string; message: string }) => {
-  const settings = state.getState().settings;
-  if (!settings.browserNotifications) return;
-
-  const notification: browser.Notifications.CreateNotificationOptions = {
-    type: "basic",
-    iconUrl: "assets/icons/alby_icon_yellow_48x48.png",
-    ...options,
-  };
-
-  return browser.notifications.create(notification);
-};
+import { notify } from "./helpers";
 
 const paymentSuccessNotification = async (
   message: "ln.sendPayment.success",
@@ -126,7 +114,6 @@ const lnurlAuthFailedNotification = (
 };
 
 export {
-  notify,
   paymentSuccessNotification,
   paymentFailedNotification,
   lnurlAuthSuccessNotification,

--- a/src/extension/content-script/batteries/helpers.ts
+++ b/src/extension/content-script/batteries/helpers.ts
@@ -1,8 +1,13 @@
 import browser from "webextension-polyfill";
-import utils from "~/common/lib/utils";
+import msg from "~/common/lib/msg";
 import type { Battery } from "~/types";
 
-import { ExtensionIcon } from "../../background-script/actions/setup/setIcon";
+// duplicate also in setup/setIcon action
+enum ExtensionIcon {
+  Default = "alby_icon_yellow",
+  Tipping = "alby_icon_blue",
+  Active = "alby_icon_green",
+}
 
 export const findLightningAddressInText = (text: string): string | null => {
   // The second lightning emoji is succeeded by an invisible
@@ -24,5 +29,5 @@ export const setLightningData = (data: [Battery]): void => {
     action: "lightningData",
     args: data,
   });
-  utils.call("setIcon", { icon: ExtensionIcon.Tipping });
+  msg.request("setIcon", { icon: ExtensionIcon.Tipping });
 };


### PR DESCRIPTION
the state, db, and other background script components should not be importend in the content scripts.
Those blow up the size and cause trouble which I don't fully understand (e.g. webln not being available when certain files are loaded)

I think this also fixes the broken window.webln and window.nostr in the current master
