### PR TITLE
chore: test switch to the axios fork/branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@noble/secp256k1": "^1.7.0",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
-    "axios": "^1.2.0",
+    "axios": "https://github.com/sgammon/axios.git#feat/fetch-adapter",
     "bech32": "^2.0.0",
     "bolt11": "^1.4.0",
     "browser-polyfill": "^3.20.2",

--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -10,6 +10,8 @@ import {
   LNURLPaymentInfo,
 } from "~/types";
 
+// @ts-ignore
+import fetchAdapter from "../../../node_modules/axios/lib/adapters/fetch";
 import { bech32Decode } from "../utils/helpers";
 
 const fromInternetIdentifier = (address: string) => {
@@ -87,19 +89,24 @@ const lnurl = {
       return lnurlAuthDetails;
     } else {
       try {
-        const { data }: { data: LNURLDetails | LNURLError } = await axios.get(
-          url.toString()
-        );
-        const lnurlDetails = data;
+        // const { data }: { data: LNURLDetails | LNURLError } = await axios.get(
+        //   url.toString(),
+        // );
+        // const lnurlDetails = data;
 
-        if (isLNURLDetailsError(lnurlDetails)) {
-          throw new Error(`LNURL Error: ${lnurlDetails.reason}`);
-        } else {
-          lnurlDetails.domain = url.hostname;
-          lnurlDetails.url = url.toString();
-        }
+        const response = await axios.get(url.toString(), {
+          adapter: fetchAdapter,
+        });
+        console.log("response: ", response);
 
-        return lnurlDetails;
+        // if (isLNURLDetailsError(lnurlDetails)) {
+        //   throw new Error(`LNURL Error: ${lnurlDetails.reason}`);
+        // } else {
+        //   lnurlDetails.domain = url.hostname;
+        //   lnurlDetails.url = url.toString();
+        // }
+
+        // return lnurlDetails;
       } catch (e) {
         throw new Error(
           `Connection problem or invalid lnurl / lightning address: ${

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -15,3 +15,5 @@ declare module "*.jpg" {
   const content: string;
   export default content;
 }
+
+declare module "~/../node_modules/axios/lib/adapters/fetch";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,14 +2363,16 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.0.tgz#1cb65bd75162c70e9f8d118a905126c4a201d383"
-  integrity sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==
+"axios@https://github.com/sgammon/axios.git#feat/fetch-adapter":
+  version "1.2.0-alpha.1"
+  resolved "https://github.com/sgammon/axios.git#2379f3a6b84cf6214e24b986cb91a9ef41cbd894"
   dependencies:
+    cross-fetch "^3.1.5"
     follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    node-abort-controller "^3.0.1"
     proxy-from-env "^1.1.0"
+    web-streams-polyfill "^3.2.1"
 
 babel-jest@^29.3.1:
   version "29.3.1"
@@ -3333,7 +3335,7 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@3.1.5:
+cross-fetch@3.1.5, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -6934,6 +6936,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-abort-controller@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
 node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
@@ -9706,6 +9713,11 @@ web-encoding@^1.1.5:
     util "^0.12.3"
   optionalDependencies:
     "@zxing/text-encoding" "0.9.0"
+
+web-streams-polyfill@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webextension-polyfill@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
- switched to the repo/fork
- used the adapter to get a response
- logging response

### Result
![image](https://user-images.githubusercontent.com/1016218/205892641-6abc89c0-940e-4de1-8b6e-5c77460d0560.png)
no error message in the console/webpack whatsoever.

<hr/>

Doing somethign similiar in replit with a minimal setup:
https://replit.com/@escapedcat/LustrousFearlessDevicedriver#src/App.jsx
### Result
webview devtools throw: 
```
SyntaxError: The requested module '/node_modules/form-data/lib/browser.js?v=fce17dee' does not provide an export named 'default' (at FormData.js?v=fce17dee:1:8)
```