### PR TITLE
feat: always focus prompt

### DIFF
--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -85,9 +85,7 @@ const utils = {
             tabId = window.tabs[0].id;
           }
 
-          // make sure that the prompt is always focussed
-          // this interval focusses the prompt every 2 secons to make sure it is not hidden and
-          // that it draws the user's attention to the popup
+          // this interval hightlights the popup in the taskbar
           const focusInterval = setInterval(() => {
             if (!window.id) {
               return;

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -67,15 +67,18 @@ const utils = {
       "prompt.html"
     )}?${urlParams.toString()}`;
 
-    const { top, left } = await getWindowPosition(400, 600);
+    const windowWidth = 400;
+    const windowHeight = 600;
+
+    const { top, left } = await getWindowPosition(windowWidth, windowHeight);
 
     return new Promise((resolve, reject) => {
       browser.windows
         .create({
           url: url,
           type: "popup",
-          width: 400,
-          height: 600,
+          width: windowWidth,
+          height: windowHeight,
           top: top,
           left: left,
         })

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -67,24 +67,37 @@ const utils = {
     )}?${urlParams.toString()}`;
 
     return new Promise(async (resolve, reject) => {
-      async function getPosition(w, h) {
+      async function getPosition(
+        width: number,
+        height: number
+      ): Promise<{ top: number; left: number }> {
         let left = 0;
         let top = 0;
         try {
           const lastFocused = await browser.windows.getLastFocused();
           // Position window in top right corner of lastFocused window.
-          top = lastFocused.top;
-          left = lastFocused.left + (lastFocused.width - w);
-          // Centered
-          // top = lastFocused.top + (lastFocused.height - h) / 2;
-          // left = lastFocused.left + (lastFocused.width - w) / 2;
+          if (
+            lastFocused &&
+            lastFocused.top != undefined &&
+            lastFocused.left != undefined &&
+            lastFocused.width != undefined &&
+            lastFocused.height != undefined
+          ) {
+            // Top right
+            top = lastFocused.top ?? 0;
+            left = lastFocused.left + (lastFocused.width - width);
+
+            // Centered
+            top = lastFocused.top + (lastFocused.height - height) / 2;
+            left = lastFocused.left + (lastFocused.width - width) / 2;
+          }
         } catch (_) {
           // The following properties are more than likely 0, due to being
           // opened from the background chrome process for the extension that
           // has no physical dimensions
           const { screenX, screenY, outerWidth } = window;
           top = Math.max(screenY, 0);
-          left = Math.max(screenX + (outerWidth - w), 0);
+          left = Math.max(screenX + (outerWidth - width), 0);
         }
         return {
           top,
@@ -114,11 +127,11 @@ const utils = {
           const focusInterval = setInterval(() => {
             if (!window.id) {
               return;
-            } // mainly for TS I guess
+            }
             browser.windows.update(window.id, {
-              focused: true,
+              drawAttention: true,
             });
-          }, 1);
+          }, 2100);
           const onMessageListener = (
             responseMessage: {
               response?: unknown;

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -1,5 +1,6 @@
 import browser, { Runtime } from "webextension-polyfill";
 import { ABORT_PROMPT_ERROR } from "~/common/constants";
+import { getPosition as getWindowPosition } from "~/common/utils/window";
 import type { Invoice, OriginData, OriginDataInternal } from "~/types";
 
 const utils = {
@@ -66,46 +67,9 @@ const utils = {
       "prompt.html"
     )}?${urlParams.toString()}`;
 
-    return new Promise(async (resolve, reject) => {
-      async function getPosition(
-        width: number,
-        height: number
-      ): Promise<{ top: number; left: number }> {
-        let left = 0;
-        let top = 0;
-        try {
-          const lastFocused = await browser.windows.getLastFocused();
-          // Position window in top right corner of lastFocused window.
-          if (
-            lastFocused &&
-            lastFocused.top != undefined &&
-            lastFocused.left != undefined &&
-            lastFocused.width != undefined &&
-            lastFocused.height != undefined
-          ) {
-            // Top right
-            top = lastFocused.top ?? 0;
-            left = lastFocused.left + (lastFocused.width - width);
+    const { top, left } = await getWindowPosition(400, 600);
 
-            // Centered
-            top = lastFocused.top + (lastFocused.height - height) / 2;
-            left = lastFocused.left + (lastFocused.width - width) / 2;
-          }
-        } catch (_) {
-          // The following properties are more than likely 0, due to being
-          // opened from the background chrome process for the extension that
-          // has no physical dimensions
-          const { screenX, screenY, outerWidth } = window;
-          top = Math.max(screenY, 0);
-          left = Math.max(screenX + (outerWidth - width), 0);
-        }
-        return {
-          top,
-          left,
-        };
-      }
-
-      const { top, left } = await getPosition(400, 600);
+    return new Promise((resolve, reject) => {
       browser.windows
         .create({
           url: url,

--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -80,6 +80,17 @@ const utils = {
             tabId = window.tabs[0].id;
           }
 
+          // make sure that the prompt is always focussed
+          // this interval focusses the prompt every 2 secons to make sure it is not hidden and
+          // that it draws the user's attention to the popup
+          const focusInterval = setInterval(() => {
+            if (!window.id) {
+              return;
+            } // mainly for TS I guess
+            browser.windows.update(window.id, {
+              focused: true,
+            });
+          }, 2100);
           const onMessageListener = (
             responseMessage: {
               response?: unknown;
@@ -94,6 +105,7 @@ const utils = {
               sender.tab &&
               sender.tab.id === tabId
             ) {
+              clearInterval(focusInterval);
               browser.tabs.onRemoved.removeListener(onRemovedListener);
               if (sender.tab.windowId) {
                 return browser.windows.remove(sender.tab.windowId).then(() => {
@@ -110,6 +122,7 @@ const utils = {
           };
 
           const onRemovedListener = (tid: number) => {
+            clearInterval(focusInterval);
             if (tabId === tid) {
               browser.runtime.onMessage.removeListener(onMessageListener);
               reject(new Error(ABORT_PROMPT_ERROR));

--- a/src/common/utils/window.ts
+++ b/src/common/utils/window.ts
@@ -1,0 +1,37 @@
+import browser from "webextension-polyfill";
+
+export async function getPosition(
+  width: number,
+  height: number
+): Promise<{ top: number; left: number }> {
+  let left = 0;
+  let top = 0;
+  try {
+    const lastFocused = await browser.windows.getLastFocused();
+
+    if (
+      lastFocused &&
+      lastFocused.top != undefined &&
+      lastFocused.left != undefined &&
+      lastFocused.width != undefined &&
+      lastFocused.height != undefined
+    ) {
+      // Position window in the center of the lastFocused window
+      // Rounding for integer values (px)
+      top = Math.round(lastFocused.top + (lastFocused.height - height) / 2);
+      left = Math.round(lastFocused.left + (lastFocused.width - width) / 2);
+    }
+  } catch (_) {
+    // The following properties are more than likely 0, due to being
+    // opened from the background chrome process for the extension that
+    // has no physical dimensions
+    const { screenX, screenY, outerWidth } = window;
+    top = Math.max(screenY, 0);
+    left = Math.max(screenX + (outerWidth - width), 0);
+  }
+
+  return {
+    top,
+    left,
+  };
+}


### PR DESCRIPTION
### Describe the changes you have made in this PR

This makes sure that the prompt is focussed every 2 seconds. 
If the user "looses" the prompt this change brings the prompt in focus again.

### Link this PR to an issue [optional]

Fixes #1856

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Video

https://share.cleanshot.com/ZmEgc6
