### PR TITLE
feat: primary colors & gradients

### DIFF
--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -1,11 +1,11 @@
 import {
   AddressBookIcon,
   CaretDownIcon,
+  CheckIcon,
   PlusIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
-import { CheckIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
 import { useNavigate } from "react-router-dom";
@@ -133,7 +133,7 @@ function AccountMenu({ showOptions = true }: Props) {
                 {accountId === authAccount?.id && (
                   <span
                     data-testid="selected"
-                    className="ml-auto w-3.5 h-3.5 rounded-full bg-orange-bitcoin flex justify-center items-center"
+                    className="ml-auto w-3.5 h-3.5 rounded-full bg-primary flex justify-center items-center"
                   >
                     <CheckIcon className="w-3 h-3 text-white" />
                   </span>

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -44,7 +44,7 @@ const Button = forwardRef(
           halfWidth && "w-1/2 first:mr-2 last:ml-2",
           fullWidth || halfWidth ? "px-0 py-2" : "px-7 py-2",
           primary
-            ? "bg-gradient-to-bl from-amber-300 to-amber-500 text-white"
+            ? "bg-gradient-to-bl from-amber-400 to-amber-600 text-white"
             : outline
             ? "bg-white text-primary border border-primary dark:bg-surface-02dp"
             : `bg-white text-gray-700 dark:bg-surface-02dp dark:text-neutral-200 dark:border-neutral-800`,

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -46,7 +46,7 @@ const Button = forwardRef(
           primary
             ? "bg-gradient-to-bl from-amber-300 to-amber-500 text-white"
             : outline
-            ? "bg-white text-orange-bitcoin border border-orange-bitcoin dark:bg-surface-02dp"
+            ? "bg-white text-primary border border-primary dark:bg-surface-02dp"
             : `bg-white text-gray-700 dark:bg-surface-02dp dark:text-neutral-200 dark:border-neutral-800`,
           primary && !disabled && "hover:bg-gradient-to-br",
           !primary &&
@@ -54,7 +54,7 @@ const Button = forwardRef(
             "hover:bg-gray-50 dark:hover:bg-surface-16dp",
           disabled ? "cursor-default opacity-60" : "cursor-pointer",
           flex && "flex-1",
-          "inline-flex justify-center items-center font-medium rounded-md shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin transition duration-150"
+          "inline-flex justify-center items-center font-medium rounded-md shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary transition duration-150"
         )}
         onClick={onClick}
         disabled={disabled}

--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -44,11 +44,11 @@ const Button = forwardRef(
           halfWidth && "w-1/2 first:mr-2 last:ml-2",
           fullWidth || halfWidth ? "px-0 py-2" : "px-7 py-2",
           primary
-            ? "bg-orange-bitcoin text-white border border-transparent"
+            ? "bg-gradient-to-bl from-amber-300 to-amber-500 text-white"
             : outline
             ? "bg-white text-orange-bitcoin border border-orange-bitcoin dark:bg-surface-02dp"
             : `bg-white text-gray-700 dark:bg-surface-02dp dark:text-neutral-200 dark:border-neutral-800`,
-          primary && !disabled && "hover:bg-orange-bitcoin-700",
+          primary && !disabled && "hover:bg-gradient-to-br",
           !primary &&
             !disabled &&
             "hover:bg-gray-50 dark:hover:bg-surface-16dp",

--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -6,10 +6,12 @@ type Props = {
 
 function Header({ title, headerLeft, headerRight }: Props) {
   return (
-    <div className="relative flex justify-center items-center bg-white px-4 py-2 border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
-      <div className="absolute left-4">{headerLeft}</div>
-      <h1 className="text-lg font-medium dark:text-white">{title}</h1>
-      <div className="absolute right-4">{headerRight}</div>
+    <div className="bg-white py-2 border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
+      <div className="max-w-screen-lg px-4 mx-auto relative flex justify-center items-center">
+        <div className="absolute left-4">{headerLeft}</div>
+        <h1 className="text-lg font-medium dark:text-white">{title}</h1>
+        <div className="absolute right-4">{headerRight}</div>
+      </div>
     </div>
   );
 }

--- a/src/app/components/Navbar/NavbarLink.tsx
+++ b/src/app/components/Navbar/NavbarLink.tsx
@@ -14,7 +14,7 @@ function NavbarLink({ children, end = false, href }: Props) {
       className={({ isActive }) =>
         "block px-1 font-semibold transition-colors duration-200" +
         (isActive
-          ? " text-orange-bitcoin hover:text-orange-bitcoin dark:text-orange-bitcoin"
+          ? " text-primary hover:text-primary dark:text-primary"
           : " text-gray-500 dark:text-neutral-400 hover:text-gray-700")
       }
     >

--- a/src/app/components/Steps/index.tsx
+++ b/src/app/components/Steps/index.tsx
@@ -17,13 +17,13 @@ export default function Steps({ steps }: Props) {
     switch (step.status) {
       case "complete":
         outerStyles =
-          "group pl-4 py-2 flex flex-col border-l-4 border-orange-bitcoin md:pl-0 md:pt-4 md:pb-0 md:border-l-0 md:border-t-4";
+          "group pl-4 py-2 flex flex-col border-l-4 border-primary md:pl-0 md:pt-4 md:pb-0 md:border-l-0 md:border-t-4";
         innerStyles =
           "text-xs text-black dark:text-white font-500 tracking-wide uppercase";
         break;
       case "current":
         outerStyles =
-          "pl-4 py-2 flex flex-col border-l-4 border-orange-bitcoin md:pl-0 md:pt-4 md:pb-0 md:border-l-0 md:border-t-4";
+          "pl-4 py-2 flex flex-col border-l-4 border-primary md:pl-0 md:pt-4 md:pb-0 md:border-l-0 md:border-t-4";
         innerStyles =
           "text-xs text-black dark:text-white font-bold tracking-wide uppercase";
         break;

--- a/src/app/components/form/Checkbox.tsx
+++ b/src/app/components/form/Checkbox.tsx
@@ -11,7 +11,7 @@ function Checkbox({
       type="checkbox"
       checked={checked}
       onChange={onChange}
-      className="h-4 w-4 text-orange-bitcoin focus:ring-orange-bitcoin border-gray-300 rounded"
+      className="h-4 w-4 text-primary focus:ring-primary border-gray-300 rounded"
     />
   );
 }

--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -87,7 +87,7 @@ export default function DualCurrencyField({
           `flex items-stretch overflow-hidden field mt-1 ${!hint && "mb-2"} ${
             fiatValue && "pb-6"
           } relative`,
-          "focus-within:ring-orange-bitcoin focus-within:border-orange-bitcoin focus-within:dark:border-orange-bitcoin focus-within:ring-1",
+          "focus-within:ring-primary focus-within:border-primary focus-within:dark:border-primary focus-within:ring-1",
           outerStyles
         )}
       >

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -40,7 +40,7 @@ export default function Input({
       className={classNames(
         "block w-full placeholder-gray-500 dark:placeholder-neutral-600 dark:text-white",
         !suffix && !endAdornment
-          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
+          ? `${outerStyles} focus:ring-primary focus:border-primary focus:dark:border-primary focus:ring-1`
           : "pr-0 border-0 focus:ring-0 bg-transparent"
       )}
       placeholder={placeholder}
@@ -65,7 +65,7 @@ export default function Input({
     <div
       className={classNames(
         "flex items-stretch overflow-hidden",
-        "focus-within:ring-orange-bitcoin focus-within:border-orange-bitcoin focus-within:dark:border-orange-bitcoin focus-within:ring-1",
+        "focus-within:ring-primary focus-within:border-primary focus-within:dark:border-primary focus-within:ring-1",
         outerStyles
       )}
     >

--- a/src/app/components/form/Toggle/index.tsx
+++ b/src/app/components/form/Toggle/index.tsx
@@ -12,8 +12,8 @@ export default function Toggle({ checked, onChange }: Props) {
       checked={checked}
       onChange={onChange}
       className={classNames(
-        checked ? "bg-orange-bitcoin" : "bg-gray-300 dark:bg-surface-00dp",
-        "relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-bitcoin"
+        checked ? "bg-primary" : "bg-gray-300 dark:bg-surface-00dp",
+        "relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
       )}
     >
       <span

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -131,7 +131,7 @@ function AccountsScreen() {
                 <tr key={accountId}>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
-                      <div className="w-12 h-12 flex justify-center items-center rounded-full bg-orange-bitcoin-50">
+                      <div className="w-12 h-12 flex justify-center items-center rounded-full bg-primary-50">
                         <WalletIcon className="w-8 h-8 text-black" />
                       </div>
                       <div className="ml-4">

--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -1,6 +1,6 @@
 import {
-  SendIcon,
   ReceiveIcon,
+  SendIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
 import Button from "@components/Button";
 import Loading from "@components/Loading";
@@ -8,8 +8,7 @@ import TransactionsTable from "@components/TransactionsTable";
 import { Tab } from "@headlessui/react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { FC } from "react";
-import { useState, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -234,7 +233,7 @@ const DefaultView: FC<Props> = (props) => {
                         "focus:outline-none",
                         "hover:bg-gray-50 dark:hover:bg-surface-16dp",
                         selected
-                          ? "text-orange-bitcoin"
+                          ? "text-primary"
                           : "text-gray-700  dark:text-neutral-200"
                       )
                     }

--- a/src/app/screens/Onboard/Intro/features.tsx
+++ b/src/app/screens/Onboard/Intro/features.tsx
@@ -14,7 +14,7 @@ export default function Features({ features }: Props) {
       {features.map((feature) => (
         <div key={feature.name}>
           <dt>
-            <div className="flex items-center justify-center h-12 w-12 rounded-md bg-orange-bitcoin text-white">
+            <div className="flex items-center justify-center h-12 w-12 rounded-md bg-primary text-white">
               <feature.icon className="h-6 w-6" aria-hidden="true" />
             </div>
             <p className="mt-5 text-lg font-medium text-gray-900 dark:text-white">

--- a/src/app/screens/Settings.tsx
+++ b/src/app/screens/Settings.tsx
@@ -14,8 +14,8 @@ import TextField from "@components/form/TextField";
 import Toggle from "@components/form/Toggle";
 import { Html5Qrcode } from "html5-qrcode";
 import type { FormEvent } from "react";
-import { useState, useEffect } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { useEffect, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import Modal from "react-modal";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
@@ -202,7 +202,6 @@ function Settings() {
                   setModalIsOpen(true);
                 }}
                 label={t("change_password.title")}
-                primary
                 fullWidth
                 loading={isLoading}
                 disabled={isLoading}

--- a/src/app/screens/Unlock/index.tsx
+++ b/src/app/screens/Unlock/index.tsx
@@ -117,7 +117,7 @@ function Unlock() {
         <div className="flex justify-center space-x-1 mt-5">
           <span className="text-gray-500">{t("help_contact.part1")} </span>
           <a
-            className="text-orange-bitcoin font-semibold"
+            className="text-primary font-semibold"
             href="mailto:support@getalby.com"
           >
             {t("help_contact.part2")}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,13 +43,10 @@ module.exports = {
         18: "4.5rem",
       },
       colors: {
-        "orange-bitcoin": "#f7931a",
-        "orange-bitcoin-700": "#e78308",
-        "orange-bitcoin-50": "#fdf0d5",
-        "red-bitcoin": "#eb5757",
+        primary: "#fbbf24",
+        "primary-50": "#fde68a",
         "green-bitcoin": "#27ae60",
         "blue-bitcoin": "#2d9cdb",
-        "purple-bitcoin": "#bb6bd9",
 
         // Material Design Surface Colors
         "surface-00dp": surfaceColor,


### PR DESCRIPTION
### Describe the changes you have made in this PR
 - renamed `orange-bitcoin` to `primary`
 - cleaned up tailwind config
 - introduced a slight gradient for primary buttons
 - fixed some usages of primary buttons (that weren't supposed to be primary)
 - colors are currently from tailwind color scheme: amber-300 / amber-500

Some impressions:
![image](https://user-images.githubusercontent.com/100827540/211431300-9214aad2-5ea7-4f06-8641-981757575ba2.png)
![image](https://user-images.githubusercontent.com/100827540/211431327-59f0ecae-7b71-48f5-8937-f8b6d9ba6313.png)
![image](https://user-images.githubusercontent.com/100827540/211431379-a33ce67d-30d0-4fd7-9f35-a669d847fbfd.png)