### PR TITLE
refactor: use convertPaymentsToTransactions to convert payments

### DIFF
--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -13,6 +13,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import { PublisherLnData } from "~/app/screens/Home/PublisherLnData";
+import { convertPaymentsToTransactions } from "~/app/utils/payments";
 import type { Allowance, Transaction, Battery } from "~/types";
 
 dayjs.extend(relativeTime);
@@ -33,52 +34,44 @@ const AllowanceView: FC<Props> = (props) => {
     getFormattedNumber,
   } = useSettings();
 
-  const [payments, setPayments] = useState<Transaction[] | null>(null);
-  const [isLoadingPayments, setIsLoadingPayments] = useState(true);
+  const [transactions, setTransactions] = useState<Transaction[] | null>(null);
+  const [isLoadingTransactions, setIsLoadingTransactions] = useState(true);
 
   const { t } = useTranslation("translation", { keyPrefix: "home" });
 
   const showFiat = !isLoadingSettings && settings.showFiat;
-  const hasPayments = !isLoadingPayments && !!payments?.length;
-  const isEmptyPayments = !isLoadingPayments && payments?.length === 0;
+  const hasPayments = !isLoadingTransactions && !!transactions?.length;
 
   // get array of payments if not done yet
   useEffect(() => {
-    const getPayments = async () => {
-      const payments: Transaction[] = props.allowance.payments.map(
-        (payment) => ({
-          ...payment,
-          id: `${payment.id}`,
-          type: "sent",
-          date: dayjs(payment.createdAt).fromNow(),
-          title: payment.name || payment.description,
-          publisherLink: `options.html#/publishers/${props.allowance.id}`,
-        })
+    const getTransactions = async () => {
+      const transactions: Transaction[] = await convertPaymentsToTransactions(
+        props.allowance.payments,
+        `options.html#/publishers/${props.allowance.id}`
       );
 
       try {
         // attach fiatAmount if enabled
-        for (const payment of payments) {
-          const totalAmountFiat = showFiat
-            ? await getFormattedFiat(payment.totalAmount)
+        for (const transaction of transactions) {
+          transaction.totalAmountFiat = showFiat
+            ? await getFormattedFiat(transaction.totalAmount)
             : "";
-          payment.totalAmountFiat = totalAmountFiat;
         }
 
-        setPayments(payments);
+        setTransactions(transactions);
       } catch (e) {
         console.error(e);
         if (e instanceof Error) toast.error(e.message);
       } finally {
-        setIsLoadingPayments(false);
+        setIsLoadingTransactions(false);
       }
     };
 
-    !payments && !isLoadingSettings && getPayments();
+    !transactions && !isLoadingSettings && getTransactions();
   }, [
     props.allowance,
     isLoadingSettings,
-    payments,
+    transactions,
     getFormattedFiat,
     showFiat,
   ]);
@@ -138,15 +131,15 @@ const AllowanceView: FC<Props> = (props) => {
           {t("allowance_view.recent_transactions")}
         </h2>
 
-        {isLoadingPayments && (
+        {isLoadingTransactions && (
           <div className="flex justify-center">
             <Loading />
           </div>
         )}
 
-        {hasPayments && <TransactionsTable transactions={payments} />}
+        {hasPayments && <TransactionsTable transactions={transactions} />}
 
-        {isEmptyPayments && (
+        {!hasPayments && (
           <p className="text-gray-500 dark:text-neutral-400">
             <Trans
               i18nKey={"allowance_view.no_transactions"}

--- a/src/app/screens/Home/AllowanceView/index.tsx
+++ b/src/app/screens/Home/AllowanceView/index.tsx
@@ -40,7 +40,7 @@ const AllowanceView: FC<Props> = (props) => {
   const { t } = useTranslation("translation", { keyPrefix: "home" });
 
   const showFiat = !isLoadingSettings && settings.showFiat;
-  const hasPayments = !isLoadingTransactions && !!transactions?.length;
+  const hasTransactions = !isLoadingTransactions && !!transactions?.length;
 
   // get array of payments if not done yet
   useEffect(() => {
@@ -137,9 +137,9 @@ const AllowanceView: FC<Props> = (props) => {
           </div>
         )}
 
-        {hasPayments && <TransactionsTable transactions={transactions} />}
+        {hasTransactions && <TransactionsTable transactions={transactions} />}
 
-        {!hasPayments && (
+        {!hasTransactions && (
           <p className="text-gray-500 dark:text-neutral-400">
             <Trans
               i18nKey={"allowance_view.no_transactions"}

--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -16,26 +16,12 @@ import { useAccount } from "~/app/context/AccountContext";
 import { useSettings } from "~/app/context/SettingsContext";
 import { PublisherLnData } from "~/app/screens/Home/PublisherLnData";
 import { classNames } from "~/app/utils/index";
+import { convertPaymentsToTransactions } from "~/app/utils/payments";
 import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
 import type { Battery, Transaction } from "~/types";
 
 dayjs.extend(relativeTime);
-
-const loadPayments = async () => {
-  const response = await api.getPayments({ limit: 10 });
-
-  const payments: Transaction[] = response.payments.map((payment) => ({
-    ...payment,
-    id: `${payment.id}`,
-    type: "sent",
-    date: dayjs(payment.createdAt).fromNow(),
-    title: payment.name || payment.description,
-    publisherLink: "options.html#/publishers",
-  }));
-
-  return payments;
-};
 
 export type Props = {
   lnDataFromCurrentTab?: Battery[];
@@ -43,8 +29,8 @@ export type Props = {
 };
 
 const DefaultView: FC<Props> = (props) => {
-  const [isLoadingPayments, setIsLoadingPayments] = useState(true);
-  const [payments, setPayments] = useState<Transaction[] | null>(null);
+  const [isLoadingTransactions, setIsLoadingTransactions] = useState(true);
+  const [transactions, setTransactions] = useState<Transaction[] | null>(null);
 
   const [isLoadingInvoices, setIsLoadingInvoices] = useState(false);
   const [incomingTransactions, setIncomingTransactions] = useState<
@@ -60,11 +46,8 @@ const DefaultView: FC<Props> = (props) => {
   } = useSettings();
 
   const showFiat = !isLoadingSettings && settings.showFiat;
-  const hasPayments = !isLoadingPayments && !!payments?.length;
-  const isEmptyPayments = !isLoadingPayments && payments?.length === 0;
+  const hasTransactions = !isLoadingTransactions && !!transactions?.length;
   const hasInvoices = !isLoadingInvoices && !!incomingTransactions?.length;
-  const isEmptyInvoices =
-    !isLoadingInvoices && incomingTransactions?.length === 0;
 
   const navigate = useNavigate();
   const { account, balancesDecorated } = useAccount();
@@ -86,29 +69,33 @@ const DefaultView: FC<Props> = (props) => {
     checkBlockedUrl();
   }, [props.currentUrl]);
 
-  // get array of payments if not done yet
+  // get array of transactions if not done yet
   useEffect(() => {
-    const getPayments = async () => {
+    const getTransactions = async () => {
       try {
-        const payments = await loadPayments();
+        const { payments } = await api.getPayments({ limit: 10 });
+        const transactions: Transaction[] = await convertPaymentsToTransactions(
+          payments,
+          "options.html#/publishers"
+        );
         // attach fiatAmount if enabled
-        for (const payment of payments) {
-          const totalAmountFiat = showFiat
-            ? await getFormattedFiat(payment.totalAmount)
+        for (const transaction of transactions) {
+          transaction.totalAmountFiat = showFiat
+            ? await getFormattedFiat(transaction.totalAmount)
             : "";
-          payment.totalAmountFiat = totalAmountFiat;
         }
-        setPayments(payments);
+
+        setTransactions(transactions);
       } catch (e) {
         console.error(e);
         if (e instanceof Error) toast.error(e.message);
       } finally {
-        setIsLoadingPayments(false);
+        setIsLoadingTransactions(false);
       }
     };
 
-    !payments && !isLoadingSettings && getPayments();
-  }, [isLoadingSettings, payments, getFormattedFiat, showFiat]);
+    !transactions && !isLoadingSettings && getTransactions();
+  }, [isLoadingSettings, transactions, getFormattedFiat, showFiat]);
 
   const unblock = async () => {
     try {
@@ -148,10 +135,9 @@ const DefaultView: FC<Props> = (props) => {
     }));
 
     for (const invoice of invoices) {
-      const totalAmountFiat = settings.showFiat
+      invoice.totalAmountFiat = settings.showFiat
         ? await getFormattedFiat(invoice.totalAmount)
         : "";
-      invoice.totalAmountFiat = totalAmountFiat;
     }
 
     setIncomingTransactions(invoices);
@@ -170,7 +156,6 @@ const DefaultView: FC<Props> = (props) => {
       {!!props.lnDataFromCurrentTab?.length && (
         <PublisherLnData lnData={props.lnDataFromCurrentTab[0]} />
       )}
-
       <div className="p-4">
         <div className="flex mb-6 space-x-4">
           <Button
@@ -210,13 +195,13 @@ const DefaultView: FC<Props> = (props) => {
           </div>
         )}
 
-        {isLoadingPayments && (
+        {isLoadingTransactions && (
           <div className="flex justify-center">
             <Loading />
           </div>
         )}
 
-        {!isLoadingPayments && (
+        {!isLoadingTransactions && (
           <div>
             <h2 className="mb-2 text-lg text-gray-900 font-bold dark:text-white">
               {t("default_view.recent_transactions")}
@@ -248,8 +233,10 @@ const DefaultView: FC<Props> = (props) => {
 
               <Tab.Panels>
                 <Tab.Panel>
-                  {hasPayments && <TransactionsTable transactions={payments} />}
-                  {isEmptyPayments && (
+                  {hasTransactions && (
+                    <TransactionsTable transactions={transactions} />
+                  )}
+                  {!hasTransactions && (
                     <p className="text-gray-500 dark:text-neutral-400">
                       {t("default_view.no_transactions")}
                     </p>
@@ -264,7 +251,7 @@ const DefaultView: FC<Props> = (props) => {
                   {hasInvoices && (
                     <TransactionsTable transactions={incomingTransactions} />
                   )}
-                  {isEmptyInvoices && (
+                  {!hasInvoices && (
                     <p className="text-gray-500 dark:text-neutral-400">
                       {t("default_view.no_transactions")}
                     </p>

--- a/src/app/screens/Transactions/index.tsx
+++ b/src/app/screens/Transactions/index.tsx
@@ -5,8 +5,8 @@ import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import { useSettings } from "~/app/context/SettingsContext";
 import { convertPaymentsToTransactions } from "~/app/utils/payments";
-import msg from "~/common/lib/msg";
-import { Payment, Transaction } from "~/types";
+import api from "~/common/lib/api";
+import { Transaction } from "~/types";
 
 function Transactions() {
   const { t } = useTranslation("translation", {
@@ -19,9 +19,7 @@ function Transactions() {
   const fetchData = useCallback(async () => {
     try {
       // @Todo: add SWR caching? Check where to reset/mutate the cache?
-      const { payments } = await msg.request<{ payments: Payment[] }>(
-        "getPayments"
-      );
+      const { payments } = await api.getPayments();
       const _transactions: Transaction[] = await convertPaymentsToTransactions(
         payments
       );

--- a/src/app/utils/payments.ts
+++ b/src/app/utils/payments.ts
@@ -1,16 +1,20 @@
 import dayjs from "dayjs";
-import { Payment, Transaction } from "~/types";
+import { DbPayment, Transaction } from "~/types";
 
-export const convertPaymentToTransaction = (payment: Payment): Transaction => ({
+export const convertPaymentToTransaction = (
+  payment: DbPayment,
+  publisherLink?: string
+): Transaction => ({
   ...payment,
   id: `${payment.id}`,
   type: "sent",
   date: dayjs(payment.createdAt).fromNow(),
   title: payment.name || payment.description,
-  publisherLink: payment.location,
+  publisherLink: publisherLink || payment.location,
 });
 
 export const convertPaymentsToTransactions = (
-  payments: Payment[]
+  payments: DbPayment[],
+  publisherLink?: string
 ): Transaction[] =>
-  payments.map((p: Payment) => convertPaymentToTransaction(p));
+  payments.map((p: DbPayment) => convertPaymentToTransaction(p, publisherLink));

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -103,7 +103,7 @@ export const selectAccount = (id: string) =>
   msg.request("selectAccount", { id });
 export const getAllowance = (host: string) =>
   msg.request<Allowance>("getAllowance", { host });
-export const getPayments = (options: { limit: number }) =>
+export const getPayments = (options?: { limit?: number }) =>
   msg.request<{ payments: DbPayment[] }>("getPayments", options);
 export const getSettings = () => msg.request<SettingsStorage>("getSettings");
 export const getStatus = () => msg.request<StatusRes>("status");


### PR DESCRIPTION
### Describe the changes you have made in this PR

This is a follow up of the Transactions page https://github.com/getAlby/lightning-browser-extension/pull/2035. Same as on the transactions page, in DefaultView and AllowanceView `payments` are fetched and transformed to transactions. In the transactions feature this transformation is abstracted into the `convertPaymentsToTransactions` util function. This PR applies the `convertPaymentsToTransactions` abstraction for the two mentioned screens.

This by itself is actually a rather small refactor. However as we are dealing with `transactions` most of the time and the component consuming the data is also using the property `transactions`, I renamed a lot of properties from "payments" to "transactions" for consistency reasons. 

### Link this PR to an issue [optional]

Fixes #2057

### Type of change

- `refactor`: Follow up of #2027 https://github.com/getAlby/lightning-browser-extension/pull/2035

### How has this been tested?

I tested manually all screens that are affected.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
