### PR TITLE
feat: add account menu avatars - avvvatars lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@noble/secp256k1": "^1.7.1",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "avvvatars-react": "^0.4.2",
     "axios": "^1.2.2",
     "bech32": "^2.0.0",
     "bolt11": "^1.4.0",

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -4,7 +4,7 @@ import {
   CheckIcon,
   PlusIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
-import { WalletIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
+import Avvvatars from "avvvatars-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
@@ -75,7 +75,7 @@ function AccountMenu({ showOptions = true }: Props) {
   return (
     <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-surface-12dp max-w-full">
       <p className="flex items-center">
-        <WalletIcon className="-ml-1 w-8 h-8 opacity-50 dark:text-white" />
+        <Avvvatars value={authAccount?.name || ""} />
       </p>
 
       <div
@@ -126,8 +126,8 @@ function AccountMenu({ showOptions = true }: Props) {
                 disabled={loading}
                 title={account.name}
               >
-                <WalletIcon className="w-6 h-6 -ml-0.5 mr-2 shrink-0 opacity-75 text-gray-700 dark:text-neutral-300" />
-                <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                <Avvvatars value={account.name} />
+                <span className="overflow-hidden text-ellipsis whitespace-nowrap ml-2">
                   {account.name}&nbsp;
                 </span>
                 {accountId === authAccount?.id && (

--- a/src/app/components/AccountMenu/index.tsx
+++ b/src/app/components/AccountMenu/index.tsx
@@ -74,9 +74,9 @@ function AccountMenu({ showOptions = true }: Props) {
 
   return (
     <div className="relative pl-2 flex bg-gray-100 rounded-md dark:bg-surface-12dp max-w-full">
-      <p className="flex items-center">
-        <Avvvatars value={authAccount?.name || ""} />
-      </p>
+      <div className="flex items-center">
+        <Avvvatars value={authAccount?.name || ""} style={"shape"} />
+      </div>
 
       <div
         className={`flex-auto mx-2 py-1 overflow-hidden ${
@@ -126,14 +126,16 @@ function AccountMenu({ showOptions = true }: Props) {
                 disabled={loading}
                 title={account.name}
               >
-                <Avvvatars value={account.name} />
+                <div className="shrink-0">
+                  <Avvvatars value={account.name} style={"shape"} />
+                </div>
                 <span className="overflow-hidden text-ellipsis whitespace-nowrap ml-2">
                   {account.name}&nbsp;
                 </span>
                 {accountId === authAccount?.id && (
                   <span
                     data-testid="selected"
-                    className="ml-auto w-3.5 h-3.5 rounded-full bg-orange-bitcoin flex justify-center items-center"
+                    className="ml-auto w-3.5 h-3.5 rounded-full bg-orange-bitcoin flex justify-center items-center shrink-0"
                   >
                     <CheckIcon className="w-3 h-3 text-white" />
                   </span>

--- a/src/app/screens/Accounts/index.tsx
+++ b/src/app/screens/Accounts/index.tsx
@@ -1,7 +1,6 @@
 import {
   EllipsisIcon,
   PlusIcon,
-  WalletIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { CrossIcon } from "@bitcoin-design/bitcoin-icons-react/outline";
 import Button from "@components/Button";
@@ -9,6 +8,7 @@ import Container from "@components/Container";
 import Loading from "@components/Loading";
 import Menu from "@components/Menu";
 import TextField from "@components/form/TextField";
+import Avvvatars from "avvvatars-react";
 import type { FormEvent } from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -131,8 +131,12 @@ function AccountsScreen() {
                 <tr key={accountId}>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
-                      <div className="w-12 h-12 flex justify-center items-center rounded-full bg-orange-bitcoin-50">
-                        <WalletIcon className="w-8 h-8 text-black" />
+                      <div className="w-12 h-12 flex justify-center items-center">
+                        <Avvvatars
+                          value={account.name}
+                          style={"shape"}
+                          size={48}
+                        />
                       </div>
                       <div className="ml-4">
                         <h3 className="font-bold text-gray-900 dark:text-white">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2347,6 +2347,13 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
+avvvatars-react@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/avvvatars-react/-/avvvatars-react-0.4.2.tgz#9569c16ae9a4925f898539ff98c6f734b6a4fe1b"
+  integrity sha512-D/bnSM+P6pQi71dFeFVqQsqmv+ct5XG7uO2lvJoiksALpXLd6kPgpRR1SUQxFZJkJNrkmg0NPgbhIgJgOsDYRQ==
+  dependencies:
+    goober "^2.1.8"
+
 axios@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.2.tgz#72681724c6e6a43a9fea860fc558127dbe32f9f1"
@@ -4793,6 +4800,11 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+goober@^2.1.8:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.11.tgz#bbd71f90d2df725397340f808dbe7acc3118e610"
+  integrity sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.6"


### PR DESCRIPTION
### Describe the changes you have made in this PR

As described in the issue the changes add an Identicon avatar icon to the accounts menu. See screenshots for more infos.

This is the same change as https://github.com/getAlby/lightning-browser-extension/pull/1990 but with the https://avvvatars.com/ lib. https://github.com/nusu/avvvatars 
This lib has types, but the styles are also different. Two styles are available: character and shapes (see screenshots) I personally prefer "character".

### Link this PR to an issue [optional]

Fixes [_#1987_](https://github.com/getAlby/lightning-browser-extension/issues/1987)

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

<img width="250" alt="Bildschirmfoto 2023-01-18 um 08 06 27" src="https://user-images.githubusercontent.com/886152/213193468-a007547e-7cce-4f7f-8d46-1ca472cbe121.png">
<img width="246" alt="Bildschirmfoto 2023-01-18 um 08 07 28" src="https://user-images.githubusercontent.com/886152/213193476-ee878df4-bfbb-4c74-b748-610dbd710a2f.png">


### How has this been tested?

Tested manually by running extension.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)