### PR TITLE
feat: support bip21 invoices in send

### DIFF
--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -9,6 +9,7 @@ import Header from "@components/Header";
 import IconButton from "@components/IconButton";
 import QrcodeScanner from "@components/QrcodeScanner";
 import TextField from "@components/form/TextField";
+import lightningPayReq from "bolt11";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -94,6 +95,7 @@ function Send() {
           },
         });
       } else {
+        lightningPayReq.decode(invoice); // throws if invalid.
         navigate("/confirmPayment", {
           state: {
             args: {

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -9,7 +9,6 @@ import Header from "@components/Header";
 import IconButton from "@components/IconButton";
 import QrcodeScanner from "@components/QrcodeScanner";
 import TextField from "@components/form/TextField";
-import lightningPayReq from "bolt11";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -95,16 +94,10 @@ function Send() {
           },
         });
       } else {
-        let bolt11, match;
-        // look for bolt11 encoding if it's a BIP21 invoice
-        if ((match = invoice.trim().match(/bitcoin:\S*lightning=([^&]*)/i))) {
-          bolt11 = match[1];
-        }
-        lightningPayReq.decode(bolt11 ?? invoice); // throws if invalid.
         navigate("/confirmPayment", {
           state: {
             args: {
-              paymentRequest: bolt11 ?? invoice,
+              paymentRequest: invoice,
             },
           },
         });
@@ -180,9 +173,7 @@ function Send() {
               disabled={loading}
               autoFocus
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                setInvoice(
-                  event.target.value.trim().replace(/^lightning:/i, "")
-                )
+                setInvoice(extractInvoiceFrom(event.target.value.trim()))
               }
               endAdornment={
                 <button

--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -95,11 +95,16 @@ function Send() {
           },
         });
       } else {
-        lightningPayReq.decode(invoice); // throws if invalid.
+        let bolt11, match;
+        // look for bolt11 encoding if it's a BIP21 invoice
+        if ((match = invoice.trim().match(/bitcoin:\S*lightning=([^&]*)/i))) {
+          bolt11 = match[1];
+        }
+        lightningPayReq.decode(bolt11 ?? invoice); // throws if invalid.
         navigate("/confirmPayment", {
           state: {
             args: {
-              paymentRequest: invoice,
+              paymentRequest: bolt11 ?? invoice,
             },
           },
         });


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds support for BIP21 invoices in Send Screen

### Link this PR to an issue [optional]

Fixes #1897 

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [Before/After]
<p>
<img width="49%" alt="Screenshot 2023-01-02 at 9 06 16 PM" src="https://user-images.githubusercontent.com/64399555/210252482-06699f7e-808c-40e5-a412-2eadd283c0c9.png">

<img width="49%" alt="Screenshot 2023-01-02 at 9 05 14 PM" src="https://user-images.githubusercontent.com/64399555/210252369-00763714-020e-4af8-8cbc-7fcd19857513.png">
<p/>

### How has this been tested?

Using this BIP21 invoice: `bitcoin:bc1q0gf7ygdcwjxtfgmzlaqqtxn3s7sdamyw5v48a5?label=Buy%20me%20Coffee&message=Let%27s%20test%20BIP21&amount=0.0005&lightning=lnbc10u1p3pj257pp5yztkwjcz5ftl5laxkav23zmzekaw37zk6kmv80pk4xaev5qhtz7qdpdwd3xger9wd5kwm36yprx7u3qd36kucmgyp282etnv3shjcqzpgxqyz5vqsp5usyc4lk9chsfp53kvcnvq456ganh60d89reykdngsmtj6yw3nhvq9qyyssqjcewm5cjwz4a6rfjx77c490yced6pemk0upkxhy89cmm7sct66k8gneanwykzgdrwrfje69h9u5u0w57rrcsysas7gadwmzxc8c6t0spjazup6`

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
