### PR TITLE
fix: update password bug when nostrprivatekey is null

### DIFF
--- a/src/extension/background-script/actions/settings/changePassword.ts
+++ b/src/extension/background-script/actions/settings/changePassword.ts
@@ -15,14 +15,16 @@ const changePassword = async (message: Message) => {
       password
     );
     tmpAccounts[accountId].config = encryptData(accountConfig, newPassword);
-    const accountNostrKey = decryptData(
-      accounts[accountId].nostrPrivateKey as string,
-      password
-    );
-    tmpAccounts[accountId].nostrPrivateKey = encryptData(
-      accountNostrKey,
-      newPassword
-    );
+    if (accounts[accountId].nostrPrivateKey) {
+      const accountNostrKey = decryptData(
+        accounts[accountId].nostrPrivateKey as string,
+        password
+      );
+      tmpAccounts[accountId].nostrPrivateKey = encryptData(
+        accountNostrKey,
+        newPassword
+      );
+    }
   }
   state.setState({ accounts: tmpAccounts, password: newPassword });
   // make sure we immediately persist the updated accounts


### PR DESCRIPTION
### Describe the changes you have made in this PR

Fixed update password error when `nostrPrivateKey` is null, so that the code doesn't crash.

### Link this PR to an issue [optional]

Fixes #2075 

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]


https://user-images.githubusercontent.com/74018438/217173649-acf57eba-a03d-4470-a17d-bb8d58b61a38.mp4



### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
