### PR TITLE
Feat/performance improved get formatted fiat

### DIFF
--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -19,6 +19,8 @@ interface SettingsContextType {
   updateSetting: (setting: Setting) => void;
   isLoading: boolean;
   getFormattedFiat: (amount: number | string) => Promise<string>;
+  getCurrencyRate: () => Promise<number>;
+  getFormattedFiatFromRate: (amount: number | string, rate: number) => string;
   getFormattedSats: (amount: number | string) => string;
   getFormattedNumber: (amount: number | string) => string;
   getFormattedInCurrency: (
@@ -89,19 +91,21 @@ export const SettingsProvider = ({
   const getFormattedFiat = async (amount: number | string) => {
     try {
       const rate = await getCurrencyRate();
-      const value = getFormattedFiatUtil({
-        amount,
-        rate,
-        currency: settings.currency,
-        locale: settings.locale,
-      });
-
-      return value;
+      return getFormattedFiatFromRate(amount, rate);
     } catch (e) {
       console.error(e);
 
       return "??"; // show the user that something went wrong
     }
+  };
+
+  const getFormattedFiatFromRate = (amount: number | string, rate: number) => {
+    return getFormattedFiatUtil({
+      amount,
+      rate,
+      currency: settings.currency,
+      locale: settings.locale,
+    });
   };
 
   const getFormattedSats = (amount: number | string) => {
@@ -145,6 +149,8 @@ export const SettingsProvider = ({
 
   const value = {
     getFormattedFiat,
+    getFormattedFiatFromRate,
+    getCurrencyRate,
     getFormattedSats,
     getFormattedNumber,
     getFormattedInCurrency,

--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -29,8 +29,9 @@ const AllowanceView: FC<Props> = (props) => {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFormattedFiat,
     getFormattedNumber,
+    getCurrencyRate,
+    getFormattedFiatFromRate,
   } = useSettings();
 
   const [payments, setPayments] = useState<Transaction[] | null>(null);
@@ -57,12 +58,12 @@ const AllowanceView: FC<Props> = (props) => {
       );
 
       try {
+        const rate = await getCurrencyRate();
         // attach fiatAmount if enabled
         for (const payment of payments) {
-          const totalAmountFiat = showFiat
-            ? await getFormattedFiat(payment.totalAmount)
+          payment.totalAmountFiat = showFiat
+            ? getFormattedFiatFromRate(payment.totalAmount, rate)
             : "";
-          payment.totalAmountFiat = totalAmountFiat;
         }
 
         setPayments(payments);
@@ -79,7 +80,8 @@ const AllowanceView: FC<Props> = (props) => {
     props.allowance,
     isLoadingSettings,
     payments,
-    getFormattedFiat,
+    getCurrencyRate,
+    getFormattedFiatFromRate,
     showFiat,
   ]);
 

--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -55,7 +55,8 @@ const DefaultView: FC<Props> = (props) => {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFormattedFiat,
+    getCurrencyRate,
+    getFormattedFiatFromRate,
   } = useSettings();
 
   const showFiat = !isLoadingSettings && settings.showFiat;
@@ -90,11 +91,11 @@ const DefaultView: FC<Props> = (props) => {
       try {
         const payments = await loadPayments();
         // attach fiatAmount if enabled
+        const rate = await getCurrencyRate();
         for (const payment of payments) {
-          const totalAmountFiat = showFiat
-            ? await getFormattedFiat(payment.totalAmount)
+          payment.totalAmountFiat = showFiat
+            ? getFormattedFiatFromRate(payment.totalAmount, rate)
             : "";
-          payment.totalAmountFiat = totalAmountFiat;
         }
         setPayments(payments);
       } catch (e) {
@@ -106,7 +107,13 @@ const DefaultView: FC<Props> = (props) => {
     };
 
     !payments && !isLoadingSettings && getPayments();
-  }, [isLoadingSettings, payments, getFormattedFiat, showFiat]);
+  }, [
+    isLoadingSettings,
+    payments,
+    getCurrencyRate,
+    getFormattedFiatFromRate,
+    showFiat,
+  ]);
 
   const unblock = async () => {
     try {
@@ -152,11 +159,11 @@ const DefaultView: FC<Props> = (props) => {
       date: dayjs(invoice.settleDate).fromNow(),
     }));
 
+    const rate = await getCurrencyRate();
     for (const invoice of invoices) {
-      const totalAmountFiat = settings.showFiat
-        ? await getFormattedFiat(invoice.totalAmount)
+      invoice.totalAmountFiat = settings.showFiat
+        ? getFormattedFiatFromRate(invoice.totalAmount, rate)
         : "";
-      invoice.totalAmountFiat = totalAmountFiat;
     }
 
     setIncomingTransactions(invoices);

--- a/src/app/screens/Publisher.tsx
+++ b/src/app/screens/Publisher.tsx
@@ -22,7 +22,8 @@ function Publisher() {
   const {
     isLoading: isLoadingSettings,
     settings,
-    getFormattedFiat,
+    getCurrencyRate,
+    getFormattedFiatFromRate,
     getFormattedNumber,
   } = useSettings();
 
@@ -49,11 +50,11 @@ function Publisher() {
           publisherLink: payment.location,
         }));
 
+        const rate = await getCurrencyRate();
         for (const payment of payments) {
-          const totalAmountFiat = settings.showFiat
-            ? await getFormattedFiat(payment.totalAmount)
+          payment.totalAmountFiat = settings.showFiat
+            ? getFormattedFiatFromRate(payment.totalAmount, rate)
             : "";
-          payment.totalAmountFiat = totalAmountFiat;
         }
         setPayments(payments);
       }
@@ -61,7 +62,7 @@ function Publisher() {
       console.error(e);
       if (e instanceof Error) toast.error(`Error: ${e.message}`);
     }
-  }, [id, settings.showFiat, getFormattedFiat]);
+  }, [id, settings.showFiat, getCurrencyRate, getFormattedFiatFromRate]);
 
   useEffect(() => {
     // Run once.


### PR DESCRIPTION
### Describe the changes you have made in this PR

Remove blocking `getFormattedFiat` from loops to improve performance. Get the rate with `getCurrencyRate` and just do the non-blocking `getFormattedFiatFromRate` inside the loop.

The changes are: Separate `getFormattedFiatUtil` from SettingsContext `getFormattedFiat` and export `getCurrencyRate` and `getFormattedFiatFromRate`.

The relevant changes are in SettingsContext. The application of this simplification and performance improvement is in the three screen components.

This is also needed for the new https://github.com/getAlby/lightning-browser-extension/issues/2027

### Link this PR to an issue [optional]

Fixes #2031

### Type of change

(Remove other not matching type)

- `refactor`: Performance improvement

### How has this been tested?

Manually.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
