### PR TITLE
fix: add favicon to extension pages (firefox)

### DIFF
--- a/static/views/options.html
+++ b/static/views/options.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/png" href="assets/icons/alby_icon_yellow_32x32.png">
   <title>Alby</title>
 </head>
 

--- a/static/views/welcome.html
+++ b/static/views/welcome.html
@@ -3,7 +3,8 @@
 
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=500" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/png" href="assets/icons/alby_icon_yellow_32x32.png">
   <title>Alby</title>
 </head>
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

Favicons in extension pages

### Link this PR to an issue [optional]

--

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

<img width="1470" alt="Screenshot 2022-12-12 at 5 15 40 PM" src="https://user-images.githubusercontent.com/64399555/207037324-b4820ee7-22e3-415d-87db-fb5dfc6c0544.png">

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
