### PR TITLE
refactor: Navbar: constrain max width to same width as the content.

### DIFF
--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -7,17 +7,19 @@ type Props = {
 
 export default function Navbar({ children }: Props) {
   return (
-    <div className="px-4 py-2 bg-white flex justify-between items-center border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
-      <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
-        <AccountMenu />
-      </div>
-      {children && (
-        <div>
-          <nav className="flex space-x-8">{children}</nav>
+    <div className="px-4 py-2 bg-white border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
+      <div className="max-w-screen-lg flex justify-between mx-auto w-full px-3 items-center">
+        <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
+          <AccountMenu />
         </div>
-      )}
-      <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
-        <UserMenu />
+        {children && (
+          <div>
+            <nav className="flex space-x-8">{children}</nav>
+          </div>
+        )}
+        <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
+          <UserMenu />
+        </div>
       </div>
     </div>
   );

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -8,15 +8,11 @@ type Props = {
 export default function Navbar({ children }: Props) {
   return (
     <div className="px-4 py-2 bg-white border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
-      <div className="max-w-screen-lg flex justify-between mx-auto w-full px-3 items-center">
+      <div className="max-w-screen-lg flex justify-between mx-auto w-full px-4 items-center">
         <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
           <AccountMenu />
         </div>
-        {children && (
-          <div>
-            <nav className="flex space-x-8">{children}</nav>
-          </div>
-        )}
+        {children && <nav className="flex space-x-8">{children}</nav>}
         <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
           <UserMenu />
         </div>

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -8,12 +8,14 @@ type Props = {
 export default function Navbar({ children }: Props) {
   return (
     <div className="px-4 py-2 bg-white border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
-      <div className="max-w-screen-lg flex justify-between mx-auto w-full px-4 items-center">
-        <div className="flex w-8/12 md:w-4/12 lg:w-3/12">
+      <div className="max-w-screen-lg flex justify-between mx-auto w-full lg:px-4 items-center">
+        <div className="flex">
           <AccountMenu />
         </div>
-        {children && <nav className="flex space-x-8">{children}</nav>}
-        <div className="md:w-4/12 lg:w-3/12 flex justify-end items-center">
+
+        {children && <nav className="flex space-x-8 lg:-ml-2">{children}</nav>}
+
+        <div className="flex justify-end items-center">
           <UserMenu />
         </div>
       </div>

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -9,15 +9,9 @@ export default function Navbar({ children }: Props) {
   return (
     <div className="px-4 py-2 bg-white border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
       <div className="max-w-screen-lg flex justify-between mx-auto w-full lg:px-4 items-center">
-        <div className="flex">
-          <AccountMenu />
-        </div>
-
+        <AccountMenu />
         {children && <nav className="flex space-x-8 lg:-ml-2">{children}</nav>}
-
-        <div className="flex justify-end items-center">
-          <UserMenu />
-        </div>
+        <UserMenu />
       </div>
     </div>
   );


### PR DESCRIPTION
### Related Rails app PR
+ https://github.com/getAlby/getalby.com/pull/272

### HELP NEEDED / TODOs
+ [x] review code
+ [x] depending on responsiveness needs, consider moving the navigation entries ("websites" etc.) a bit more to the right so they are more centered instead of leaning left.
+ [x] reviewer: test with an extension development setup (or pair with me / let me know how to set one up)
+ [x] reviewer: test responsiveness (current extension's header looks as broken to me on smaller breakpoints as with these changes but I'm not sure!?)

### Describe the changes you have made in this PR
+ Navbar: constrain max width to same width as the content.
+ reason: on desktop the navigation items in the top left and right corners were easy to miss. With this change, everything is closer together and easier to notice.

### Type of change

+ UI improvement

### Screenshots of the changes [optional]
#### Before
<img width="1680" alt="SCR-20221210-ugq" src="https://user-images.githubusercontent.com/100707419/206874947-040900e1-33d8-42fa-b71b-4152675c5453.png">

#### After
<img width="1678" alt="SCR-20221210-ug6" src="https://user-images.githubusercontent.com/100707419/206874949-5cd121b2-9834-4e46-820a-5c4679df7c27.png">



### How has this been tested?

+ ~~⚠️ I only tested this with my browser's inspector. I don't have a development setup for the extension yet.~~ Ok, I have the development setup for the extension now and everything looked good to me.