### PR TITLE
feat: added blocklist note

### DIFF
--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -48,9 +48,7 @@ function Enable(props: Props) {
       domain: props.origin.domain,
       host: props.origin.host,
     });
-    alert(
-      `Added ${props.origin.host} to the blocklist, please reload the website`
-    );
+    alert(t("block_added", { host: props.origin.host }));
     msg.error(USER_REJECTED_ERROR);
   }
 

--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -48,6 +48,9 @@ function Enable(props: Props) {
       domain: props.origin.domain,
       host: props.origin.host,
     });
+    alert(
+      `Added ${props.origin.host} to the blocklist, please reload the website`
+    );
     msg.error(USER_REJECTED_ERROR);
   }
 

--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -66,6 +66,11 @@ const DefaultView: FC<Props> = (props) => {
   const isEmptyInvoices =
     !isLoadingInvoices && incomingTransactions?.length === 0;
 
+  const navigate = useNavigate();
+
+  const { t } = useTranslation("translation", { keyPrefix: "home" });
+  const { t: tCommon } = useTranslation("common");
+
   // check if currentURL is blocked
   useEffect(() => {
     const checkBlockedUrl = async () => {
@@ -110,6 +115,9 @@ const DefaultView: FC<Props> = (props) => {
         await msg.request("deleteBlocklist", {
           host: props.currentUrl.host,
         });
+        toast.info(
+          t("default_view.block_removed", { host: props.currentUrl.host })
+        );
       }
       setIsBlockedUrl(false);
     } catch (e) {
@@ -124,11 +132,6 @@ const DefaultView: FC<Props> = (props) => {
       !incomingTransactions && (await loadInvoices());
     }
   };
-
-  const navigate = useNavigate();
-
-  const { t } = useTranslation("translation", { keyPrefix: "home" });
-  const { t: tCommon } = useTranslation("common");
 
   const loadInvoices = async () => {
     setIsLoadingInvoices(true);

--- a/src/app/screens/Nostr/Confirm.tsx
+++ b/src/app/screens/Nostr/Confirm.tsx
@@ -43,6 +43,7 @@ function NostrConfirm() {
       domain: origin.domain,
       host: origin.host,
     });
+    alert(`Added ${origin.host} to the blocklist, please reload the website`);
     msg.error(USER_REJECTED_ERROR);
   }
 

--- a/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
+++ b/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
@@ -41,6 +41,7 @@ function NostrConfirmGetPublicKey() {
       domain: origin.domain,
       host: origin.host,
     });
+    alert(`Added ${origin.host} to the blocklist, please reload the website`);
     msg.error(USER_REJECTED_ERROR);
   }
 

--- a/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
+++ b/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
@@ -41,7 +41,7 @@ function NostrConfirmGetPublicKey() {
       domain: origin.domain,
       host: origin.host,
     });
-    alert(`Added ${origin.host} to the blocklist, please reload the website`);
+    alert(t("block_added", { host: origin.host }));
     msg.error(USER_REJECTED_ERROR);
   }
 

