### PR TITLE
fix: display name instead of url as the publishercard title

### DIFF
--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -5,7 +5,7 @@ import PublisherCard from "@components/PublisherCard";
 import TransactionsTable from "@components/TransactionsTable";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -75,7 +75,7 @@ function Publisher() {
     <div>
       <div className="border-b border-gray-200 dark:border-neutral-500">
         <PublisherCard
-          title={allowance?.host || ""}
+          title={allowance?.name || ""}
           image={allowance?.imageURL || ""}
           url={allowance?.host}
           isCard={false}


### PR DESCRIPTION
### Describe the changes you have made in this PR

Currently the website url is displayed twice. Instead we want to show the website name as the title of the publisher card. 