### PR TITLE
feat: move nostr key to accounts

### DIFF
--- a/src/app/components/AccountMenu/index.test.tsx
+++ b/src/app/components/AccountMenu/index.test.tsx
@@ -13,8 +13,20 @@ const defaultProps = {
 };
 
 const mockAccounts: Accounts = {
-  "1": { id: "1", connector: "lnd", config: "", name: "LND account" },
-  "2": { id: "2", connector: "galoy", config: "", name: "Galoy account" },
+  "1": {
+    id: "1",
+    connector: "lnd",
+    config: "",
+    name: "LND account",
+    nostrPrivateKey: "",
+  },
+  "2": {
+    id: "2",
+    connector: "galoy",
+    config: "",
+    name: "Galoy account",
+    nostrPrivateKey: "",
+  },
 };
 
 jest.mock("~/app/context/AccountsContext", () => ({

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -21,7 +21,7 @@ import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
 import type { Account } from "~/types";
 
-type AccountAction = Omit<Account, "connector" | "config">;
+type AccountAction = Omit<Account, "connector" | "config" | "nostrPrivateKey">;
 
 function AccountsScreen() {
   const auth = useAccount();

--- a/src/app/screens/connectors/AlbyWallet/index.tsx
+++ b/src/app/screens/connectors/AlbyWallet/index.tsx
@@ -115,6 +115,7 @@ export default function AlbyWallet({ variant }: Props) {
         lnAddress,
       },
       connector: "lndhub",
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectBtcpay/index.tsx
+++ b/src/app/screens/connectors/ConnectBtcpay/index.tsx
@@ -75,6 +75,7 @@ export default function ConnectBtcpay() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectCitadel/index.tsx
+++ b/src/app/screens/connectors/ConnectCitadel/index.tsx
@@ -7,7 +7,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -55,6 +55,7 @@ export default function ConnectCitadel() {
         password,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectCommando/index.tsx
+++ b/src/app/screens/connectors/ConnectCommando/index.tsx
@@ -68,6 +68,7 @@ export default function ConnectCommando() {
         privateKey,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectEclair/index.tsx
+++ b/src/app/screens/connectors/ConnectEclair/index.tsx
@@ -6,7 +6,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -41,6 +41,7 @@ export default function ConnectEclair() {
         url,
       },
       connector: "eclair",
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -3,7 +3,7 @@ import Input from "@components/form/Input";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import axios from "axios";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -266,6 +266,7 @@ export default function ConnectGaloy(props: Props) {
         walletId: config.walletId,
       },
       connector: "galoy",
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectKollider/index.tsx
+++ b/src/app/screens/connectors/ConnectKollider/index.tsx
@@ -61,6 +61,7 @@ export default function ConnectKollidier() {
         currency: formData.currency,
       },
       connector: "kollider",
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectLnbits/index.tsx
+++ b/src/app/screens/connectors/ConnectLnbits/index.tsx
@@ -3,7 +3,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -46,6 +46,7 @@ export default function ConnectLnbits() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectLnd/index.tsx
+++ b/src/app/screens/connectors/ConnectLnd/index.tsx
@@ -52,6 +52,7 @@ export default function ConnectLnd() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectLndHub/index.tsx
+++ b/src/app/screens/connectors/ConnectLndHub/index.tsx
@@ -61,6 +61,7 @@ export default function ConnectLndHub({
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectMyNode/index.tsx
+++ b/src/app/screens/connectors/ConnectMyNode/index.tsx
@@ -3,7 +3,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -62,6 +62,7 @@ export default function ConnectMyNode() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
+++ b/src/app/screens/connectors/ConnectRaspiBlitz/index.tsx
@@ -3,7 +3,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -59,6 +59,7 @@ export default function ConnectRaspiBlitz() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -3,7 +3,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -62,6 +62,7 @@ export default function ConnectStart9() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -3,7 +3,7 @@ import ConnectorForm from "@components/ConnectorForm";
 import TextField from "@components/form/TextField";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import { useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import msg from "~/common/lib/msg";
@@ -62,6 +62,7 @@ export default function ConnectUmbrel() {
         url,
       },
       connector: getConnectorType(),
+      nostrPrivateKey: null,
     };
 
     try {

--- a/src/extension/background-script/actions/accounts/__tests__/add.test.ts
+++ b/src/extension/background-script/actions/accounts/__tests__/add.test.ts
@@ -27,6 +27,7 @@ const message: MessageAccountAdd = {
     connector: "lnd",
     config: "123456config",
     name: "purple",
+    nostrPrivateKey: "123456nostr",
   },
   origin: { internal: true },
   prompt: true,
@@ -57,6 +58,7 @@ describe("add account to account-list", () => {
           connector: "lnd",
           config: "secret-config-string-42",
           name: "purple",
+          nostrPrivateKey: "123456nostr",
         },
       },
     });
@@ -77,11 +79,13 @@ describe("add account to account-list", () => {
           config: "abc",
           connector: "lnd",
           name: "BLUE",
+          nostrPrivateKey: "123",
         },
         "666": {
           config: "xyz",
           connector: "lnd",
           name: "GREEN",
+          nostrPrivateKey: "123",
         },
       },
     };
@@ -102,9 +106,20 @@ describe("add account to account-list", () => {
           connector: "lnd",
           config: "secret-config-string-42",
           name: "purple",
+          nostrPrivateKey: "123456nostr",
         },
-        "666": { config: "xyz", connector: "lnd", name: "GREEN" },
-        "888": { config: "abc", connector: "lnd", name: "BLUE" },
+        "666": {
+          config: "xyz",
+          connector: "lnd",
+          name: "GREEN",
+          nostrPrivateKey: "123",
+        },
+        "888": {
+          config: "abc",
+          connector: "lnd",
+          name: "BLUE",
+          nostrPrivateKey: "123",
+        },
       },
     });
 

--- a/src/extension/background-script/actions/settings/changePassword.ts
+++ b/src/extension/background-script/actions/settings/changePassword.ts
@@ -8,7 +8,6 @@ const changePassword = async (message: Message) => {
   const password = state.getState().password as string;
   const newPassword = message.args.password as string;
   const tmpAccounts = { ...accounts };
-  const nostPrivateKey = await state.getState().getNostr().getPrivateKey();
 
   for (const accountId in tmpAccounts) {
     const accountConfig = decryptData(
@@ -16,9 +15,16 @@ const changePassword = async (message: Message) => {
       password
     );
     tmpAccounts[accountId].config = encryptData(accountConfig, newPassword);
+    const accountNostrKey = decryptData(
+      accounts[accountId].nostrPrivateKey as string,
+      password
+    );
+    tmpAccounts[accountId].nostrPrivateKey = encryptData(
+      accountNostrKey,
+      newPassword
+    );
   }
   state.setState({ accounts: tmpAccounts, password: newPassword });
-  await state.getState().getNostr().setPrivateKey(nostPrivateKey);
   // make sure we immediately persist the updated accounts
   await state.getState().saveToStorage();
 

--- a/src/extension/background-script/migrations/index.ts
+++ b/src/extension/background-script/migrations/index.ts
@@ -46,6 +46,20 @@ const migrations = {
       // state is saved with the setMigrated call
     }
   },
+  migrateisUsingGlobalNostrKey: async () => {
+    const { nostrPrivateKey, accounts } = state.getState();
+
+    if (nostrPrivateKey) {
+      Object.values(accounts).map((account) => {
+        account.nostrPrivateKey = nostrPrivateKey;
+      });
+
+      state.setState({
+        accounts,
+        nostrPrivateKey: null,
+      });
+    }
+  },
 };
 
 const migrate = async () => {
@@ -57,6 +71,11 @@ const migrate = async () => {
     );
     await migrations["migrateisUsingLegacyLnurlAuthKeySetting"]();
     await setMigrated("migrateisUsingLegacyLnurlAuthKeySetting");
+  }
+  if (shouldMigrate("migrateisUsingGlobalNostrKey")) {
+    console.info("Running migration for: migrateisUsingGlobalNostrKey");
+    await migrations["migrateisUsingGlobalNostrKey"]();
+    await setMigrated("migrateisUsingGlobalNostrKey");
   }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { PaymentRequestObject } from "bolt11";
-import { CURRENCIES, ACCOUNT_CURRENCIES } from "~/common/constants";
+import { ACCOUNT_CURRENCIES, CURRENCIES } from "~/common/constants";
 import connectors from "~/extension/background-script/connectors";
 import {
   ConnectorInvoice,
@@ -16,6 +16,7 @@ export interface Account {
   connector: ConnectorType;
   config: string;
   name: string;
+  nostrPrivateKey: string | null;
 }
 
 export interface Accounts {


### PR DESCRIPTION
### Describe the changes you have made in this PR

This removes the nostr key in settings (which is being used globally across all accounts) and adds functionality for accounts to have nostr keys instead

### Link this PR to an issue [optional]

Fixes #1934

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

Not ready yet.

### How has this been tested?

Tested manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
