### PR TITLE
chore: use fake (in memory) indexed db if indexedDB is not available (Tor Browser)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.32.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "fake-indexeddb": "^3.1.8",
+    "fake-indexeddb": "^4.0.1",
     "filemanager-webpack-plugin": "^8.0.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^8.0.3",

--- a/src/extension/background-script/db.ts
+++ b/src/extension/background-script/db.ts
@@ -1,9 +1,10 @@
 import Dexie from "dexie";
+import { IDBKeyRange, indexedDB } from "fake-indexeddb";
 import browser from "webextension-polyfill";
 import type {
   DbAllowance,
-  DbPayment,
   DbBlocklist,
+  DbPayment,
   DbPermission,
 } from "~/types";
 
@@ -14,7 +15,7 @@ class DB extends Dexie {
   permissions: Dexie.Table<DbPermission, number>;
 
   constructor() {
-    super("LBE");
+    super("LBE", { indexedDB: indexedDB, IDBKeyRange: IDBKeyRange });
     this.version(1).stores({
       allowances:
         "++id,&host,name,imageURL,tag,enabled,totalBudget,remainingBudget,lastPaymentAt,lnurlAuth,createdAt",

--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -3,7 +3,7 @@ import utils from "~/common/lib/utils";
 
 import { ExtensionIcon, setIcon } from "./actions/setup/setIcon";
 import connectors from "./connectors";
-import db from "./db";
+import { isIndexedDbAvailable, db } from "./db";
 import * as events from "./events";
 import migrate from "./migrations";
 import { router } from "./router";
@@ -123,7 +123,14 @@ async function init() {
   await state.getState().init();
   console.info("State loaded");
 
-  await db.open();
+  const dbAvailable = await isIndexedDbAvailable();
+  if (dbAvailable) {
+    console.info("Using indexedDB");
+    await db.open();
+  } else {
+    console.info("Using in memory DB");
+    await db.openWithInMemoryDB();
+  }
   console.info("DB opened");
 
   events.subscribe();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,11 +3148,6 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.5.tgz#bdee0ed2f9b78f2862cda4338a07b13a49b6c9a9"
   integrity sha512-8xo9R00iYD7TcV7OrC98GwxiUEAabVWO3dix+uyWjnYrx9fyASLlIX+f/3p5dW5qByaP2bcZ8X/T47s55et/tA==
 
-core-js@^3.4:
-  version "3.26.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.0.tgz#a516db0ed0811be10eac5d94f3b8463d03faccfe"
-  integrity sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==
-
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
@@ -4343,12 +4338,12 @@ extract-zip@2.0.1:
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
 
-fake-indexeddb@^3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-3.1.8.tgz#229e3cff6fa7355aebb3f147b908d2efa4605d70"
-  integrity sha512-7umIgcdnDfNcjw0ZaoD6yR2BflngKmPsyzZC+sV2fdttwz5bH6B6CCaNzzD+MURfRg8pvr/aL0trfNx65FLiDg==
+fake-indexeddb@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-4.0.1.tgz#09bb2468e21d0832b2177e894765fb109edac8fb"
+  integrity sha512-hFRyPmvEZILYgdcLBxVdHLik4Tj3gDTu/g7s9ZDOiU3sTNiGx+vEu1ri/AMsFJUZ/1sdRbAVrEcKndh3sViBcA==
   dependencies:
-    realistic-structured-clone "^2.0.1"
+    realistic-structured-clone "^3.0.0"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -8018,12 +8013,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-realistic-structured-clone@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/realistic-structured-clone/-/realistic-structured-clone-2.0.4.tgz#7eb4c2319fc3cb72f4c8d3c9e888b11647894b50"
-  integrity sha512-lItAdBIFHUSe6fgztHPtmmWqKUgs+qhcYLi3wTRUl4OTB3Vb8aBVSjGfQZUvkmJCKoX3K9Wf7kyLp/F/208+7A==
+realistic-structured-clone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz#7b518049ce2dad41ac32b421cd297075b00e3e35"
+  integrity sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==
   dependencies:
-    core-js "^3.4"
     domexception "^1.0.1"
     typeson "^6.1.0"
     typeson-registry "^1.0.0-alpha.20"


### PR DESCRIPTION
### Describe the changes you have made in this PR

TLDR; Uses fake-indexeddb to make Alby work in Tor

`indexedDB.open()` throws errors in Firefox Private Mode. You might not be reproduce this in Firefox by enabling Private Mode access to the extension because it still initializes using the default mode's indexedDB (and hence also reflects the changes made in Private Mode to normal mode as well). However, in browsers like Tor, the only available mode (during initialization of the extension) is Private Mode so that makes `indexedDB.open()` throw an error.

To tackle this, we use fake-indexeddb whenever we detect this error thrown due to lack of indexedDB. (We conditionally initialize Dexie with `IDBKeyRange`and `indexedDB` from fake-indexedDB from `._options` and `._deps`)

Related: https://bugzilla.mozilla.org/show_bug.cgi?id=781982

### Type of change

- `chore`

### Screenshots of the changes [optional]

_Add screenshots to make your changes easier to understand. You can also add a video here._

### How has this been tested?

Tested manually on Tor.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
