### PR TITLE
fix(storage): use local when sync is unavailable

### DIFF
--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -3,7 +3,7 @@ import utils from "~/common/lib/utils";
 
 import { ExtensionIcon, setIcon } from "./actions/setup/setIcon";
 import connectors from "./connectors";
-import { isIndexedDbAvailable, db } from "./db";
+import { db, isIndexedDbAvailable } from "./db";
 import * as events from "./events";
 import migrate from "./migrations";
 import { router } from "./router";
@@ -119,7 +119,6 @@ const routeCalls = (
 async function init() {
   console.info("Loading background script");
 
-  //await browser.storage.sync.set({ settings: { debug: true }, allowances: [] });
   await state.getState().init();
   console.info("State loaded");
 

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -121,14 +121,11 @@ const state = createState<State>((set, get) => ({
     const syncStorage = browser.storage.sync;
 
     return syncStorage
-      .set({ test: "alby" })
-      .then(() => {
-        syncStorage.remove("test");
-        return syncStorage.get(browserStorageKeys).then((result) => {
-          // Deep merge to ensure that nested defaults are also merged instead of overwritten.
-          const data = merge(browserStorageDefaults, result as BrowserStorage);
-          set(data);
-        });
+      .get(browserStorageKeys)
+      .then((result) => {
+        // Deep merge to ensure that nested defaults are also merged instead of overwritten.
+        const data = merge(browserStorageDefaults, result as BrowserStorage);
+        set(data);
       })
       .catch((e) => {
         console.info("storage.sync is not available. using storage.local");
@@ -155,10 +152,9 @@ const state = createState<State>((set, get) => ({
     };
 
     return syncStorage
-      .set({ test: "alby" })
-      .then(() => {
-        syncStorage.remove("test");
-        return syncStorage.set(data);
+      .set(data)
+      .then((result) => {
+        return result;
       })
       .catch((e) => {
         return browser.storage.local.set({ mockSync: data });

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -130,7 +130,7 @@ const state = createState<State>((set, get) => ({
       .catch((e) => {
         console.info("storage.sync is not available. using storage.local");
         storage = "local";
-        return browser.storage.local.get("mockSync").then((result) => {
+        return browser.storage.local.get("__sync").then((result) => {
           // Deep merge to ensure that nested defaults are also merged instead of overwritten.
           const data = merge(
             browserStorageDefaults,
@@ -154,7 +154,9 @@ const state = createState<State>((set, get) => ({
     if (storage === "sync") {
       return browser.storage.sync.set(data);
     } else {
-      return browser.storage.local.set({ mockSync: data });
+      // because there's an overlap with accounts being stored in
+      // the local storage, see src/common/lib/cache.ts
+      return browser.storage.local.set({ __sync: data });
     }
   },
 }));


### PR DESCRIPTION
### Describe the changes you have made in this PR

Uses `browser.storage.local` when `browser.storage.sync` is unavailable.

### Link this PR to an issue [optional]

Fixes #

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Tested in the latest Tor Browser

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
