### PR TITLE
feat: back button in send sats screen (not prompt)

### DIFF
--- a/src/app/screens/LNURLPay/index.tsx
+++ b/src/app/screens/LNURLPay/index.tsx
@@ -1,3 +1,4 @@
+import { CaretLeftIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import Button from "@components/Button";
 import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import Container from "@components/Container";
@@ -11,6 +12,8 @@ import React, { Fragment, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import Header from "~/app/components/Header";
+import IconButton from "~/app/components/IconButton";
 import ScreenHeader from "~/app/components/ScreenHeader";
 import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
@@ -350,9 +353,25 @@ function LNURLPay() {
   return (
     <>
       <div className="flex flex-col grow overflow-hidden">
-        <ScreenHeader
-          title={!successAction ? tCommon("actions.send") : tCommon("success")}
-        />
+        {!navState.isPrompt ? (
+          <Header
+            title={
+              !successAction ? tCommon("actions.send") : tCommon("success")
+            }
+            headerLeft={
+              <IconButton
+                onClick={() => navigate(-1)}
+                icon={<CaretLeftIcon className="w-4 h-4" />}
+              />
+            }
+          />
+        ) : (
+          <ScreenHeader
+            title={
+              !successAction ? tCommon("actions.send") : tCommon("success")
+            }
+          />
+        )}
         {!successAction ? (
           <>
             <div className="grow overflow-y-auto no-scrollbar">


### PR DESCRIPTION
### Describe the changes you have made in this PR

Added back button to send satoshis screen, while keeping in mind that we don't need a back button in prompt screen. I have used `navigate.isPrompt` for the same.

### Link this PR to an issue [optional]

Fixes #1535 

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]


https://user-images.githubusercontent.com/74018438/218791326-5481766c-103a-480d-a531-ae665b9bbfe7.mp4



### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
