### PR TITLE
README:

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,6 @@ Then run the following
 
 ### 🛠 Development
 
-- Install dependencies\
-  `yarn install`
-- To watch file changes in development
-  - Chrome\
-    `yarn run dev:chrome`
-  - Firefox\
-    `yarn run dev:firefox`
-  - Opera\
-    `yarn run dev:opera`
-
 [Refer to SETUP.md for info regarding how to setup Alby](./doc/SETUP.md)
 
 ## Native Companions

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -2,7 +2,20 @@
 
 ## 🚀 Quick Start
 
+- Install dependencies\
+  `$ yarn install`
+
 ### 💻 Load extension into browser
+
+- Start development build, which will automatically watch for file changes:
+
+  - Chrome\
+    `$ yarn run dev:chrome`
+  - Firefox\
+    `$ yarn run dev:firefox`
+  - Opera\
+     `$ yarn run dev:opera`
+    **NOTE:** by default, the extension built this way will talk to the development regtest API. In case you want to do manual tests against the production API, add the following `WALLET_CREATE_URL` environment variable to your command: `$ WALLET_CREATE_URL="https://getalby.com/api/users" yarn run dev:your-browser-of-choice`
 
 - **Chrome**
 

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -15,7 +15,7 @@
     `$ yarn run dev:firefox`
   - Opera\
      `$ yarn run dev:opera`
-    **NOTE:** by default, the extension built this way will talk to the development regtest API. In case you want to do manual tests against the production API, add the following `WALLET_CREATE_URL` environment variable to your command: `$ WALLET_CREATE_URL="https://getalby.com/api/users" yarn run dev:your-browser-of-choice`
+    **NOTE:** by default, the extension built this way will talk to the testnet API (which runs under [app.regtest.getalby.com](https://app.regtest.getalby.com/user)). In case you want to do manual tests against the mainnet API, add the following `WALLET_CREATE_URL` environment variable to your command: `$ WALLET_CREATE_URL="https://getalby.com/api/users" yarn run dev:your-browser-of-choice`
 
 - **Chrome**
 


### PR DESCRIPTION
+ move all dev setup instructions to one place. Before they were scattered and you could miss esssential steps when only looking at SETUP.md.

SETUP:
+ add note on how to talk to production API (WALLET_CREATE_URL).
