### PR TITLE
Add safari to compatible browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Alby supports
 
 - All [Chromium based browsers](<https://en.wikipedia.org/wiki/Chromium_(web_browser)#Browsers_based_on_Chromium>) - Chrome Opera, Brave etc.
 - Firefox
+- Safari
 - more coming soon...
 
 ## Installation


### PR DESCRIPTION
### Describe the changes you have made in this PR

The [macOS installer](https://github.com/getAlby/alby-installer-macos) suggests that Safari is supported. Feel free to reject this PR if I've misunderstood something.

### Type of change

- `docs`: Documentation update
