### PR TITLE
fix: spacing on lg

### DIFF
--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -8,7 +8,7 @@ type Props = {
 export default function Navbar({ children }: Props) {
   return (
     <div className="px-4 py-2 bg-white border-b border-gray-200 dark:bg-surface-01dp dark:border-white/10">
-      <div className="max-w-screen-lg flex justify-between items-center mx-auto w-full lg:px-4">
+      <div className="max-w-screen-lg flex justify-between items-center mx-auto w-full">
         <div className="flex">
           <UserMenu />
           {children && (


### PR DESCRIPTION
### Describe the changes you have made in this PR

Removes duplicate spacing on lg screens. (container already has `px-4`)