### PR TITLE
Feat/i18n zh cn

### DIFF
--- a/src/i18n/i18nConfig.ts
+++ b/src/i18n/i18nConfig.ts
@@ -3,6 +3,7 @@ import "dayjs/locale/es";
 import "dayjs/locale/it";
 import "dayjs/locale/pt-br";
 import "dayjs/locale/sv";
+import "dayjs/locale/zh-cn";
 import i18n from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
@@ -12,6 +13,7 @@ import es from "~/i18n/locales/es/translation.json";
 import it from "~/i18n/locales/it/translation.json";
 import pt_BR from "~/i18n/locales/pt_BR/translation.json";
 import sv from "~/i18n/locales/sv/translation.json";
+import zh_Hans from "~/i18n/locales/zh_Hans/translation.json";
 
 export const defaultNS = "translation";
 // needs to be aligned with `supportedLocales`
@@ -42,6 +44,11 @@ export const resources = {
     common: sv.common,
     components: sv.components,
   },
+  "zh-CN": {
+    translation: zh_Hans.translation,
+    common: zh_Hans.common,
+    components: zh_Hans.components,
+  },
 } as const;
 
 // needs to be aligned with `resources`
@@ -51,6 +58,7 @@ export const supportedLocales = [
   { locale: "it", label: "Italiano" },
   { locale: "pt-BR", label: "Português (Brasil)" },
   { locale: "sv", label: "Svenska" },
+  { locale: "zh-CN", label: "中文（简化字）" },
 ];
 
 i18n

--- a/src/i18n/locales/zh_Hans/translation.json
+++ b/src/i18n/locales/zh_Hans/translation.json
@@ -328,7 +328,7 @@
       "allowance_view": {
         "recent_transactions": "近期交易",
         "no_transactions": "<0>{{name}}</0>还没有交易。",
-        "sats_used": "已使用的聪",
+        "sats_used": "已使用的sats",
         "allowance": "限额"
       },
       "default_view": {
@@ -679,8 +679,8 @@
     "optional": "可选",
     "description": "描述",
     "message": "消息",
-    "sats_one": "聪",
-    "sats_other": "聪",
+    "sats_one": "sat",
+    "sats_other": "sats",
     "success_message": "{{amount}}{{fiatAmount}}已发送至{{destination}}",
     "response": "答复",
     "help": "帮助",


### PR DESCRIPTION
Chinese is at 84%: https://hosted.weblate.org/projects/getalby-lightning-browser-extension/getalby-lightning-browser-extension/  
Other languages we already support have a similar percentage.
像差不多吧

- switched 聪 to sat/sats, we shouldn't translate these