### PR TITLE
refactor: getOS: don't use deprecated appVersion.

### DIFF
--- a/src/app/components/CompanionDownloadInfo.tsx
+++ b/src/app/components/CompanionDownloadInfo.tsx
@@ -17,7 +17,7 @@ function CompanionDownloadInfo({ hasTorCallback }: Props) {
     if (userAgent.indexOf("Win") !== -1) return "Windows";
     if (userAgent.indexOf("Mac") !== -1) return "MacOS";
     if (userAgent.indexOf("X11") !== -1) return "UNIX";
-    if (userAgent.indexOf("Linux") !== -1) return "Linux"
+    if (userAgent.indexOf("Linux") !== -1) return "Linux";
   }
 
   // TODO: check if the companion app is already installed

--- a/src/app/components/CompanionDownloadInfo.tsx
+++ b/src/app/components/CompanionDownloadInfo.tsx
@@ -13,10 +13,11 @@ function CompanionDownloadInfo({ hasTorCallback }: Props) {
   });
 
   function getOS() {
-    if (navigator.appVersion.indexOf("Win") != -1) return "Windows";
-    if (navigator.appVersion.indexOf("Mac") != -1) return "MacOS";
-    if (navigator.appVersion.indexOf("X11") != -1) return "UNIX";
-    if (navigator.appVersion.indexOf("Linux") != -1) return "Linux";
+    const userAgent = navigator.userAgent;
+    if (userAgent.indexOf("Win") !== -1) return "Windows";
+    if (userAgent.indexOf("Mac") !== -1) return "MacOS";
+    if (userAgent.indexOf("X11") !== -1) return "UNIX";
+    if (userAgent.indexOf("Linux") !== -1) return "Linux"
   }
 
   // TODO: check if the companion app is already installed


### PR DESCRIPTION
### Describe the changes you have made in this PR

+ From MDN:
  https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appVersion

  > Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. ... Be aware that this feature may cease to work at any time.

  There's no such warning for `userAgent` and here's a source on how to use it instead:
  https://www.educative.io/answers/how-to-detect-the-operating-system-of-the-client-machine-using-js

### Screenshots of the problem [optional]

<img width="808" alt="SCR-20221207-v0z" src="https://user-images.githubusercontent.com/100707419/206298967-dba65d57-b246-4061-be7c-fd84c65ce364.png">


### How has this been tested?

+ only on my local system. Trusting the linked blog post that user agents are generally well-behaving and as reliable as `appVersion`.

### Checklist

- [ ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
