### PR TITLE
feat: create Contact type and complete changes to db script

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -513,6 +513,7 @@ export type Transaction = {
 
 export interface DbPayment {
   allowanceId: string;
+  contactId?: string;
   createdAt: string;
   description: string;
   destination: string;
@@ -611,6 +612,18 @@ export interface Allowance extends Omit<DbAllowance, "id"> {
   paymentsCount: number;
   percentage: string;
   usedBudget: number;
+}
+
+export interface DbContact {
+  accountId: string;
+  createdAt: string;
+  enabled: boolean;
+  id: number;
+  lnAddress: string;
+}
+
+export interface Contact extends Omit<DbContact, "id"> {
+  id: number;
 }
 
 export interface SettingsStorage {


### PR DESCRIPTION
### Describe the changes you have made in this PR

1. Adding `DbContact` and `Contact` types
2. Adding `enabled` and `createdAt` to contact schema. All the other schemas have createdAt so I figured it's appropriate. As for enabled, my thinking was similar to `Allowance`. From what I gather, an allowance is created on the backend when a payment is made to an address with a host / website. But it's up to the user to enable / disable the Allowance for it be shown on the UI. Similarly, I imagine we can create a contact db entry for every payment made to an LN address, but only show the user the "Contact" for that address if they enable it.
3. Complete the db script for contacts

### Link this PR to an issue

https://github.com/getAlby/lightning-browser-extension/issues/1965

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
        - one e2e test failed, looks like a React issue however
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
