### PR TITLE
feat: nip-26 support

### DIFF
--- a/src/extension/background-script/actions/nostr/delegateOrPrompt.ts
+++ b/src/extension/background-script/actions/nostr/delegateOrPrompt.ts
@@ -1,0 +1,85 @@
+import utils from "~/common/lib/utils";
+import state from "~/extension/background-script/state";
+import { Nip26DelegateConditions } from "~/extension/ln/nostr/types";
+import { MessageDelegateGet, PermissionMethodNostr } from "~/types";
+
+import { addPermissionFor, hasPermissionFor } from "./helpers";
+
+const generateDelegationResponse = async (
+  delegateePubkey: string,
+  conditions: Nip26DelegateConditions
+) => {
+  const publicKey = state.getState().getNostr().getPublicKey();
+  const { cond, sig } = await state
+    .getState()
+    .getNostr()
+    .delegate(delegateePubkey, conditions);
+  const response = {
+    from: publicKey,
+    to: delegateePubkey,
+    cond,
+    sig,
+  };
+
+  return response;
+};
+
+const delegateOrPrompt = async (message: MessageDelegateGet) => {
+  const { args } = message;
+  const { delegateePubkey, conditions } = args;
+
+  if (!("host" in message.origin)) {
+    console.error("error", message.origin);
+    return;
+  }
+
+  try {
+    const hasPermission = await hasPermissionFor(
+      PermissionMethodNostr["NOSTR_NIP26DELEGATE"],
+      message.origin.host
+    );
+
+    if (hasPermission) {
+      const response = await generateDelegationResponse(
+        delegateePubkey,
+        conditions
+      );
+      return { data: response };
+    } else {
+      const promptResponse = await utils.openPrompt<{
+        confirm: boolean;
+        rememberPermission: boolean;
+      }>({
+        ...message,
+        action: "public/nostr/confirm",
+        args: {
+          description: "Key delegation of events with these conditions",
+          details: JSON.stringify(conditions),
+        },
+      });
+
+      // add permission to db only if user decided to always allow this request
+      if (promptResponse.data.rememberPermission) {
+        await addPermissionFor(
+          PermissionMethodNostr["NOSTR_NIP26DELEGATE"],
+          message.origin.host
+        );
+      }
+      if (promptResponse.data.confirm) {
+        const response = await generateDelegationResponse(
+          delegateePubkey,
+          conditions
+        );
+        return { data: response };
+      } else {
+        return { error: "User rejected" };
+      }
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      return { error: e.message };
+    }
+  }
+};
+
+export default delegateOrPrompt;

--- a/src/extension/background-script/actions/nostr/index.ts
+++ b/src/extension/background-script/actions/nostr/index.ts
@@ -1,4 +1,5 @@
 import decryptOrPrompt from "./decryptOrPrompt";
+import delegateOrPrompt from "./delegateOrPrompt";
 import encryptOrPrompt from "./encryptOrPrompt";
 import generatePrivateKey from "./generatePrivateKey";
 import getPrivateKey from "./getPrivateKey";
@@ -16,4 +17,5 @@ export {
   signEventOrPrompt,
   encryptOrPrompt,
   decryptOrPrompt,
+  delegateOrPrompt,
 };

--- a/src/extension/background-script/nostr/index.ts
+++ b/src/extension/background-script/nostr/index.ts
@@ -66,8 +66,7 @@ class Nostr {
     if (conditions.kind) cond.push(`kind=${conditions.kind}`);
     if (conditions.until) cond.push(`created_at>${conditions.until}`);
     if (conditions.since) cond.push(`created_at<${conditions.since}`);
-    if (conditions.content)
-      cond.push(`content=${encodeURIComponent(conditions.content)}`);
+    if (conditions.content) cond.push(`content=${sha256(conditions.content)}`);
 
     const encodedConditions = cond.join("&");
 

--- a/src/extension/background-script/router.ts
+++ b/src/extension/background-script/router.ts
@@ -81,6 +81,7 @@ const routes = {
       getRelays: nostr.getRelays,
       encryptOrPrompt: nostr.encryptOrPrompt,
       decryptOrPrompt: nostr.decryptOrPrompt,
+      delegateOrPrompt: nostr.delegateOrPrompt,
     },
   },
 };

