### PR TITLE
fix: remove window or tab based on what the browser opens

### DIFF
--- a/src/common/lib/utils.ts
+++ b/src/common/lib/utils.ts
@@ -83,6 +83,7 @@ const utils = {
           left: left,
         })
         .then((window) => {
+          let closeWindow = true; // by default we call remove.window (except the browser forces this prompt to open in a tab)
           let tabId: number | undefined;
           if (window.tabs) {
             tabId = window.tabs[0].id;
@@ -92,6 +93,7 @@ const utils = {
           // Find the currently active tab to validate messages
           if (window.tabs && window.tabs?.length > 1) {
             tabId = window.tabs?.find((x) => x.active)?.id;
+            closeWindow = false; // we'll only remove the tab and not the window further down
           }
 
           // this interval hightlights the popup in the taskbar
@@ -116,21 +118,30 @@ const utils = {
               responseMessage &&
               responseMessage.response &&
               sender.tab &&
-              sender.tab.id === tabId
+              sender.tab.id === tabId &&
+              sender.tab.windowId
             ) {
               clearInterval(focusInterval);
               browser.tabs.onRemoved.removeListener(onRemovedListener);
-              if (sender.tab.id) {
-                return browser.tabs.remove(sender.tab.id).then(() => {
-                  // in the future actual "remove" (closing prompt) will be moved to component for i.e. budget flow
-                  // https://github.com/getAlby/lightning-browser-extension/issues/1197
-                  if (responseMessage.error) {
-                    return reject(new Error(responseMessage.error));
-                  } else {
-                    return resolve(responseMessage);
-                  }
-                });
+              // if the window was opened as tab we remove the tab
+              // otherwise if a window was opened we have to remove the window.
+              // Opera fails to close the window with tabs.remove - it fails with: "Tabs cannot be edited right now (user may be dragging a tab)"
+              let closePromise;
+              if (closeWindow) {
+                closePromise = browser.windows.remove(sender.tab.windowId);
+              } else {
+                closePromise = browser.tabs.remove(sender.tab.id as number); // as number only for TS - we check for sender.tab.id in the if above
               }
+
+              return closePromise.then(() => {
+                // in the future actual "remove" (closing prompt) will be moved to component for i.e. budget flow
+                // https://github.com/getAlby/lightning-browser-extension/issues/1197
+                if (responseMessage.error) {
+                  return reject(new Error(responseMessage.error));
+                } else {
+                  return resolve(responseMessage);
+                }
+              });
             }
           };
 


### PR DESCRIPTION
Normally when we open a new window the prompt is the only tab in this window If that's the case we have to close the prompt using windows.remove()

Some browsers force the new window to open in a tab. In this case we have to close the prompt using tabs.remove()

Some browsers actually can close the window when tabs.remove() removes the only/last tab. But Opera fails with the following error: "Tabs cannot be edited right now (user may be dragging a tab)"

