### PR TITLE
feat: add account menu identicon avatar

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -7,6 +7,9 @@ import "@testing-library/jest-dom";
 // https://github.com/mswjs/examples/tree/master/examples/rest-react
 import { server } from "./tests/unit/helpers/server";
 
+// mocking Identicon component canvas
+import 'jest-canvas-mock';
+
 // fix "This script should only be loaded in a browser extension." e.g. https://github.com/mozilla/webextension-polyfill/issues/218
 if (!chrome.runtime.id) chrome.runtime.id = "history-delete";
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "html-webpack-plugin": "^5.5.0",
     "husky": "^8.0.3",
     "jest": "^29.3.1",
+    "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.3.1",
     "jest-webextension-mock": "^3.8.7",
     "lint-staged": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-confetti": "^6.1.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^12.1.4",
+    "react-identicons": "^1.2.5",
     "react-loading-skeleton": "^3.1.0",
     "react-modal": "^3.16.1",
     "react-qr-code": "^2.0.8",

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -4,9 +4,9 @@ import {
   CheckIcon,
   PlusIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
-import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import Identicon from "react-identicons";
 import Skeleton from "react-loading-skeleton";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -75,7 +75,11 @@ function AccountMenu({ showOptions = true }: Props) {
   return (
     <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-surface-12dp max-w-full">
       <p className="flex items-center">
-        <WalletIcon className="-ml-1 w-8 h-8 opacity-50 dark:text-white" />
+        <Identicon
+          string={authAccount?.id}
+          className="ml-1 dark:text-white"
+          size="24"
+        />
       </p>
 
       <div
@@ -126,7 +130,11 @@ function AccountMenu({ showOptions = true }: Props) {
                 disabled={loading}
                 title={account.name}
               >
-                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 shrink-0 opacity-75 text-gray-700 dark:text-neutral-300" />
+                <Identicon
+                  string={accountId}
+                  className="w-6 h-6 -ml-0.5 mr-2 shrink-0 text-gray-700 dark:text-neutral-300"
+                  size="24"
+                />
                 <span className="overflow-hidden text-ellipsis whitespace-nowrap">
                   {account.name}&nbsp;
                 </span>

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -15,3 +15,5 @@ declare module "*.jpg" {
   const content: string;
   export default content;
 }
+
+declare module "react-identicons";

--- a/yarn.lock
+++ b/yarn.lock
@@ -7914,6 +7914,11 @@ react-i18next@^12.1.4:
     "@babel/runtime" "^7.20.6"
     html-parse-stringify "^3.0.1"
 
+react-identicons@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/react-identicons/-/react-identicons-1.2.5.tgz#3502249e49d88f4e3500092694410a984bb102fa"
+  integrity sha512-x7prkDoc2pD7wSl2C1pGxS+XAoSdq1ABWJWTBUimVTDVJArKOLd0B4wRUJpDm4r+9y7pgf8ylyPGsmlWSV5n2g==
+
 react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3319,6 +3319,11 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
+
 cssnano-preset-default@^5.2.9:
   version "5.2.9"
   resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.2.9.tgz#63f6aa9a9f0b21d9a526371dd308253b656a9784"
@@ -5597,6 +5602,14 @@ javascript-natural-sort@0.7.1:
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
   integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
 
+jest-canvas-mock@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz#947b71442d7719f8e055decaecdb334809465341"
+  integrity sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^29.2.0:
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.2.0.tgz#b6598daa9803ea6a4dce7968e20ab380ddbee289"
@@ -6682,6 +6695,13 @@ mkdirp-classic@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 mrmime@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Describe the changes you have made in this PR

As described in the issue the changes add an Identicon avatar icon to the accounts menu. See screenshots for more infos.

### Link this PR to an issue [optional]

Fixes [_#1987_](https://github.com/getAlby/lightning-browser-extension/issues/1987)

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

<img width="446" alt="Bildschirmfoto 2023-01-16 um 20 10 18" src="https://user-images.githubusercontent.com/886152/212795993-7d5ab10f-ac0a-4e54-963a-b553c23f35f3.png">
<img width="441" alt="Bildschirmfoto 2023-01-16 um 20 10 26" src="https://user-images.githubusercontent.com/886152/212796004-a9faad2c-ce86-43a3-8a15-cac71565707b.png">
<img width="390" alt="Bildschirmfoto 2023-01-16 um 20 10 40" src="https://user-images.githubusercontent.com/886152/212796007-36bab539-0c3a-4bbf-8822-955b2b5864af.png">


### How has this been tested?

Tested manually by running extension.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
