### PR TITLE
chore: add test for cancel

### DIFF
--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -290,6 +290,40 @@ describe("ln request", () => {
       expect(result).toStrictEqual(requestResponse);
     });
 
+    test("doesn't call requestMethod if clicks cancel", async () => {
+      (utils.openPrompt as jest.Mock).mockImplementationOnce(() => {
+        throw new Error();
+      });
+      // prepare DB with a permission
+      await db.permissions.bulkAdd([permissionInDB]);
+
+      const messageWithOtherPermission = {
+        ...message,
+        args: {
+          ...message.args,
+          method: "sendPayment",
+        },
+      };
+
+      expect(await db.permissions.toArray()).toHaveLength(1);
+      expect(
+        await db.permissions.get({ method: "webln/lnd/sendpayment" })
+      ).toBeUndefined();
+
+      const result = await request(messageWithOtherPermission);
+
+      expect(utils.openPrompt).toHaveBeenCalledTimes(1);
+
+      expect(connector.requestMethod).not.toHaveBeenCalled();
+
+      expect(await db.permissions.toArray()).toHaveLength(1);
+      expect(
+        await db.permissions.get({ method: "webln/lnd/sendpayment" })
+      ).toBeUndefined();
+
+      expect(result).toHaveProperty("error");
+    });
+
     test("does not save the permission if enabled 'false'", async () => {
       (utils.openPrompt as jest.Mock).mockResolvedValueOnce({
         data: { enabled: false, blocked: false },


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds the test case where the user clicks on cancel in the prompt or removes the prompt by clicking on the close button.

### Type of change

(Remove other not matching type)

- `chore`: Adds new test

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
