### PR TITLE
fix: total budget is set to null

### DIFF
--- a/src/app/components/AllowanceMenu/index.tsx
+++ b/src/app/components/AllowanceMenu/index.tsx
@@ -47,7 +47,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
   const hasPermissions = !isLoadingPermissions && !!permissions?.length;
 
   const enableSubmit =
-    parseInt(budget) !== allowance.totalBudget ||
+    parseInt(budget || "0") !== allowance.totalBudget ||
     lnurlAuth !== allowance.lnurlAuth ||
     getChangedPermissionsIds().length;
 
@@ -116,7 +116,7 @@ function AllowanceMenu({ allowance, onEdit, onDelete }: Props) {
     try {
       await msg.request("updateAllowance", {
         id: allowance.id,
-        totalBudget: parseInt(budget),
+        totalBudget: parseInt(budget || "0"),
         lnurlAuth,
       });
 


### PR DESCRIPTION
## ⚠️ Test only with a unused website/allowance as you won't be able to use the website budget again unless you separately change the totalBudget of the allowance from `null` to number.

### Describe the changes you have made in this PR

The modal doesn't open because the totalBudget is set to null and we are using `.toString()` method on it.

### Link this PR to an issue [optional]

Fixes #2078

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Tested manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
