### PR TITLE
fix: lnurl auth return value cause  error msg

### DIFF
--- a/src/extension/background-script/actions/lnurl/__tests__/auth.test.ts
+++ b/src/extension/background-script/actions/lnurl/__tests__/auth.test.ts
@@ -1,0 +1,54 @@
+import { settingsFixture as mockSettings } from "~/../tests/fixtures/settings";
+import state from "~/extension/background-script/state";
+import type { LNURLDetails } from "~/types";
+
+import { authFunction } from "../auth";
+
+jest.mock("~/extension/background-script/state");
+
+const mockState = {
+  settings: mockSettings,
+  getConnector: () => ({
+    signMessage: () =>
+      Promise.resolve({
+        data: {
+          signature:
+            "rnu5pnhanjs3bfxz33fuyf9ywzrmkm1ns6jxdraxff1irq3hpxcbkce6zk34ee9bh7bamgd891tfy4gq1y119w53qg1ap5zodwi4u51n",
+        },
+      }),
+  }),
+};
+
+const lnurlDetails: LNURLDetails = {
+  domain: "lnurl.fiatjaf.com",
+  k1: "dea6a5e410ae8db8872b30ed715d9c10bbaca1dda653396511a40bb353529572",
+  tag: "login",
+  url: "https://lnurl.fiatjaf.com/lnurl-login",
+};
+
+describe("auth", () => {
+  test("returns success response", async () => {
+    state.getState = jest.fn().mockReturnValue(mockState);
+
+    expect(await authFunction({ lnurlDetails })).toStrictEqual({
+      success: true,
+      status: "OK",
+      reason: undefined,
+      authResponseData: { status: "OK" },
+    });
+  });
+
+  test("fails gracefully if no status is set", async () => {
+    const lnurlDetails: LNURLDetails = {
+      domain: "lnurl.fiatjaf.com",
+      k1: "dea6a5e410ae8db8872b30ed715d9c10bbaca1dda653396511a40bb353529572",
+      tag: "login",
+      url: "https://lnurl.fiatjaf.com/lnurl-login-fail",
+    };
+    state.getState = jest.fn().mockReturnValue(mockState);
+
+    expect(() => authFunction({ lnurlDetails })).rejects.toThrowError(
+      "Auth: Something went wrong"
+    );
+  });
+});

--- a/src/extension/background-script/actions/lnurl/auth.ts
+++ b/src/extension/background-script/actions/lnurl/auth.ts
@@ -89,7 +89,7 @@ export async function authFunction({
     );
 
     // if the service returned with a HTTP 200 we still check if the response data is OK
-    if (authResponse?.data.status.toUpperCase() !== "OK") {
+    if (authResponse?.data.status?.toUpperCase() !== "OK") {
       throw new Error(
         authResponse?.data?.reason || "Auth: Something went wrong"
       );

--- a/src/extension/background-script/actions/lnurl/auth.ts
+++ b/src/extension/background-script/actions/lnurl/auth.ts
@@ -7,11 +7,11 @@ import utils from "~/common/lib/utils";
 import HashKeySigner from "~/common/utils/signer";
 import state from "~/extension/background-script/state";
 import {
-  MessageLnurlAuth,
-  LNURLDetails,
-  LnurlAuthResponse,
-  OriginData,
   AuthResponseObject,
+  LnurlAuthResponse,
+  LNURLDetails,
+  MessageLnurlAuth,
+  OriginData,
 } from "~/types";
 
 const LNURLAUTH_CANONICAL_PHRASE =
@@ -44,6 +44,7 @@ export async function authFunction({
       key_index: 0,
     },
   });
+
   const lnSignature = signResponse.data.signature;
 
   // make sure we got a signature
@@ -64,6 +65,7 @@ export async function authFunction({
   } else {
     linkingKeyPriv = hmacSHA256(url.host, Hex.parse(hashingKey)).toString(Hex);
   }
+
   // make sure we got a hashingKey and a linkingkey (just to be sure for whatever reason)
   if (!hashingKey || !linkingKeyPriv) {
     throw new Error("Invalid hashingKey/linkingKey");

--- a/tests/fixtures/msw/handlers.ts
+++ b/tests/fixtures/msw/handlers.ts
@@ -39,4 +39,22 @@ export const handlers = [
       );
     }
   ),
+
+  rest.get("https://lnurl.fiatjaf.com/lnurl-login", (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: "OK",
+      })
+    );
+  }),
+
+  rest.get("https://lnurl.fiatjaf.com/lnurl-login-fail", (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: null,
+      })
+    );
+  }),
 ];


### PR DESCRIPTION
### Describe the changes you have made in this PR

When the result returned by the lnurl auth api is missing a field, the prompt should be Auth: Something went wrong


### Link this PR to an issue [optional]

- Fixes #1874

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)


### Screenshots of the changes [optional]
For example, the status field is missing
<img width="383" alt="WX20221215-131744@2x" src="https://user-images.githubusercontent.com/3917994/207782054-91c100a0-1fa2-43fc-a5a8-903031ed9374.png">

after fix 
![WX20221215-134759](https://user-images.githubusercontent.com/3917994/207782641-effb9107-45c3-4cc2-8f3d-31cf48f47b38.png)


### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
