### PR TITLE
fix: add type in publishPaymentNotification

### DIFF
--- a/src/common/lib/pubsub.ts
+++ b/src/common/lib/pubsub.ts
@@ -3,6 +3,7 @@ import { Message, MessageSendPayment, PaymentNotificationData } from "~/types";
 
 const pubsub = {
   publishPaymentNotification: (
+    type: "sendPayment" | "keysend",
     message: MessageSendPayment | Message, // 'keysend' & 'sendPaymentOrPrompt' still need the Message type
     data: Omit<PaymentNotificationData, "origin">
   ) => {
@@ -10,7 +11,7 @@ const pubsub = {
     if ("error" in data.response) {
       status = "failed";
     }
-    PubSub.publish(`ln.sendPayment.${status}`, {
+    PubSub.publish(`ln.${type}.${status}`, {
       response: data.response,
       details: data.details,
       paymentRequestDetails: data.paymentRequestDetails,

--- a/src/extension/background-script/actions/ln/keysend.ts
+++ b/src/extension/background-script/actions/ln/keysend.ts
@@ -30,7 +30,7 @@ export default async function keysend(message: Message) {
       error: e instanceof Error ? e.message : "Something went wrong",
     };
   }
-  pubsub.publishPaymentNotification(message, {
+  pubsub.publishPaymentNotification("keysend", message, {
     response,
     details: {
       destination: destination,

--- a/src/extension/background-script/actions/ln/sendPayment.ts
+++ b/src/extension/background-script/actions/ln/sendPayment.ts
@@ -2,7 +2,7 @@ import lightningPayReq from "bolt11";
 import PubSub from "pubsub-js";
 import pubsub from "~/common/lib/pubsub";
 import state from "~/extension/background-script/state";
-import { MessageSendPayment, Message } from "~/types";
+import { Message, MessageSendPayment } from "~/types";
 
 export default async function sendPayment(
   message: MessageSendPayment | Message // 'keysend' & 'sendPaymentOrPrompt' still need the Message type
@@ -41,7 +41,7 @@ export default async function sendPayment(
     };
   }
 
-  pubsub.publishPaymentNotification(message, {
+  pubsub.publishPaymentNotification("sendPayment", message, {
     paymentRequestDetails,
     response,
     details: {

--- a/src/extension/background-script/events/index.js
+++ b/src/extension/background-script/events/index.js
@@ -2,16 +2,18 @@ import PubSub from "pubsub-js";
 
 import { updateAllowance } from "./allowances";
 import {
-  paymentSuccessNotification,
-  paymentFailedNotification,
-  lnurlAuthSuccessNotification,
   lnurlAuthFailedNotification,
+  lnurlAuthSuccessNotification,
+  paymentFailedNotification,
+  paymentSuccessNotification,
 } from "./notifications";
 import { persistSuccessfullPayment } from "./persistPayments";
 
 const subscribe = () => {
   PubSub.subscribe("ln.sendPayment.success", paymentSuccessNotification);
   PubSub.subscribe("ln.sendPayment.failed", paymentFailedNotification);
+  PubSub.subscribe("ln.keysend.success", paymentSuccessNotification);
+  PubSub.subscribe("ln.keysend.failed", paymentFailedNotification);
 
   PubSub.subscribe("ln.sendPayment.success", persistSuccessfullPayment);
   PubSub.subscribe("ln.sendPayment.success", updateAllowance);

--- a/src/extension/background-script/events/index.js
+++ b/src/extension/background-script/events/index.js
@@ -10,15 +10,15 @@ import {
 import { persistSuccessfullPayment } from "./persistPayments";
 
 const subscribe = () => {
-  PubSub.subscribe("ln.sendPayment.success", paymentSuccessNotification);
-  PubSub.subscribe("ln.sendPayment.failed", paymentFailedNotification);
-  PubSub.subscribe("ln.keysend.success", paymentSuccessNotification);
-  PubSub.subscribe("ln.keysend.failed", paymentFailedNotification);
+  const paymentTypes = ["sendPayment", "keysend"];
 
-  PubSub.subscribe("ln.sendPayment.success", persistSuccessfullPayment);
-  PubSub.subscribe("ln.sendPayment.success", updateAllowance);
-  PubSub.subscribe("ln.keysend.success", persistSuccessfullPayment);
-  PubSub.subscribe("ln.keysend.success", updateAllowance);
+  paymentTypes.forEach((type) => {
+    PubSub.subscribe(`ln.${type}.success`, paymentSuccessNotification);
+    PubSub.subscribe(`ln.${type}.failed`, paymentFailedNotification);
+
+    PubSub.subscribe(`ln.${type}.success`, persistSuccessfullPayment);
+    PubSub.subscribe(`ln.${type}.success`, updateAllowance);
+  });
 
   PubSub.subscribe("lnurl.auth.success", lnurlAuthSuccessNotification);
   PubSub.subscribe("lnurl.auth.failed", lnurlAuthFailedNotification);

--- a/src/extension/background-script/events/notifications.ts
+++ b/src/extension/background-script/events/notifications.ts
@@ -9,7 +9,7 @@ import type { AuthNotificationData, PaymentNotificationData } from "~/types";
 import { notify } from "./helpers";
 
 const paymentSuccessNotification = async (
-  message: "ln.sendPayment.success",
+  message: "ln.sendPayment.success" | "ln.keysend.success",
   data: PaymentNotificationData
 ) => {
   const recipient = data?.origin?.name;
@@ -65,7 +65,7 @@ const paymentSuccessNotification = async (
 };
 
 const paymentFailedNotification = (
-  message: "ln.sendPayment.failed",
+  message: "ln.sendPayment.failed" | "ln.keysend.failed",
   data: PaymentNotificationData
 ) => {
   let error;


### PR DESCRIPTION
## ⚠️ Requires Input

This change starts calling ln.keysend.success for keysend payments (as desired), but that would mean we are not calling the success/failure notifications here: https://github.com/getAlby/lightning-browser-extension/blob/master/src/extension/background-script/events/index.js#L13-L14
Wanted to know if that's also done on purpose or I should add notifs for keysend payments

### Describe the changes you have made in this PR

The `ln.keysend.success` event isn't being triggered at all because we only publish the `ln.sendPayment.success` event everytime.

### Link this PR to an issue [optional]

Fixes _#ISSUE-NUMBER_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Didn't test yet, require input.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
