### PR TITLE
fix: allowances enable unit test fixture data

### DIFF
--- a/src/extension/background-script/actions/allowances/__tests__/enable.test.ts
+++ b/src/extension/background-script/actions/allowances/__tests__/enable.test.ts
@@ -22,7 +22,7 @@ utils.openPrompt = jest
   .fn()
   .mockReturnValue({ data: { enabled: true, remember: true } });
 
-const mockAllowances: DbAllowance[] = allowanceFixture;
+const mockAllowances: DbAllowance[] = [{ ...allowanceFixture[0] }];
 
 describe("enable allowance", () => {
   afterEach(() => {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Edit the allowance enable test  fixture data

When checking the data, the data with id 2 is used, so there can only be one item fixture data
```
const allowance = await db.allowances.get(2);
```

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)


### Screenshots of the changes [optional]

_Add screenshots to make your changes easier to understand. You can also add a video here._

### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
