### PR TITLE
feat: new ui for tipping options on publisher card

### DIFF
--- a/src/app/screens/Home/PublisherLnData.tsx
+++ b/src/app/screens/Home/PublisherLnData.tsx
@@ -1,9 +1,9 @@
-import Button from "@components/Button";
 import PublisherCard from "@components/PublisherCard";
 import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import Button from "~/app/components/Button";
 import lnurlLib from "~/common/lib/lnurl";
 import { isLNURLDetailsError } from "~/common/utils/typeHelpers";
 import type { Battery } from "~/types";
@@ -81,12 +81,12 @@ export const PublisherLnData: FC<Props> = ({ lnData }) => {
         isCard={false}
         isSmall={false}
       >
-        <Button
-          onClick={sendSatoshis}
-          label={t("actions.send_satoshis")}
-          primary
-          loading={loadingSendSats}
-        />
+        <div className="flex gap-2">
+          <Button label=<>🍬<br/> 5k</> onClick={() => onClick("5000")} fullWidth className="w-10" />
+          <Button label=<>☕<br/> 1k</> onClick={() => onClick("5000")} fullWidth />
+          <Button label=<>🍕<br/> 5k</> onClick={() => onClick("5000")} fullWidth />
+          <Button label=<>🌯 50k</> onClick={() => onClick("5000")} fullWidth />
+        </div>
       </PublisherCard>
     </div>
   );


### PR DESCRIPTION
### Describe the changes you have made in this PR

Users seem to confuse the "send sats" button on the publisher card, also we want to make tipping more prominent in the app if there is tipping information available for the current site. 

### Open tasks
 - [ ] Decide about icons / emojis and their respective values
 - [ ] Implement proper buttons (currently they are a hack)
 - [ ] Take users to the tipping flow with the amount already filled in
 - [ ] Add a custom amount option 
 - [ ] Think about re-using them below the amount field (quick selection of amounts)

### Screenshots of the changes [optional]

![image](https://user-images.githubusercontent.com/100827540/207662232-98adc419-a6c8-4098-a5aa-cb02aa3a3f1f.png)

### How has this been tested?

-

### Checklist

- [ ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
