### PR TITLE
Feature/eclair improvements

### DIFF
--- a/src/extension/background-script/connectors/eclair.ts
+++ b/src/extension/background-script/connectors/eclair.ts
@@ -98,19 +98,9 @@ class Eclair implements Connector {
   }
 
   async getBalance(): Promise<GetBalanceResponse> {
-    const channels = await this.request("/channels");
-    const total = channels
-      .map(
-        (
-          channel: Record<
-            string,
-            Record<
-              string,
-              Record<string, Record<string, Record<string, number>>>
-            >
-          >
-        ) => channel.data?.commitments?.localCommit?.spec?.toLocal || 0
-      )
+    const balances = await this.request("/usablebalances");
+    const total = balances
+      .map((balance: Record<string, number>) => balance.canSend || 0)
       .reduce((acc: number, b: number) => acc + b, 0);
     return {
       data: {
@@ -136,7 +126,7 @@ class Eclair implements Connector {
         paymentHash,
         route: {
           total_amt: Math.floor(recipientAmount / 1000),
-          total_fees: status.feesPaid,
+          total_fees: Math.floor(status.feesPaid / 1000),
         },
       },
     };


### PR DESCRIPTION
### Describe the changes you have made in this PR

- Add `/listinvoices` function to connector to avoid error messages. However, Eclair has currently no way of listing only settled invoices, so all created invoices are displayed.
- Fixes a bug where a payment fee was displayed as 1000x too much.
- Use the [`/usablebalances`](https://acinq.github.io/eclair/#usablebalances) endpoint to fetch the balance, which is easier and more accurate than using the `/channels` endpoint. 

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Tested locally by using Eclair.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
