### PR TITLE
fix: avoid showing welcome screen on re-install

### DIFF
--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -158,7 +158,7 @@ browser.runtime.onInstalled.addListener(handleInstalled);
 
 console.info("Welcome to Alby");
 init().then(() => {
-  if (isFirstInstalled) {
+  if (isFirstInstalled && !state.getState().getAccount()) {
     utils.openUrl("welcome.html");
   }
   if (isRecentlyUpdated) {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Whenever we remove the extension and load it again, the state is persisted, but the user is redirected to welcome page to set a new password. But we can still unlock the extension using the last used password before removing the extension.

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

## Before
https://user-images.githubusercontent.com/64399555/214838447-dabe7d82-2e7b-4cc2-9cfd-3705240b827d.mov

## After
https://user-images.githubusercontent.com/64399555/214838660-307d3253-e88e-4600-a078-75aa7f07809a.mov

### How has this been tested?

Tested manually.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
