### PR TITLE
chore: move default_settings to constants

### DIFF
--- a/src/app/context/SettingsContext.tsx
+++ b/src/app/context/SettingsContext.tsx
@@ -3,15 +3,18 @@ import i18n from "i18next";
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { getTheme } from "~/app/utils";
-import { CURRENCIES, ACCOUNT_CURRENCIES } from "~/common/constants";
+import {
+  ACCOUNT_CURRENCIES,
+  CURRENCIES,
+  DEFAULT_SETTINGS,
+} from "~/common/constants";
 import api from "~/common/lib/api";
 import {
+  getFormattedCurrency as getFormattedCurrencyUtil,
   getFormattedFiat as getFormattedFiatUtil,
   getFormattedNumber as getFormattedNumberUtil,
   getFormattedSats as getFormattedSatsUtil,
-  getFormattedCurrency as getFormattedCurrencyUtil,
 } from "~/common/utils/currencyConvert";
-import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
 import type { SettingsStorage } from "~/types";
 
 interface SettingsContextType {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,7 +2,7 @@
 // Could be split up into i.e.
 // constants/messages
 // constants/[...etc]
-import i18n from "i18next";
+import i18n from "~/i18n/i18nConfig";
 import type { SettingsStorage } from "~/types";
 
 export const ABORT_PROMPT_ERROR = "Prompt was closed";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,8 @@
 // Could be split up into i.e.
 // constants/messages
 // constants/[...etc]
+import i18n from "i18next";
+import type { SettingsStorage } from "~/types";
 
 export const ABORT_PROMPT_ERROR = "Prompt was closed";
 export const USER_REJECTED_ERROR = "User rejected";
@@ -168,3 +170,20 @@ export enum TIPS {
   DEMO = "demo",
   ADDRESS = "address",
 }
+
+export const DEFAULT_SETTINGS: SettingsStorage = {
+  browserNotifications: true,
+  websiteEnhancements: true,
+  legacyLnurlAuth: false,
+  isUsingLegacyLnurlAuthKey: false,
+  userName: "",
+  userEmail: "",
+  locale: i18n.resolvedLanguage,
+  theme: "system",
+  showFiat: true,
+  currency: CURRENCIES.USD,
+  exchange: "alby",
+  debug: false,
+  nostrEnabled: false,
+  closedTips: [],
+};

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -2,10 +2,9 @@ import merge from "lodash.merge";
 import pick from "lodash.pick";
 import browser from "webextension-polyfill";
 import createState from "zustand";
-import { CURRENCIES } from "~/common/constants";
+import { DEFAULT_SETTINGS } from "~/common/constants";
 import { decryptData } from "~/common/lib/crypto";
 import { Migration } from "~/extension/background-script/migrations";
-import i18n from "~/i18n/i18nConfig";
 import type { Account, Accounts, SettingsStorage } from "~/types";
 
 import connectors from "./connectors";
@@ -39,23 +38,6 @@ interface BrowserStorage {
   migrations: Migration[] | null;
   nostrPrivateKey: string | null;
 }
-
-export const DEFAULT_SETTINGS: SettingsStorage = {
-  browserNotifications: true,
-  websiteEnhancements: true,
-  legacyLnurlAuth: false,
-  isUsingLegacyLnurlAuthKey: false,
-  userName: "",
-  userEmail: "",
-  locale: i18n.resolvedLanguage,
-  theme: "system",
-  showFiat: true,
-  currency: CURRENCIES.USD,
-  exchange: "alby",
-  debug: false,
-  nostrEnabled: false,
-  closedTips: [],
-};
 
 // these keys get synced from the state to the browser storage
 // the values are the default values

--- a/tests/fixtures/settings.ts
+++ b/tests/fixtures/settings.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SETTINGS } from "~/extension/background-script/state";
+import { DEFAULT_SETTINGS } from "~/common/constants";
 import type { SettingsStorage } from "~/types";
 
 export const settingsFixture: SettingsStorage = { ...DEFAULT_SETTINGS };


### PR DESCRIPTION
### Describe the changes you have made in this PR

This reduces the size of the extension greatly as this removes the dependency on background-script in settings provider used in welcome, options, popup, and prompt routes.

### Link this PR to an issue [optional]

Fixes #2089

### Type of change

(Remove other not matching type)

- `chore`

### Screenshots of the changes [optional]

## Before
<img width="1469" alt="Screenshot 2023-02-09 at 6 18 40 PM" src="https://user-images.githubusercontent.com/64399555/217817138-3818039c-4c49-4447-8b19-b7062db552d6.png">

## After
### @lightninglabs/lnc-web/dist package in pages meaning connectors are not being loaded anymore:
<img width="1470" alt="Screenshot 2023-02-09 at 6 15 00 PM" src="https://user-images.githubusercontent.com/64399555/217816330-2df144cf-4ed0-4154-ba95-6e8dd582e0f0.png">

### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
