### PR TITLE
feat: settings bottom div margin added

### DIFF
--- a/src/app/screens/Settings/index.tsx
+++ b/src/app/screens/Settings/index.tsx
@@ -395,7 +395,7 @@ function Settings() {
           components={[<strong></strong>]}
         />
       </p>
-      <div className="shadow bg-white sm:rounded-md sm:overflow-hidden px-6 py-2 divide-y divide-black/10 dark:divide-white/10 dark:bg-surface-02dp">
+      <div className="shadow bg-white sm:rounded-md sm:overflow-hidden px-6 py-2 divide-y divide-black/10 dark:divide-white/10 dark:bg-surface-02dp mb-5">
         <Setting
           title={t("lnurl_auth.legacy_lnurl_auth_202207.title")}
           subtitle={t("lnurl_auth.legacy_lnurl_auth_202207.subtitle")}


### PR DESCRIPTION
### Describe the changes you have made in this PR

_Under the Legacy settings, the toggle buttons ``Legacy LNURL-Auth`` and ``Legacy signing for LNDhub and LNbits`` had their Parent DIV touching the bottom, leading to a poor user experience. To fix this issue, I added the Tailwind Class ``mb-5`` to the parent div of the buttons, which added a margin from the bottom._
 
 


### Link this PR to an issue 

Fixes _#2299_

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)


### Screenshots of the changes [optional]

![bug-fixed](https://user-images.githubusercontent.com/81313264/229898252-1839572d-a6f4-479b-b68a-d1415cb5d1a2.png)


### Checklist

- [&#x2611; ] My code follows the style guidelines of this project and performed a self-review of my own code
- [&#x2611; ] New and existing tests pass locally with my changes
- [ &#x2611;] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
