### PR TITLE
feat: added receive another payment button

### DIFF
--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -100,6 +100,13 @@ function Receive() {
       });
   }
 
+  function receiveAnotherPayment() {
+    setPaid(false);
+    setPollingForPayment(false);
+    setInvoice(undefined);
+    navigate("/receive");
+  }
+
   async function createInvoice() {
     try {
       setLoading(true);
@@ -140,6 +147,17 @@ function Receive() {
             </div>
           )}
         </div>
+        {paid && (
+          <div className="my-4">
+            <Button
+              type="submit"
+              label={tCommon("actions.receive_again")}
+              primary
+              fullWidth
+              onClick={receiveAnotherPayment}
+            />
+          </div>
+        )}
         {!paid && (
           <>
             <div className="mt-8 mb-4 flex justify-center">

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -769,6 +769,7 @@
       "send": "Send",
       "save": "Save",
       "receive": "Receive",
+      "receive_again": "Receive another payment",
       "close": "Close",
       "export": "Export",
       "remove": "Remove",


### PR DESCRIPTION
### Describe the changes you have made in this PR

I have added a Receive another payment button under the Payment Received confetti on successful payment, which on click takes the user back to Receive screen.

### Link this PR to an issue [optional]

Fixes #2022 

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]


https://user-images.githubusercontent.com/74018438/217906810-8f4ca75e-5ecf-4f32-b5de-3af106b523ad.mp4



### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
