### PR TITLE
fix: show toast if nostr key is malformed

### DIFF
--- a/src/app/screens/Accounts/Show/index.tsx
+++ b/src/app/screens/Accounts/Show/index.tsx
@@ -239,9 +239,16 @@ function AccountScreen() {
         currentPrivateKey ? nostrlib.hexToNip19(currentPrivateKey, "nsec") : ""
       );
     } catch (e) {
-      if (e instanceof Error) toast.error(e.message);
+      if (e instanceof Error)
+        toast.error(
+          <p>
+            {t("nostr.errors.failed_to_load")}
+            <br />
+            {e.message}
+          </p>
+        );
     }
-  }, [currentPrivateKey]);
+  }, [currentPrivateKey, t]);
 
   return !account ? (
     <div className="flex justify-center mt-5">

--- a/src/app/screens/Accounts/Show/index.tsx
+++ b/src/app/screens/Accounts/Show/index.tsx
@@ -231,12 +231,16 @@ function AccountScreen() {
   }, [fetchData, isLoadingSettings]);
 
   useEffect(() => {
-    setNostrPublicKey(
-      currentPrivateKey ? generatePublicKey(currentPrivateKey) : ""
-    );
-    setNostrPrivateKey(
-      currentPrivateKey ? nostrlib.hexToNip19(currentPrivateKey, "nsec") : ""
-    );
+    try {
+      setNostrPublicKey(
+        currentPrivateKey ? generatePublicKey(currentPrivateKey) : ""
+      );
+      setNostrPrivateKey(
+        currentPrivateKey ? nostrlib.hexToNip19(currentPrivateKey, "nsec") : ""
+      );
+    } catch (e) {
+      if (e instanceof Error) toast.error(e.message);
+    }
   }, [currentPrivateKey]);
 
   return !account ? (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -417,6 +417,9 @@
           },
           "actions": {
             "generate": "Generate a new key"
+          },
+          "errors": {
+            "failed_to_load": "Failed to load the Nostr key. Is it a valid Nostr key?"
           }
         },
         "remove": {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds try catch in the useEffect hook (used when the migrated nostr key is malformed in the first-place)

### Link this PR to an issue [optional]

Fixes _#ISSUE-NUMBER_

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

<img width="1470" alt="Screenshot 2023-02-10 at 2 32 24 PM" src="https://user-images.githubusercontent.com/64399555/218049059-7e5a70f6-a3dc-48f5-86a3-ccfa22020890.png">

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
