### PR TITLE
feat: contentUri to alby boost button

### DIFF
--- a/src/common/lib/lnurl.ts
+++ b/src/common/lib/lnurl.ts
@@ -4,9 +4,9 @@ import Hex from "crypto-js/enc-hex";
 import sha256 from "crypto-js/sha256";
 import { isLNURLDetailsError } from "~/common/utils/typeHelpers";
 import {
+  LNURLAuthServiceResponse,
   LNURLDetails,
   LNURLError,
-  LNURLAuthServiceResponse,
   LNURLPaymentInfo,
 } from "~/types";
 
@@ -123,6 +123,7 @@ const lnurl = {
       | {
           name?: string;
           email?: string;
+          contentUri?: string;
         };
     metadata: string;
     amount: number;

--- a/src/extension/content-script/batteries/GeyserProject.ts
+++ b/src/extension/content-script/batteries/GeyserProject.ts
@@ -1,9 +1,10 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { setLightningData } from "./helpers";
 
 const urlMatcher = /^https:\/\/geyser.fund\/([^/]+)(\/([^/]+))?$/;
 
-const battery = (): void => {
+const battery = (): Battery | void => {
   const urlParts = document.location.pathname.split("/");
   const project = urlParts[1];
   const name = urlParts[2];
@@ -23,16 +24,14 @@ function handleProjectPage(name: string) {
   )?.src;
 
   if (address) {
-    setLightningData([
-      {
-        method: "lnurl",
-        address: address,
-        ...getOriginData(),
-        description: "geyser.fund",
-        name: title ?? name,
-        icon: icon ?? "https://geyser.fund/logo-brand.svg",
-      },
-    ]);
+    return {
+      method: "lnurl",
+      address: address,
+      ...getOriginData(),
+      description: "geyser.fund",
+      name: title ?? name,
+      icon: icon ?? "https://geyser.fund/logo-brand.svg",
+    };
   }
 }
 

--- a/src/extension/content-script/batteries/GitHub.ts
+++ b/src/extension/content-script/batteries/GitHub.ts
@@ -1,9 +1,11 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/github.com\/([^/]+)(\/)?(\/([^/]+))?(\/)?$/;
 
-const battery = (): void => {
+const battery = (): Battery | void => {
   const urlParts = document.location.pathname.split("/");
   const username = urlParts[1];
   const repo = urlParts[2];
@@ -12,9 +14,7 @@ const battery = (): void => {
     handleRepositoryPage(username);
   } else if (username) {
     const lightningData = handleProfilePage() || handleOrganizationPage();
-    if (lightningData) {
-      setLightningData([lightningData]);
-    }
+    if (lightningData) return lightningData;
   }
 };
 
@@ -97,18 +97,15 @@ function handleRepositoryPage(username: string) {
   const address = parseElement("article");
 
   if (address) {
-    setLightningData([
-      {
-        method: "lnurl",
-        address: address,
-        ...getOriginData(),
-        description:
-          document.querySelector<HTMLHeadingElement>("article")?.innerText ??
-          "",
-        name: username,
-        icon: "",
-      },
-    ]);
+    return {
+      method: "lnurl",
+      address: address,
+      ...getOriginData(),
+      description:
+        document.querySelector<HTMLHeadingElement>("article")?.innerText ?? "",
+      name: username,
+      icon: "",
+    };
   }
 }
 

--- a/src/extension/content-script/batteries/LinkTree.ts
+++ b/src/extension/content-script/batteries/LinkTree.ts
@@ -1,9 +1,11 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/linktr.ee\/([\S]+)$/;
 
-function battery(): void {
+function battery(): Battery | void {
   const linkElement = document.querySelector<HTMLAnchorElement>(
     "a[href*='getalby.com']"
   );
@@ -20,18 +22,16 @@ function battery(): void {
   const address = findLightningAddressInText(text ?? "");
   if (!address) return;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address,
-      ...getOriginData(),
-      description: description?.innerText ?? "",
-      name: document.querySelector<HTMLHeadingElement>("h1")?.innerText ?? "",
-      icon:
-        document.querySelector<HTMLImageElement>('[data-testid="ProfileImage"]')
-          ?.src ?? "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address,
+    ...getOriginData(),
+    description: description?.innerText ?? "",
+    name: document.querySelector<HTMLHeadingElement>("h1")?.innerText ?? "",
+    icon:
+      document.querySelector<HTMLImageElement>('[data-testid="ProfileImage"]')
+        ?.src ?? "",
+  };
 }
 
 const linkTree = {

--- a/src/extension/content-script/batteries/Medium.ts
+++ b/src/extension/content-script/batteries/Medium.ts
@@ -1,31 +1,30 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/(.+\.)?medium.com\/(\S+)?/;
 
-const battery = (): void => {
+const battery = (): Battery | void => {
   const name =
     document.querySelector<HTMLHeadingElement>(".pw-author-name")?.innerText;
-  const description = document.querySelector<HTMLParagraphElement>(
-    ".pw-follower-count ~ p"
-  )?.textContent;
+  const description =
+    document.querySelector<HTMLParagraphElement>("main ~ div")?.innerText;
   if (!name || !description) return;
 
   const match = findLightningAddressInText(description);
   if (!match) return;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: match,
-      ...getOriginData(),
-      description,
-      name,
-      icon:
-        document.querySelector<HTMLImageElement>(`img[alt*='${name}']`)?.src ??
-        "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: match,
+    ...getOriginData(),
+    description,
+    name,
+    icon:
+      document.querySelector<HTMLImageElement>(`img[alt*='${name}']`)?.src ??
+      "",
+  };
 };
 
 const Medium = {

--- a/src/extension/content-script/batteries/Medium.ts
+++ b/src/extension/content-script/batteries/Medium.ts
@@ -14,7 +14,7 @@ const battery = (): Battery | void => {
 
   const match = findLightningAddressInText(description);
   if (!match) return;
-
+  const contentUri = document.location.toString();
   return {
     method: "lnurl",
     address: match,
@@ -24,6 +24,7 @@ const battery = (): Battery | void => {
     icon:
       document.querySelector<HTMLImageElement>(`img[alt*='${name}']`)?.src ??
       "",
+    contentUri: contentUri,
   };
 };
 

--- a/src/extension/content-script/batteries/Mixcloud.ts
+++ b/src/extension/content-script/batteries/Mixcloud.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/www.mixcloud.com\/([^/]+)(\/)?([^/]+)?(\/)?$/;
 
@@ -33,16 +33,14 @@ async function handleShowPage(username: string) {
     return;
   }
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: address,
-      ...getOriginData(),
-      description: descriptionElement.content ?? "",
-      name: document.title.split(" | Mixcloud")[0] ?? "",
-      icon: imageUrl ?? "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: address,
+    ...getOriginData(),
+    description: descriptionElement.content ?? "",
+    name: document.title.split(" | Mixcloud")[0] ?? "",
+    icon: imageUrl ?? "",
+  };
 }
 
 async function handleProfilePage(username: string) {
@@ -54,16 +52,14 @@ async function handleProfilePage(username: string) {
 
   if (!address) return;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: address,
-      ...getOriginData(),
-      description: userInfo.biog,
-      name: userInfo.name ?? "",
-      icon: userInfo.pictures.medium ?? "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: address,
+    ...getOriginData(),
+    description: userInfo.biog,
+    name: userInfo.name ?? "",
+    icon: userInfo.pictures.medium ?? "",
+  };
 }
 
 const mixcloud = {

--- a/src/extension/content-script/batteries/Monetization.ts
+++ b/src/extension/content-script/batteries/Monetization.ts
@@ -1,7 +1,6 @@
-import { BatteryMetaTagRecipient } from "~/types";
+import { Battery, BatteryMetaTagRecipient } from "~/types";
 
 import getOriginData from "../originData";
-import { setLightningData } from "./helpers";
 
 const urlMatcher = /^https?:\/\/.*/i;
 
@@ -20,7 +19,7 @@ const parseRecipient = (content: string): BatteryMetaTagRecipient => {
   return recipient;
 };
 
-const battery = (): void => {
+const battery = (): Battery | void => {
   const monetizationTag = document.querySelector<HTMLMetaElement>(
     'head > meta[name="lightning" i]'
   );
@@ -43,12 +42,10 @@ const battery = (): void => {
 
   const metaData = getOriginData();
 
-  setLightningData([
-    {
-      ...recipient,
-      ...metaData,
-    },
-  ]);
+  return {
+    ...recipient,
+    ...metaData,
+  };
 };
 
 const Monetization = {

--- a/src/extension/content-script/batteries/Peertube.ts
+++ b/src/extension/content-script/batteries/Peertube.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
+import { Battery } from "~/types";
 
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 interface PeertubeRes {
   channel: {
@@ -19,7 +20,7 @@ interface PeertubeRes {
 // add more peertube URLs to this regex
 const urlMatcher = /^https?:\/\/(bitcointv\.com|www\.bitcast\.online)\/w\/.*/i;
 
-const battery = (): void => {
+const battery = (): Battery | void => {
   const hostMatch = document.location.toString().match(urlMatcher);
   if (!hostMatch) {
     return;
@@ -66,16 +67,14 @@ const battery = (): void => {
       }
       const metaData = getOriginData();
 
-      setLightningData([
-        {
-          ...metaData,
-          method: "lnurl",
-          address: recipient,
-          name: channelName,
-          icon: icon,
-          description: channelDescription,
-        },
-      ]);
+      return {
+        ...metaData,
+        method: "lnurl",
+        address: recipient,
+        name: channelName,
+        icon: icon,
+        description: channelDescription,
+      };
     })
     .catch((e) => {
       console.error("Alby could not load video data", e);

--- a/src/extension/content-script/batteries/Reddit.ts
+++ b/src/extension/content-script/batteries/Reddit.ts
@@ -1,9 +1,11 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/www.reddit\.com\/user\/(\w+).*/;
 
-function battery(): void {
+function battery(): Battery | void {
   const descriptionElement = document.querySelector<HTMLMetaElement>(
     'head > meta[name="description"]'
   );
@@ -35,16 +37,14 @@ function battery(): void {
     return;
   }
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: recipient,
-      ...getOriginData(),
-      description,
-      icon: imageUrl,
-      name: userName,
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: recipient,
+    ...getOriginData(),
+    description,
+    icon: imageUrl,
+    name: userName,
+  };
 }
 
 const reddit = {

--- a/src/extension/content-script/batteries/SoundCloud.ts
+++ b/src/extension/content-script/batteries/SoundCloud.ts
@@ -1,11 +1,13 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher =
   /^https:\/\/soundcloud.com\/([^/]+)(\/([^/]+))?(\/([^/]+))?(\/([^/]+))?$/;
 
 const pages = ["popular-tracks", "tracks", "albums", "sets", "reposts"];
-function battery(): void {
+function battery(): Battery | void {
   const urlParts = document.location
     .toString()
     .replace("https://soundcloud.com", "")
@@ -14,9 +16,9 @@ function battery(): void {
   const page = urlParts[2];
 
   if (username && (!page || pages.includes(page))) {
-    handleProfilePage();
+    return handleProfilePage();
   } else if (username && page) {
-    handleTrackPage();
+    return handleTrackPage();
   }
 }
 
@@ -29,26 +31,23 @@ function handleTrackPage() {
   const address = findLightningAddressInText(description.innerText);
   if (!address) return;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: address,
-      ...getOriginData(),
-      description:
-        document.querySelector<HTMLDivElement>(
-          ".soundTitle__titleHeroContainer"
-        )?.innerText ?? "",
-      name:
-        document.querySelector<HTMLAnchorElement>(
-          ".userBadge__username .userBadge__usernameLink"
-        )?.innerText ?? "",
-      icon:
-        document
-          .querySelector<HTMLSpanElement>(`.userBadge__avatar span.sc-artwork`)
-          ?.style.backgroundImage.slice(4, -1)
-          .replace(/"/g, "") ?? "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: address,
+    ...getOriginData(),
+    description:
+      document.querySelector<HTMLDivElement>(".soundTitle__titleHeroContainer")
+        ?.innerText ?? "",
+    name:
+      document.querySelector<HTMLAnchorElement>(
+        ".userBadge__username .userBadge__usernameLink"
+      )?.innerText ?? "",
+    icon:
+      document
+        .querySelector<HTMLSpanElement>(`.userBadge__avatar span.sc-artwork`)
+        ?.style.backgroundImage.slice(4, -1)
+        .replace(/"/g, "") ?? "",
+  };
 }
 
 function handleProfilePage() {
@@ -76,25 +75,23 @@ function handleProfilePage() {
   const address = findLightningAddressInText(text);
   if (!address) return;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: address,
-      ...getOriginData(),
-      description: descriptionElement?.innerText ?? "",
-      name:
-        document
-          .querySelector<HTMLHeadingElement>(".profileHeaderInfo__userName")
-          ?.childNodes[0]?.textContent?.trim() ?? "",
-      icon:
-        document
-          .querySelector<HTMLSpanElement>(
-            `.profileHeaderInfo__avatar span.sc-artwork`
-          )
-          ?.style.backgroundImage.slice(4, -1)
-          .replace(/"/g, "") ?? "",
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: address,
+    ...getOriginData(),
+    description: descriptionElement?.innerText ?? "",
+    name:
+      document
+        .querySelector<HTMLHeadingElement>(".profileHeaderInfo__userName")
+        ?.childNodes[0]?.textContent?.trim() ?? "",
+    icon:
+      document
+        .querySelector<HTMLSpanElement>(
+          `.profileHeaderInfo__avatar span.sc-artwork`
+        )
+        ?.style.backgroundImage.slice(4, -1)
+        .replace(/"/g, "") ?? "",
+  };
 }
 
 const soundCloud = {

--- a/src/extension/content-script/batteries/StackOverflow.ts
+++ b/src/extension/content-script/batteries/StackOverflow.ts
@@ -2,12 +2,12 @@ import axios from "axios";
 import type { Battery } from "~/types";
 
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher =
   /^https:\/\/stackoverflow\.com\/(users|questions)\/(\d+)\/(\w+).*/;
 
-const battery = async (): Promise<void> => {
+const battery = async (): Promise<Battery | void> => {
   const urlParts = document.location.pathname.split("/");
   const route = urlParts[1];
   const userOrQuestionId = urlParts[2];
@@ -21,7 +21,7 @@ const battery = async (): Promise<void> => {
     lightningData = await handleQuestionPage(userOrQuestionId);
   }
 
-  if (lightningData) setLightningData([lightningData]);
+  if (lightningData) return lightningData;
 };
 
 function htmlToText(html: string) {

--- a/src/extension/content-script/batteries/Twitter.ts
+++ b/src/extension/content-script/batteries/Twitter.ts
@@ -1,5 +1,6 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { setLightningData } from "./helpers";
 
 declare global {
   interface Window {
@@ -74,7 +75,7 @@ function getUserData(username: string) {
   return null;
 }
 
-function battery(): void {
+function battery(): Battery | void {
   // Twitter loads everything async...so we observe DOM changes to check if data finished loading.
   function twitterDOMChanged(_: MutationRecord[], observer: MutationObserver) {
     const username = getUsername();
@@ -124,15 +125,13 @@ function battery(): void {
         return;
       }
 
-      setLightningData([
-        {
-          method: "lnurl",
-          address: recipient,
-          ...getOriginData(),
-          icon: userData.imageUrl,
-          name: userData.name,
-        },
-      ]);
+      return {
+        method: "lnurl",
+        address: recipient,
+        ...getOriginData(),
+        icon: userData.imageUrl,
+        name: userData.name,
+      };
     }
   }
 
@@ -147,7 +146,7 @@ function battery(): void {
   });
   // On slow connections the observer is added after the DOM is fully loaded.
   // Therefore the callback twitterDOMChanged needs to also be called manually.
-  twitterDOMChanged([], window.LBE_TWITTER_MUTATION_OBSERVER);
+  return twitterDOMChanged([], window.LBE_TWITTER_MUTATION_OBSERVER);
 }
 
 const twitter = {

--- a/src/extension/content-script/batteries/Vida.ts
+++ b/src/extension/content-script/batteries/Vida.ts
@@ -1,9 +1,11 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/vida.page\/(\w+)$/;
 
-function battery(): void {
+function battery(): Battery | void {
   const monetizationTag = document.querySelector<HTMLMetaElement>(
     'head > meta[name="lightning" i]'
   );
@@ -43,13 +45,11 @@ function battery(): void {
   if (icon) {
     originData.icon = icon;
   }
-  setLightningData([
-    {
-      method: "lnurl",
-      address,
-      ...originData,
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address,
+    ...originData,
+  };
 }
 
 const vida = {

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -16,6 +16,7 @@ const battery = (): Battery | void => {
   const text = videoDescription.textContent || "";
   let match;
   let recipient;
+  const contentUri = document.location.toString();
   // check for an lnurl
   if ((match = text.match(/(lnurlp:)(\S+)/i))) {
     recipient = match[2];
@@ -38,6 +39,7 @@ const battery = (): Battery | void => {
     ...getOriginData(),
     name,
     icon: imageUrl,
+    contentUri: contentUri,
   };
 };
 

--- a/src/extension/content-script/batteries/VimeoVideo.ts
+++ b/src/extension/content-script/batteries/VimeoVideo.ts
@@ -1,9 +1,11 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/vimeo.com\/.*\d{4,}\/?$/;
 
-const battery = (): void => {
+const battery = (): Battery | void => {
   const videoDescription = document.querySelector("[data-description-content]");
   const channelLink = document.querySelector(
     ".clip_info-subline--watch .js-user_link"
@@ -30,15 +32,13 @@ const battery = (): void => {
   const imageUrl =
     document.querySelector<HTMLImageElement>(".clip_info-subline--watch img")
       ?.src || "";
-  setLightningData([
-    {
-      method: "lnurl",
-      address: recipient,
-      ...getOriginData(),
-      name,
-      icon: imageUrl,
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: recipient,
+    ...getOriginData(),
+    name,
+    icon: imageUrl,
+  };
 };
 
 const VimeoVideo = {

--- a/src/extension/content-script/batteries/YouTubeChannel.ts
+++ b/src/extension/content-script/batteries/YouTubeChannel.ts
@@ -22,6 +22,7 @@ const battery = async (): Promise<Battery | void> => {
     )?.src || "";
 
   let lnurl;
+  const contentUri = match[0];
 
   const headerLink = document.querySelector<HTMLAnchorElement>(
     "#channel-header #primary-links a[href*='getalby.com']"
@@ -43,6 +44,7 @@ const battery = async (): Promise<Battery | void> => {
     name: name,
     description: "", // we can not reliably find a description (the meta tag might be of a different video)
     icon: imageUrl,
+    contentUri: contentUri,
   };
 };
 

--- a/src/extension/content-script/batteries/YouTubeChannel.ts
+++ b/src/extension/content-script/batteries/YouTubeChannel.ts
@@ -1,12 +1,13 @@
 import axios from "axios";
+import { Battery } from "~/types";
 
 import getOriginData from "../originData";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher =
   /^https:\/\/www\.youtube.com\/(((channel|c)\/([^/]+))|(@[^/]+)).*/;
 
-const battery = async (): Promise<void> => {
+const battery = async (): Promise<Battery | void> => {
   const match = document.location.toString().match(urlMatcher);
   if (!match) {
     return;
@@ -35,16 +36,14 @@ const battery = async (): Promise<void> => {
 
   if (!lnurl) return;
 
-  setLightningData([
-    {
-      method: "lnurl",
-      address: lnurl,
-      ...getOriginData(),
-      name: name,
-      description: "", // we can not reliably find a description (the meta tag might be of a different video)
-      icon: imageUrl,
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: lnurl,
+    ...getOriginData(),
+    name: name,
+    description: "", // we can not reliably find a description (the meta tag might be of a different video)
+    icon: imageUrl,
+  };
 };
 
 const findLnurlFromHeaderLink = (

--- a/src/extension/content-script/batteries/YouTubeVideo.ts
+++ b/src/extension/content-script/batteries/YouTubeVideo.ts
@@ -2,7 +2,7 @@ import { Battery } from "~/types";
 
 import getOriginData from "../originData";
 import { findLnurlFromYouTubeAboutPage } from "./YouTubeChannel";
-import { findLightningAddressInText, setLightningData } from "./helpers";
+import { findLightningAddressInText } from "./helpers";
 
 const urlMatcher = /^https:\/\/www\.youtube.com\/watch.*/;
 
@@ -23,6 +23,7 @@ const battery = async (): Promise<Battery | void> => {
   }
   let match;
   let lnurl;
+  const contentUri = document.location.toString();
   // check for an lnurl
   if ((match = text.match(/(lnurlp:)(\S+)/i))) {
     lnurl = match[2];
@@ -52,16 +53,15 @@ const battery = async (): Promise<Battery | void> => {
       "#columns #primary #primary-inner #owner #avatar img" // support maybe new UI being rolled out 2022/09
     )?.src ||
     "";
-  setLightningData([
-    {
-      method: "lnurl",
-      address: lnurl,
-      ...getOriginData(),
-      name,
-      description: "", // we can not reliably find a description (the meta tag might be of a different video)
-      icon: imageUrl,
-    },
-  ]);
+  return {
+    method: "lnurl",
+    address: lnurl,
+    ...getOriginData(),
+    name,
+    description: "", // we can not reliably find a description (the meta tag might be of a different video)
+    icon: imageUrl,
+    contentUri: contentUri,
+  };
 };
 
 const YouTubeVideo = {

--- a/src/extension/content-script/batteries/YouTubeVideo.ts
+++ b/src/extension/content-script/batteries/YouTubeVideo.ts
@@ -1,10 +1,12 @@
+import { Battery } from "~/types";
+
 import getOriginData from "../originData";
 import { findLnurlFromYouTubeAboutPage } from "./YouTubeChannel";
 import { findLightningAddressInText, setLightningData } from "./helpers";
 
 const urlMatcher = /^https:\/\/www\.youtube.com\/watch.*/;
 
-const battery = async (): Promise<void> => {
+const battery = async (): Promise<Battery | void> => {
   let text = "";
   document
     .querySelectorAll(

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -46,7 +46,7 @@ async function extractLightningData() {
   );
 
   if (match) {
-    match.battery();
+    return match.battery();
   }
 }
 export default extractLightningData;

--- a/src/extension/content-script/boost-button/button.jsx
+++ b/src/extension/content-script/boost-button/button.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import "~/app/styles/index.css";
+import WebLNProvider from "~/extension/ln/webln";
 
-import WebLNProvider from "../../ln/webln";
 import extractLightningData from "../batteries/index";
 
 function BoostButton() {
@@ -11,13 +11,20 @@ function BoostButton() {
   const [lnurl, setLnurl] = useState(false);
 
   useEffect(() => {
+    let count = 0;
+
     const extract = async () => {
+      count++;
       const lnData = await extractLightningData();
       if (lnData) {
         setLnurl(lnData.address);
+        clearInterval(intervalId);
+      } else if (count >= 5) {
+        clearInterval(intervalId);
       }
     };
 
+    const intervalId = setInterval(extract, 3000);
     extract();
   }, []);
 

--- a/src/extension/content-script/boost-button/button.jsx
+++ b/src/extension/content-script/boost-button/button.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import "~/app/styles/index.css";
+
+import WebLNProvider from "../../ln/webln";
+import extractLightningData from "../batteries/index";
+
+function BoostButton() {
+  const [sats, setSats] = useState(0);
+  const [sent, setSent] = useState(false);
+
+  const [lnurl, setLnurl] = useState(false);
+
+  useEffect(() => {
+    const extract = async () => {
+      const lnData = await extractLightningData();
+      if (lnData) {
+        setLnurl(lnData.address);
+      }
+    };
+
+    extract();
+  }, []);
+
+  const sendSats = async () => {
+    window.webln = new WebLNProvider();
+    try {
+      await window.webln.enable();
+      try {
+        const result = await window.webln.lnurl(lnurl);
+        if (result) {
+          setSats(result.route.total_amt);
+          setSent(true);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return lnurl ? (
+    <button
+      onClick={sendSats}
+      style={{
+        position: "fixed",
+        zIndex: 1000000000,
+        bottom: 20,
+        right: 20,
+        padding: 10,
+        border: "none",
+        fontFamily: "monospace",
+        fontSize: "1rem",
+        boxShadow: "0 0 10px #0000004a",
+        color: "white",
+        backgroundColor: "orange",
+        borderRadius: "0.25rem",
+      }}
+    >
+      {sent ? `Sent ${sats}. Send more?` : `Boost Sats to ${lnurl}`}
+    </button>
+  ) : null;
+}
+
+export default BoostButton;

--- a/src/extension/content-script/boost-button/button.jsx
+++ b/src/extension/content-script/boost-button/button.jsx
@@ -50,11 +50,12 @@ function BoostButton() {
         padding: 10,
         border: "none",
         fontFamily: "monospace",
-        fontSize: "1rem",
+        fontSize: "15px",
         boxShadow: "0 0 10px #0000004a",
         color: "white",
         backgroundColor: "orange",
         borderRadius: "0.25rem",
+        cursor: "pointer",
       }}
     >
       {sent ? `Sent ${sats}. Send more?` : `Boost Sats to ${lnurl}`}

--- a/src/extension/content-script/boost-button/index.tsx
+++ b/src/extension/content-script/boost-button/index.tsx
@@ -6,16 +6,19 @@ import BoostButton from "./button";
 
 function injectBoostButton() {
   const body = document.querySelector("body");
+  const shadowWrapper = document.createElement("div");
   const app = document.createElement("div");
 
+  shadowWrapper.id = "alby-shadow";
   app.id = "alby-root";
 
   if (body && !window.frameElement) {
-    body.prepend(app);
+    body.prepend(shadowWrapper);
+    const shadow = shadowWrapper.attachShadow({ mode: "open" });
+    shadow.appendChild(app);
   }
 
-  const container = document.getElementById("alby-root") as HTMLElement;
-  const root = createRoot(container);
+  const root = createRoot(app);
 
   root.render(<BoostButton />);
 }

--- a/src/extension/content-script/boost-button/index.tsx
+++ b/src/extension/content-script/boost-button/index.tsx
@@ -1,0 +1,23 @@
+import { createRoot } from "react-dom/client";
+import "~/app/styles/index.css";
+import "~/i18n/i18nConfig";
+
+import BoostButton from "./button";
+
+function injectBoostButton() {
+  const body = document.querySelector("body");
+  const app = document.createElement("div");
+
+  app.id = "alby-root";
+
+  if (body && !window.frameElement) {
+    body.prepend(app);
+  }
+
+  const container = document.getElementById("alby-root") as HTMLElement;
+  const root = createRoot(container);
+
+  root.render(<BoostButton />);
+}
+
+export default injectBoostButton;

--- a/src/extension/content-script/onend.js
+++ b/src/extension/content-script/onend.js
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 
-import extractLightningData from "./batteries";
+import injectBoostButton from "./boost-button";
 import injectScript from "./injectScript";
 import getOriginData from "./originData";
 import shouldInject from "./shouldInject";
@@ -31,11 +31,12 @@ async function init() {
   }
 
   injectScript(browser.runtime.getURL("js/inpageScript.bundle.js")); // registers the DOM event listeners and checks webln again (which is also loaded onstart
+  injectBoostButton();
 
   // extract LN data from websites
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "extractLightningData") {
-      extractLightningData();
+      // extractLightningData();
     }
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface Battery extends OriginData {
   suggested?: string;
   name: string;
   icon: string;
+  contentUri?: string;
 }
 
 export type BatteryMetaTagRecipient = Pick<


### PR DESCRIPTION

_A clear and concise description of what you want to happen_
add contentUri field to battery responses of Alby boost button
support for youtube video, youtube channel, vimeo and medium



### Type of change
- `feat`: New feature (non-breaking change which adds functionality)


### Screenshots of the changes [optional]




### Checklist

- [X] My code follows the style guidelines of this project and performed a self-review of my own code
- [X] New and existing tests pass locally with my changes
- [X] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
