### PR TITLE
fixed 'good-first-issue' link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ We use the [Development Project Board](https://github.com/orgs/getAlby/projects/
 
 #### Developer
 
-- Check out the issues that have specifically been [marked as being friendly to new contributors](https://github.com/getAlby/lightning-browser-extension/issues?q=is%3Aopen+is%3Aissue+label%3Adesign+label%3A%22good+first+issue%22)
+- Check out the issues that have specifically been [marked as being friendly to new contributors](https://github.com/getAlby/lightning-browser-extension/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 - You can also review open PRs
 - [Contribution guide for new developers](./doc/CONTRIBUTION.md)
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

In the Contributing section there's a link for good first issues for developers. Thats broken because there's also a design label in it. I took out the design label.

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Clicked on the fixed link in the README and it shows the correct issues.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
