### PR TITLE
Compress discover page images

### DIFF
--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -5,19 +5,19 @@
       {
         "title": "LNMarkets",
         "subtitle": "Instant Bitcoin derivatives trading",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lnmarketes.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lnmarkets.png",
         "url": "https://lnmarkets.com/"
       },
       {
         "title": "Kollider",
         "subtitle": "Instant Bitcoin derivatives trading",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/kollider_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/kollider_thumbnail.png",
         "url": "https://kollider.xyz/"
       },
       {
         "title": "LOFT",
         "subtitle": "Trade investment products in Bitcoin",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/loft-trade_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/loft-trade_thumbnail.png",
         "url": "https://loft.trade/"
       }
     ]
@@ -28,13 +28,13 @@
       {
         "title": "Lightning Poker",
         "subtitle": "Play Poker with Bitcoin",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightning-poker_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightning-poker_thumbnail.png",
         "url": "https://lightning-poker.com/"
       },
       {
         "title": "LNBlackJack",
         "subtitle": "Play Blackjack with Bitcoin",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lnblackjack_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lnblackjack_thumbnail.png",
         "url": "https://www.lnblackjack.com/"
       },
       {
@@ -46,7 +46,7 @@
       {
         "title": "LNflip",
         "subtitle": "Play coin flip matches against other players",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lnflip_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lnflip_thumbnail.png",
         "url": "https://www.lnflip.com/"
       }
     ]
@@ -57,25 +57,25 @@
       {
         "title": "Podverse",
         "subtitle": "Podcast player with bitcoin payments",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/podverse_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/podverse_thumbnail.png",
         "url": "https://podverse.fm/"
       },
       {
         "title": "Stacker.News",
         "subtitle": "Lightning powered Bitcoin news site",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/stacker-news_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/stacker-news_thumbnail.png",
         "url": "https://stacker.news/"
       },
       {
         "title": "Wavlake",
         "subtitle": "Lightning powered music player",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/wavlake.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/wavlake.png",
         "url": "https://www.wavlake.com/"
       },
       {
         "title": "Y'alls",
         "subtitle": "Articles about the Lightning Network",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/yalls.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/yalls.png",
         "url": "https://yalls.org/"
       }
     ]
@@ -92,7 +92,7 @@
       {
         "title": "Lightning Network Stores",
         "subtitle": "Collection of stores and websites accepting bitcoin",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightning-network-stores_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightning-network-stores_thumbnail.png",
         "url": "https://lightningnetworkstores.com/"
       },
       {
@@ -150,31 +150,31 @@
       {
         "title": "Geyser",
         "subtitle": "Crowdfunding projects with Bitcoin Lightning",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/geyser_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/geyser_thumbnail.png",
         "url": "https://geyser.fund/"
       },
       {
         "title": "Amboss",
         "subtitle": "Lightning Network node explorer",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/amboss-space_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/amboss-space_thumbnail.png",
         "url": "https://amboss.space/"
       },
       {
         "title": "Lightsats",
         "subtitle": "Onboard people to bitcoin by sending them tips",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightsats_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightsats_thumbnail.png",
         "url": "https://lightsats.com/"
       },
       {
         "title": "Sats for Likes",
         "subtitle": "Earn sats for accomplishing tasks",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/sats4likes.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/sats4likes.png",
         "url": "https://www.sats4likes.com/"
       },
       {
         "title": "Vida",
         "subtitle": "Earn sats anytime someone wants to connect and chatt",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/vida_thumbnail.svg",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/vida_thumbnail.png",
         "url": "https://vida.page/"
       },
       {

--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -113,16 +113,22 @@
         "url": "https://astral.ninja/"
       },
       {
-        "title": "Snort",
-        "subtitle": "Fast nostr web client.",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/snort_thumbnail.png",
-        "url": "https://snort.social"
-      },
-      {
         "title": "emon.chat",
         "subtitle": "Instant messaging client with built in lightning payments.",
         "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/emon_thumbnail.svg",
         "url": "https://emon.chat/"
+      },
+      {
+        "title": "Hamstr",
+        "subtitle": "A twitter-style nostr web client",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/hamstr-to.png",
+        "url": "https://hamstr.to/home"
+      },
+      {
+        "title": "Snort",
+        "subtitle": "Fast nostr web client.",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/snort_thumbnail.png",
+        "url": "https://snort.social"
       },
       {
         "title": "Yo, Sup?",

--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -186,7 +186,7 @@
       {
         "title": "channel.ninja",
         "subtitle": "Get recommended channel partners for your lightning node",
-        "logo": "https://fra1.digitaloceanspaces.com/alby-storage/alby-extension-website-screen/channelninja.png",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/channelninja.png",
         "url": "https://channel.ninja/"
       }
     ]


### PR DESCRIPTION
+ fixes https://github.com/getAlby/lightning-browser-extension/issues/2018


### ⚠️ do not merge until the files have been uploaded to the DigitalOcean buckets (see TODOs below)


## What

+ adds [Hamstr](https://hamstr.to/) to list of Nostr clients.

+ reduces total file size from `2.4MB` to `179kB`.

+ Compressed images will be uploaded to DigitalOcean (DO) bucket. File extension were changed from `.svg` to `.png` because those were either:
  a. fake SVGs that only contained embedded PNGs (I extracted the PNG content, so it's a real PNG now - no worries).
  b. real SVG files I found on the net did not fit square formatting or had weird viewbox/size parameters so I couldn't get them to fit into our page without editing the SVGs in Adobe Illustrator -> converted to PNG with photoshop

+ PNGs were scaled to 256x256px where the original PNG was large enough. One original image was slightly smaller and I kept its original size. 256px is more than enough for the 56x56 CSS-pixel elements we have on the discover page.

+ ### [📥 DOWNLOAD compressed-icons.zip](https://github.com/getAlby/lightning-browser-extension/files/10561331/compressed-icons.zip)

## TODOs
+ [x] deploy [images](https://github.com/getAlby/lightning-browser-extension/files/10561331/compressed-icons.zip) to the https://cdn.getalby-assets.com/alby-extension-website-screen digital ocean bucket.
+ I'd keep old SVG images on DO and clean them up in 6 months or so when it's unlikely that people still use old extension versions.

## Screenshots
![chrome-extension___ilikpdojllekoampbknappljinadggld_options html](https://user-images.githubusercontent.com/100707419/216161396-55078979-feed-4f5c-bc61-d101700adcf9.png)