--- a/src/extension/content-script/onendnostr.js
+++ b/src/extension/content-script/onendnostr.js
@@ -12,6 +12,7 @@ const nostrCalls = [
   "nostr/enable",
   "nostr/encryptOrPrompt",
   "nostr/decryptOrPrompt",
+  "nostr/delegateOrPrompt",
 ];
 // calls that can be executed when webln is not enabled for the current content page
 const disabledCalls = ["nostr/enable"];

--- a/src/extension/ln/nostr/index.ts
+++ b/src/extension/ln/nostr/index.ts
@@ -1,7 +1,8 @@
-import { Event } from "./types";
+import { Event, Nip26DelegateConditions } from "./types";
 
 export default class NostrProvider {
   nip04 = new Nip04(this);
+  nip26 = new Nip26(this);
   enabled: boolean;
 
   constructor() {
@@ -93,5 +94,24 @@ class Nip04 {
   async decrypt(peer: string, ciphertext: string): Promise<string> {
     await this.provider.enable();
     return this.provider.execute("decryptOrPrompt", { peer, ciphertext });
+  }
+}
+
+class Nip26 {
+  provider: NostrProvider;
+
+  constructor(provider: NostrProvider) {
+    this.provider = provider;
+  }
+
+  async delegate(
+    delegateePubkey: string,
+    conditions: Nip26DelegateConditions
+  ): Promise<string> {
+    await this.provider.enable();
+    return this.provider.execute("delegateOrPrompt", {
+      delegateePubkey,
+      conditions,
+    });
   }
 }

--- a/src/extension/ln/nostr/types.ts
+++ b/src/extension/ln/nostr/types.ts
@@ -16,3 +16,10 @@ export enum EventKind {
   DM = 4,
   Deleted = 5,
 }
+
+export type Nip26DelegateConditions = {
+  kind?: number;
+  until?: number;
+  since?: number;
+  content?: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import {
   WebLNNode,
 } from "~/extension/background-script/connectors/connector.interface";
 
-import { Event } from "./extension/ln/nostr/types";
+import { Event, Nip26DelegateConditions } from "./extension/ln/nostr/types";
 
 export type ConnectorType = keyof typeof connectors;
 
@@ -140,6 +140,7 @@ export type NavigationState = {
     customRecords?: Record<string, string>;
     message?: string;
     event?: Event;
+    conditions?: Nip26DelegateConditions;
     description?: string;
     details?: string;
     requestPermission: {
@@ -423,6 +424,14 @@ export interface MessageDecryptGet extends MessageDefault {
   action: "decrypt";
 }
 
+export interface MessageDelegateGet extends MessageDefault {
+  args: {
+    delegateePubkey: string;
+    conditions: Nip26DelegateConditions;
+  };
+  action: "delegate";
+}
+
 export interface LNURLChannelServiceResponse {
   uri: string; // Remote node address of form node_key@ip_address:port_number
   callback: string; // a second-level URL which would initiate an OpenChannel message from target LN node
@@ -557,6 +566,7 @@ export enum PermissionMethodNostr {
   NOSTR_GETPUBLICKEY = "nostr/getPublicKey",
   NOSTR_NIP04DECRYPT = "nostr/nip04decrypt",
   NOSTR_NIP04ENCRYPT = "nostr/nip04encrypt",
+  NOSTR_NIP26DELEGATE = "nostr/nip26delegate",
 }
 
 export interface DbPermission {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds support for NIP-26 Delegated Event Signing.

### Link this PR to an issue [optional]

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

<img width="405" alt="Screenshot 2023-02-05 at 12 46 29 AM" src="https://user-images.githubusercontent.com/779813/216781925-bc59abda-341a-47cc-a76f-bdecee97006c.png">

### How has this been tested?

Used it with a webapp that leverages this new functionality.

```javascript
window.nostr.nip26.delegate(<delegateePubkey>, { kind:1, since: since: Math.floor(Date.now() / 1000) })

// returns
{
  "from": __DELEGATORPUBKEY__,
  "to": __DELEGATEEPUBKEY__,
  "cond": "kind=1",
  "sig": __GENERATEDSCHNORRSIG__
}
```

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