--- a/src/extension/content-script/onend.js
+++ b/src/extension/content-script/onend.js
@@ -21,7 +21,8 @@ const weblnCalls = [
 const disabledCalls = ["webln/enable"];
 
 let isEnabled = false; // store if webln is enabled for this content page
-let callActive = false; // store if a webln is currently active. Used to prevent multiple calls in parallel
+let isRejected = false; // store if the webln enable call failed. if so we do not prompt again
+let callActive = false; // store if a webln call is currently active. Used to prevent multiple calls in parallel
 
 async function init() {
   const inject = await shouldInject();
@@ -52,6 +53,13 @@ async function init() {
     }
 
     if (ev.data && !ev.data.response) {
+      // if an enable call railed we ignore the request to prevent spamming the user with prompts
+      if (isRejected) {
+        console.error(
+          "Enable had failed. Rejecting further WebLN calls until the next reload"
+        );
+        return;
+      }
       // if a call is active we ignore the request
       if (callActive) {
         console.error("WebLN call already executing");
@@ -82,6 +90,11 @@ async function init() {
         // if it is the enable call we store if webln is enabled for this content script
         if (ev.data.action === "webln/enable") {
           isEnabled = response.data?.enabled;
+          if (response.error) {
+            console.error(response.error);
+            console.info("Enable was rejected ignoring further webln calls");
+            isRejected = true;
+          }
         }
         window.postMessage(
           {

--- a/src/extension/content-script/onendnostr.js
+++ b/src/extension/content-script/onendnostr.js
@@ -13,7 +13,12 @@ const nostrCalls = [
   "nostr/encryptOrPrompt",
   "nostr/decryptOrPrompt",
 ];
-let callActive = false;
+// calls that can be executed when webln is not enabled for the current content page
+const disabledCalls = ["nostr/enable"];
+
+let isEnabled = false; // store if nostr is enabled for this content page
+let isRejected = false; // store if the nostr enable call failed. if so we do not prompt again
+let callActive = false; // store if a nostr call is currently active. Used to prevent multiple calls in parallel
 
 async function init() {
   const inject = await shouldInject();
@@ -35,6 +40,13 @@ async function init() {
     }
 
     if (ev.data && !ev.data.response) {
+      // if an enable call railed we ignore the request to prevent spamming the user with prompts
+      if (isRejected) {
+        console.error(
+          "Enable had failed. Rejecting further WebLN calls until the next reload"
+        );
+        return;
+      }
       // if a call is active we ignore the request
       if (callActive) {
         console.error("nostr call already executing");
@@ -44,7 +56,8 @@ async function init() {
       // limit the calls that can be made from window.nostr
       // only listed calls can be executed
       // if not enabled only enable can be called.
-      if (!nostrCalls.includes(ev.data.action)) {
+      const availableCalls = isEnabled ? nostrCalls : disabledCalls;
+      if (!availableCalls.includes(ev.data.action)) {
         console.error("Function not available.");
         return;
       }
@@ -62,6 +75,16 @@ async function init() {
 
       const replyFunction = (response) => {
         callActive = false; // reset call is active
+
+        if (ev.data.action === "nostr/enable") {
+          isEnabled = response.data?.enabled;
+          if (response.error) {
+            console.error(response.error);
+            console.info("Enable was rejected ignoring further nostr calls");
+            isRejected = true;
+          }
+        }
+
         window.postMessage(
           {
             application: "LBE",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -344,7 +344,8 @@
       "default_view": {
         "recent_transactions": "Recent Transactions",
         "no_transactions": "No transactions made with Alby, yet.",
-        "is_blocked_hint": "Alby is currently disabled on {{host}}"
+        "is_blocked_hint": "Alby is currently disabled on {{host}}",
+        "block_removed": "Enabled {{host}}. Please reload the website."
       }
     },
     "accounts": {
@@ -354,7 +355,9 @@
       },
       "edit": {
         "title": "Edit Account",
-        "name": { "label": "Name" },
+        "name": {
+          "label": "Name"
+        },
         "screen_reader": "Edit account name"
       },
       "export": {
@@ -375,7 +378,8 @@
       "allow": "Allow {{host}} to:",
       "request1": "Request approval for transactions",
       "request2": "Request invoices and lightning information",
-      "block_and_ignore": "Block and ignore {{host}}"
+      "block_and_ignore": "Block and ignore {{host}}",
+      "block_added": "Added {{host}} to the blocklist, please reload the website."
     },
     "unlock": {
       "unlock_to_continue": "Unlock to continue",
@@ -469,7 +473,9 @@
         "confirm_password": {
           "label": "Confirm new password:"
         },
-        "submit": { "label": "Change" },
+        "submit": {
+          "label": "Change"
+        },
         "errors": {
           "enter_password": "Please enter a new unlock password.",
           "confirm_password": "Please confirm your password.",
@@ -639,6 +645,7 @@
       "allow": "Allow {{host}} to:",
       "read_public_key": "Read your public key",
       "block_and_ignore": "Block and ignore {{host}}",
+      "block_added": "Added {{host}} to the blocklist, please reload the website.",
       "confirm_sign_message": {
         "remember": {
           "label": "Remember and don't ask again"


### PR DESCRIPTION
the blocklist only takes effect after a page reload.
This might be confusing for the user as the user adds something to the blocklist but it has no effect (until a page reload)
This alert is a quick hack to give the user some feedback.

This PR also adds a check to ignore any webln/nostr calls from the website if the enable call has failed. This prevents the website from spamming the user with multiple prompts. 
