### PR TITLE
fix: change lndconnect host to http (tor)

### DIFF
--- a/src/app/screens/connectors/ConnectStart9/index.tsx
+++ b/src/app/screens/connectors/ConnectStart9/index.tsx
@@ -29,7 +29,7 @@ export default function ConnectStart9() {
       let lndconnect = new URL(lndconnectUrl);
       lndconnect.protocol = "http:";
       lndconnect = new URL(lndconnect.toString());
-      const url = `https://${lndconnect.host}${lndconnect.pathname}`;
+      const url = `http://${lndconnect.host}${lndconnect.pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector


### PR DESCRIPTION
### Describe the changes you have made in this PR

Cloud9 nodes connect via TOR, there is no need to use HTTPS here. (as this also requires users to confirm that they want to accept the self-signed cert)