### PR TITLE
fix: style disabled state of inputs

### DIFF
--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -29,7 +29,7 @@ export default function Input({
 }: React.InputHTMLAttributes<HTMLInputElement> & Props) {
   const inputEl = useRef<HTMLInputElement>(null);
   const outerStyles =
-    "rounded-md border border-gray-300 dark:border-neutral-800 bg-white dark:bg-black transition duration-300";
+    "rounded-md border border-gray-300 dark:border-neutral-800 transition duration-300";
 
   const inputNode = (
     <input
@@ -39,11 +39,12 @@ export default function Input({
       id={id}
       className={classNames(
         "block w-full placeholder-gray-500 dark:placeholder-neutral-600",
+        !suffix && !endAdornment
+          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
+          : "pr-0 border-0 focus:ring-0",
         disabled
-          ? "rounded-md border border-gray-300 dark:border-neutral-800 bg-gray-50 dark:bg-surface-01dp text-gray-500 dark:text-neutral-500"
-          : !suffix && !endAdornment
-          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1 dark:text-white`
-          : "pr-0 border-0 focus:ring-0 bg-transparent dark:text-white"
+          ? "bg-gray-50 dark:bg-surface-01dp text-gray-500 dark:text-neutral-500"
+          : "bg-white dark:bg-black dark:text-white"
       )}
       placeholder={placeholder}
       required={required}

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -40,8 +40,8 @@ export default function Input({
       className={classNames(
         "block w-full placeholder-gray-500 dark:placeholder-neutral-600 dark:text-white",
         disabled
-        ? `${outerStyles} bg-gray-50 dark:bg-surface-16dp text-gray-500 dark:text-gray-500`
-        : !suffix && !endAdornment
+          ? `${outerStyles} bg-gray-50 dark:bg-surface-16dp text-gray-500 dark:text-gray-500`
+          : !suffix && !endAdornment
           ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
           : "pr-0 border-0 focus:ring-0 bg-transparent"
       )}

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -39,7 +39,9 @@ export default function Input({
       id={id}
       className={classNames(
         "block w-full placeholder-gray-500 dark:placeholder-neutral-600 dark:text-white",
-        !suffix && !endAdornment
+        disabled
+        ? `${outerStyles} bg-gray-50 dark:bg-surface-16dp text-gray-500 dark:text-gray-500`
+        : !suffix && !endAdornment
           ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
           : "pr-0 border-0 focus:ring-0 bg-transparent"
       )}

--- a/src/app/components/form/Input/index.tsx
+++ b/src/app/components/form/Input/index.tsx
@@ -38,12 +38,12 @@ export default function Input({
       name={name}
       id={id}
       className={classNames(
-        "block w-full placeholder-gray-500 dark:placeholder-neutral-600 dark:text-white",
+        "block w-full placeholder-gray-500 dark:placeholder-neutral-600",
         disabled
-          ? `${outerStyles} bg-gray-50 dark:bg-surface-16dp text-gray-500 dark:text-gray-500`
+          ? "rounded-md border border-gray-300 dark:border-neutral-800 bg-gray-50 dark:bg-surface-01dp text-gray-500 dark:text-neutral-500"
           : !suffix && !endAdornment
-          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1`
-          : "pr-0 border-0 focus:ring-0 bg-transparent"
+          ? `${outerStyles} focus:ring-orange-bitcoin focus:border-orange-bitcoin focus:dark:border-orange-bitcoin focus:ring-1 dark:text-white`
+          : "pr-0 border-0 focus:ring-0 bg-transparent dark:text-white"
       )}
       placeholder={placeholder}
       required={required}


### PR DESCRIPTION
### Description

I have made the changes in the inputNode component className prop which had classNames function in which I added the extra condition to check whether the field is disabled or not and applied the styles as desired in the issue discription


### Link this PR to an issue

Fixes #2292

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

![Screenshot from 2023-03-31 07-19-44](https://user-images.githubusercontent.com/91190547/229002512-e671c3bb-1ace-4cb4-999c-3dc843340771.png)
![Screenshot from 2023-03-31 07-20-11](https://user-images.githubusercontent.com/91190547/229002532-9f3f76d7-1c2f-462c-bb73-41de21af001d.png)

### How has this been tested?

The Public Key field can be now checked and it is according to the required UI which reflects that it is disabled in both light and dark modes. It can be seen in the above images.


### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
