### PR TITLE
feat: add schnorr to nostr

### DIFF
--- a/src/app/router/Prompt/Prompt.tsx
+++ b/src/app/router/Prompt/Prompt.tsx
@@ -12,8 +12,9 @@ import MakeInvoice from "@screens/MakeInvoice";
 import NostrConfirm from "@screens/Nostr/Confirm";
 import NostrConfirmGetPublicKey from "@screens/Nostr/ConfirmGetPublicKey";
 import NostrConfirmSignMessage from "@screens/Nostr/ConfirmSignMessage";
+import NostrConfirmSignSchnorr from "@screens/Nostr/ConfirmSignSchnorr";
 import Unlock from "@screens/Unlock";
-import { HashRouter, Outlet, Route, Routes, Navigate } from "react-router-dom";
+import { HashRouter, Navigate, Outlet, Route, Routes } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import Providers from "~/app/context/Providers";
 import RequireAuth from "~/app/router/RequireAuth";
@@ -81,6 +82,10 @@ function Prompt() {
             <Route
               path="public/nostr/confirmSignMessage"
               element={<NostrConfirmSignMessage />}
+            />
+            <Route
+              path="public/nostr/confirmSignSchnorr"
+              element={<NostrConfirmSignSchnorr />}
             />
 
             <Route path="lnurlAuth" element={<LNURLAuth />} />

--- a/src/app/screens/Nostr/ConfirmSignSchnorr.tsx
+++ b/src/app/screens/Nostr/ConfirmSignSchnorr.tsx
@@ -1,0 +1,121 @@
+import ConfirmOrCancel from "@components/ConfirmOrCancel";
+import Container from "@components/Container";
+import ContentMessage from "@components/ContentMessage";
+import PublisherCard from "@components/PublisherCard";
+import SuccessMessage from "@components/SuccessMessage";
+import Checkbox from "@components/form/Checkbox";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import ScreenHeader from "~/app/components/ScreenHeader";
+import { useNavigationState } from "~/app/hooks/useNavigationState";
+import { USER_REJECTED_ERROR } from "~/common/constants";
+import msg from "~/common/lib/msg";
+import type { OriginData } from "~/types";
+
+function ConfirmSignSchnorr() {
+  const navState = useNavigationState();
+  const { t: tCommon } = useTranslation("common");
+  const { t } = useTranslation("translation", {
+    keyPrefix: "nostr",
+  });
+  const navigate = useNavigate();
+
+  const sigHash = navState.args?.sigHash as string;
+  const origin = navState.origin as OriginData;
+  const [loading, setLoading] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+  const [rememberPermission, setRememberPermission] = useState(false);
+
+  // TODO: refactor: the success message and loading will not be displayed because after the reply the prompt is closed.
+  async function confirm() {
+    try {
+      setLoading(true);
+      msg.reply({
+        blocked: false,
+        enabled: rememberPermission,
+      });
+      setSuccessMessage(tCommon("success"));
+    } catch (e) {
+      console.error(e);
+      if (e instanceof Error) toast.error(`${tCommon("error")}: ${e.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function reject(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    msg.error(USER_REJECTED_ERROR);
+  }
+
+  function close(e: React.MouseEvent<HTMLButtonElement>) {
+    if (navState.isPrompt) {
+      window.close();
+    } else {
+      e.preventDefault();
+      navigate(-1);
+    }
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    confirm();
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-y-auto no-scrollbar">
+      <ScreenHeader title={t("title")} />
+      {!successMessage ? (
+        <form onSubmit={handleSubmit} className="h-full">
+          <Container justifyBetween maxWidth="sm">
+            <div>
+              <PublisherCard
+                title={origin.name}
+                image={origin.icon}
+                url={origin.host}
+              />
+              <ContentMessage
+                heading={t("allow_sign", { host: origin.host })}
+                content={sigHash}
+              />
+              <div className="flex items-center">
+                <Checkbox
+                  id="remember_permission"
+                  name="remember_permission"
+                  checked={rememberPermission}
+                  onChange={(event) => {
+                    setRememberPermission(event.target.checked);
+                  }}
+                />
+                <label
+                  htmlFor="remember_permission"
+                  className="cursor-pointer ml-2 block text-sm text-gray-900 font-medium dark:text-white"
+                >
+                  {tCommon("actions.remember")}
+                </label>
+              </div>
+            </div>
+            <ConfirmOrCancel
+              disabled={loading}
+              loading={loading}
+              onCancel={reject}
+            />
+          </Container>
+        </form>
+      ) : (
+        <Container maxWidth="sm">
+          <PublisherCard
+            title={origin.name}
+            image={origin.icon}
+            url={origin.host}
+          />
+          <SuccessMessage message={successMessage} onClose={close} />
+        </Container>
+      )}
+    </div>
+  );
+}
+
+export default ConfirmSignSchnorr;

--- a/src/extension/background-script/actions/nostr/__tests__/signSchnorr.test.ts
+++ b/src/extension/background-script/actions/nostr/__tests__/signSchnorr.test.ts
@@ -194,7 +194,7 @@ describe("signSchnorr", () => {
     });
 
     test("doesn't call signSchnorr if clicks cancel", async () => {
-      (utils.openPrompt as jest.Mock).mockResolvedValueOnce(() => {
+      (utils.openPrompt as jest.Mock).mockImplementationOnce(() => {
         throw new Error();
       });
       // prepare DB with a permission

--- a/src/extension/background-script/actions/nostr/__tests__/signSchnorr.test.ts
+++ b/src/extension/background-script/actions/nostr/__tests__/signSchnorr.test.ts
@@ -1,0 +1,224 @@
+import utils from "~/common/lib/utils";
+import db from "~/extension/background-script/db";
+import Nostr from "~/extension/background-script/nostr";
+import { allowanceFixture } from "~/fixtures/allowances";
+import { permissionsFixture } from "~/fixtures/permissions";
+import type { MessageSignSchnorr, OriginData } from "~/types";
+
+import signSchnorr from "../signSchnorrOrPrompt";
+
+// suppress console logs when running tests
+console.error = jest.fn();
+
+jest.mock("~/common/lib/utils", () => ({
+  openPrompt: jest.fn(() => Promise.resolve({ data: {} })),
+}));
+
+let nostr: Nostr;
+const NostrClass = jest.fn().mockImplementation(() => {
+  return nostr;
+});
+
+jest.mock("~/extension/background-script/state", () => ({
+  getState: () => ({
+    getNostr: jest.fn(() => new NostrClass()),
+  }),
+}));
+
+const allowanceInDB = allowanceFixture[0];
+
+const permissionInDB = {
+  ...permissionsFixture[0],
+  method: "nostr/signSchnorr",
+};
+
+const message: MessageSignSchnorr = {
+  action: "signSchnorr",
+  origin: { host: allowanceInDB.host } as OriginData,
+  args: {
+    sigHash: "sighash12345",
+  },
+};
+
+const requestResponse = { data: "" };
+const fullNostr = {
+  signSchnorr: jest.fn(() => Promise.resolve(requestResponse.data)),
+} as unknown as Nostr;
+
+// prepare DB with allowance
+db.allowances.bulkAdd([allowanceInDB]);
+
+// resets after every test
+afterEach(async () => {
+  jest.clearAllMocks();
+  // ensure a clear permission table in DB
+  await db.permissions.clear();
+  // set a default connector if overwritten in a previous test
+  nostr = fullNostr;
+});
+
+describe("signSchnorr", () => {
+  describe("throws error", () => {
+    test("if the host's allowance does not exist", async () => {
+      const messageWithUndefinedAllowanceHost = {
+        ...message,
+        origin: {
+          ...message.origin,
+          host: "some-host",
+        },
+      };
+
+      const result = await signSchnorr(messageWithUndefinedAllowanceHost);
+
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(result).toStrictEqual({
+        error: "Could not find an allowance for this host",
+      });
+    });
+
+    test("if the message args are not correct", async () => {
+      const messageWithoutSigHash = {
+        ...message,
+        args: {
+          ...message.args,
+          sigHash: undefined,
+        },
+      } as unknown as MessageSignSchnorr;
+
+      const result = await signSchnorr(messageWithoutSigHash);
+
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(result).toStrictEqual({
+        error: "sigHash is missing or not correct",
+      });
+    });
+  });
+
+  describe("directly calls signSchnorr with method and params", () => {
+    test("if permission for signSchnorr exists and is enabled", async () => {
+      // prepare DB with matching permission
+      await db.permissions.bulkAdd([permissionInDB]);
+
+      const result = await signSchnorr(message);
+
+      expect(result).toStrictEqual(requestResponse);
+      expect(nostr.signSchnorr).toHaveBeenCalledWith(message.args.sigHash);
+
+      expect(utils.openPrompt).not.toHaveBeenCalled();
+
+      expect(result).toStrictEqual(requestResponse);
+    });
+  });
+
+  describe("prompts the user first and then calls signSchnorr", () => {
+    test("if the permission for signSchnorr does not exist", async () => {
+      // prepare DB with other permission
+      const otherPermission = {
+        ...permissionInDB,
+        method: "nostr/getPublicKey",
+      };
+      await db.permissions.bulkAdd([otherPermission]);
+
+      const result = await signSchnorr(message);
+
+      expect(utils.openPrompt).toHaveBeenCalledWith({
+        args: {
+          sigHash: message.args.sigHash,
+        },
+        origin: message.origin,
+        action: "public/nostr/confirmSignSchnorr",
+      });
+      expect(nostr.signSchnorr).toHaveBeenCalledWith(message.args.sigHash);
+      expect(result).toStrictEqual(requestResponse);
+    });
+
+    test("if the permission for signSchnorr exists but is not enabled", async () => {
+      // prepare DB with disabled permission
+      const disabledPermission = {
+        ...permissionInDB,
+        enabled: false,
+      };
+      await db.permissions.bulkAdd([disabledPermission]);
+
+      const result = await signSchnorr(message);
+
+      expect(utils.openPrompt).toHaveBeenCalledWith({
+        args: {
+          sigHash: message.args.sigHash,
+        },
+        origin: message.origin,
+        action: "public/nostr/confirmSignSchnorr",
+      });
+      expect(nostr.signSchnorr).toHaveBeenCalledWith(message.args.sigHash);
+      expect(result).toStrictEqual(requestResponse);
+    });
+  });
+
+  describe("on the user's prompt response", () => {
+    test("saves the permission if enabled 'true'", async () => {
+      (utils.openPrompt as jest.Mock).mockResolvedValueOnce({
+        data: { enabled: true, blocked: false },
+      });
+      // prepare DB with a permission
+      await db.permissions.bulkAdd([
+        { ...permissionInDB, method: "nostr/getPublicKey" },
+      ]);
+
+      expect(await db.permissions.toArray()).toHaveLength(1);
+      expect(
+        await db.permissions.get({ method: "nostr/signSchnorr" })
+      ).toBeUndefined();
+
+      const result = await signSchnorr(message);
+
+      expect(utils.openPrompt).toHaveBeenCalledTimes(1);
+
+      expect(nostr.signSchnorr).toHaveBeenCalledWith(message.args.sigHash);
+
+      expect(await db.permissions.toArray()).toHaveLength(2);
+
+      const addedPermission = await db.permissions.get({
+        method: "nostr/signSchnorr",
+      });
+      expect(addedPermission).toEqual(
+        expect.objectContaining({
+          method: "nostr/signSchnorr",
+          enabled: true,
+          allowanceId: allowanceInDB.id,
+          host: allowanceInDB.host,
+          blocked: false,
+        })
+      );
+
+      expect(result).toStrictEqual(requestResponse);
+    });
+
+    test("does not save the permission if enabled 'false'", async () => {
+      (utils.openPrompt as jest.Mock).mockResolvedValueOnce({
+        data: { enabled: false, blocked: false },
+      });
+      // prepare DB with a permission
+      await db.permissions.bulkAdd([
+        { ...permissionInDB, method: "nostr/getPublicKey" },
+      ]);
+
+      expect(await db.permissions.toArray()).toHaveLength(1);
+      expect(
+        await db.permissions.get({ method: "nostr/signSchnorr" })
+      ).toBeUndefined();
+
+      const result = await signSchnorr(message);
+
+      expect(utils.openPrompt).toHaveBeenCalledTimes(1);
+
+      expect(nostr.signSchnorr).toHaveBeenCalledWith(message.args.sigHash);
+
+      expect(await db.permissions.toArray()).toHaveLength(1);
+      expect(
+        await db.permissions.get({ method: "nostr/signSchnorr" })
+      ).toBeUndefined();
+
+      expect(result).toStrictEqual(requestResponse);
+    });
+  });
+});

--- a/src/extension/background-script/actions/nostr/helpers.ts
+++ b/src/extension/background-script/actions/nostr/helpers.ts
@@ -9,12 +9,15 @@ export async function hasPermissionFor(method: string, host: string) {
     return false;
   }
 
-  const allowance = await db.allowances.get({
-    host,
-  });
+  const allowance = await db.allowances
+    .where("host")
+    .equalsIgnoreCase(host)
+    .first();
 
   if (!allowance?.id) {
-    return false;
+    return Promise.reject(
+      new Error("Could not find an allowance for this host")
+    );
   }
 
   const findPermission = await db.permissions.get({

--- a/src/extension/background-script/actions/nostr/index.ts
+++ b/src/extension/background-script/actions/nostr/index.ts
@@ -6,6 +6,7 @@ import getPublicKeyOrPrompt from "./getPublicKeyOrPrompt";
 import getRelays from "./getRelays";
 import setPrivateKey from "./setPrivateKey";
 import signEventOrPrompt from "./signEventOrPrompt";
+import signSchnorrOrPrompt from "./signSchnorrOrPrompt";
 
 export {
   generatePrivateKey,
@@ -14,6 +15,7 @@ export {
   getPublicKeyOrPrompt,
   getRelays,
   signEventOrPrompt,
+  signSchnorrOrPrompt,
   encryptOrPrompt,
   decryptOrPrompt,
 };

--- a/src/extension/background-script/actions/nostr/signSchnorrOrPrompt.ts
+++ b/src/extension/background-script/actions/nostr/signSchnorrOrPrompt.ts
@@ -1,0 +1,50 @@
+import utils from "~/common/lib/utils";
+import { MessageSignSchnorr, PermissionMethodNostr } from "~/types";
+
+import state from "../../state";
+import { addPermissionFor, hasPermissionFor } from "../nostr/helpers";
+
+const signSchnorrOrPrompt = async (message: MessageSignSchnorr) => {
+  if (!("host" in message.origin)) {
+    console.error("error", message.origin);
+    return;
+  }
+
+  const nostr = state.getState().getNostr();
+  const sigHash = message.args.sigHash;
+
+  try {
+    const hasPermission = await hasPermissionFor(
+      PermissionMethodNostr["NOSTR_SIGNSCHNORR"],
+      message.origin.host
+    );
+    if (!hasPermission) {
+      const promptResponse = await utils.openPrompt<{
+        enabled: boolean;
+        blocked: boolean;
+      }>({
+        ...message,
+        action: "public/nostr/confirmSignSchnorr",
+      });
+
+      // add permission to db only if user decided to always allow this request
+      if (promptResponse.data.enabled) {
+        await addPermissionFor(
+          PermissionMethodNostr["NOSTR_SIGNSCHNORR"],
+          message.origin.host
+        );
+      }
+    }
+
+    const signedSchnorr = await nostr.signSchnorr(sigHash);
+
+    return { data: signedSchnorr };
+  } catch (e) {
+    console.error("signSchnorr cancelled", e);
+    if (e instanceof Error) {
+      return { error: e.message };
+    }
+  }
+};
+
+export default signSchnorrOrPrompt;

--- a/src/extension/background-script/actions/nostr/signSchnorrOrPrompt.ts
+++ b/src/extension/background-script/actions/nostr/signSchnorrOrPrompt.ts
@@ -14,6 +14,10 @@ const signSchnorrOrPrompt = async (message: MessageSignSchnorr) => {
   const sigHash = message.args.sigHash;
 
   try {
+    if (!sigHash || typeof sigHash !== "string") {
+      throw new Error("sigHash is missing or not correct");
+    }
+
     const hasPermission = await hasPermissionFor(
       PermissionMethodNostr["NOSTR_SIGNSCHNORR"],
       message.origin.host

--- a/src/extension/background-script/nostr/index.ts
+++ b/src/extension/background-script/nostr/index.ts
@@ -30,6 +30,15 @@ class Nostr {
     return event;
   }
 
+  async signSchnorr(sigHash: string): Promise<string> {
+    const signature = await secp256k1.schnorr.sign(
+      Buffer.from(secp256k1.utils.hexToBytes(sigHash)),
+      secp256k1.utils.hexToBytes(this.privateKey)
+    );
+    const signedHex = secp256k1.utils.bytesToHex(signature);
+    return signedHex;
+  }
+
   encrypt(pubkey: string, text: string) {
     const key = secp256k1.getSharedSecret(this.privateKey, "02" + pubkey);
     const normalizedKey = Buffer.from(key.slice(1, 33));

--- a/src/extension/background-script/router.ts
+++ b/src/extension/background-script/router.ts
@@ -78,6 +78,7 @@ const routes = {
       enable: allowances.enable,
       getPublicKeyOrPrompt: nostr.getPublicKeyOrPrompt,
       signEventOrPrompt: nostr.signEventOrPrompt,
+      signSchnorrOrPrompt: nostr.signSchnorrOrPrompt,
       getRelays: nostr.getRelays,
       encryptOrPrompt: nostr.encryptOrPrompt,
       decryptOrPrompt: nostr.decryptOrPrompt,

--- a/src/extension/content-script/onendnostr.js
+++ b/src/extension/content-script/onendnostr.js
@@ -8,6 +8,7 @@ import shouldInject from "./shouldInject";
 const nostrCalls = [
   "nostr/getPublicKeyOrPrompt",
   "nostr/signEventOrPrompt",
+  "nostr/signSchnorrOrPrompt",
   "nostr/getRelays",
   "nostr/enable",
   "nostr/encryptOrPrompt",

--- a/src/extension/ln/nostr/index.ts
+++ b/src/extension/ln/nostr/index.ts
@@ -28,6 +28,11 @@ export default class NostrProvider {
     return this.execute("signEventOrPrompt", { event });
   }
 
+  async signSchnorr(sigHash: string): Promise<Buffer> {
+    await this.enable();
+    return this.execute("signSchnorrOrPrompt", { sigHash });
+  }
+
   async getRelays(): Promise<string[]> {
     await this.enable();
     return this.execute<string[]>("getRelays");

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export type NavigationState = {
     customRecords?: Record<string, string>;
     message?: string;
     event?: Event;
+    sigHash?: string;
     description?: string;
     details?: string;
     requestPermission: {
@@ -407,6 +408,13 @@ export interface MessageSignEvent extends MessageDefault {
   action: "signEvent";
 }
 
+export interface MessageSignSchnorr extends MessageDefault {
+  args: {
+    sigHash: string;
+  };
+  action: "signSchnorr";
+}
+
 export interface MessageEncryptGet extends MessageDefault {
   args: {
     peer: string;
@@ -554,6 +562,7 @@ export interface Payment extends Omit<DbPayment, "id"> {
 
 export enum PermissionMethodNostr {
   NOSTR_SIGNMESSAGE = "nostr/signMessage",
+  NOSTR_SIGNSCHNORR = "nostr/signSchnorr",
   NOSTR_GETPUBLICKEY = "nostr/getPublicKey",
   NOSTR_NIP04DECRYPT = "nostr/nip04decrypt",
   NOSTR_NIP04ENCRYPT = "nostr/nip04encrypt",


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds signSchnorr to nostr

### Link this PR to an issue [optional]

Fixes _#ISSUE-NUMBER_

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

Signed using Nostr key:

<img width="1470" alt="Screenshot 2023-02-08 at 1 39 41 PM" src="https://user-images.githubusercontent.com/64399555/217471344-9aa27a06-168e-47c5-aa38-23134d43b61b.png">

### How has this been tested?

Tested on ionio: https://github.com/im-adithya/ionio/tree/alby-liquid
(change window.liquid to window.nostr in the Alby app (https://github.com/im-adithya/ionio/tree/alby-liquid/examples/alby-app) before testing)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
