### PR TITLE
Fix :Correct upper helper text in inputs coloring #2291

### DIFF
--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -85,7 +85,7 @@ export default function DualCurrencyField({
           {label}
         </label>
         {(min || max) && (
-          <span className="text-xs font-normal text-gray-800 dark:text-neutral-400">
+          <span className="text-xs font-normal text-gray-700 dark:text-neutral-400">
             <RangeLabel min={min} max={max} /> sats
           </span>
         )}


### PR DESCRIPTION
### Describe the changes you have made in this PR

Updated the current upper helper text in inputs is black in both light and dark theme to
Light theme: gray-700
Dark theme: neutral-400

### Link this PR to an issue 

Fixes #2291

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)


### Screenshots of the changes [optional]
![Screenshot from 2023-04-07 21-50-43](https://user-images.githubusercontent.com/91190547/230642830-b931c3ad-6562-44d0-a805-8a134cc90f24.png)



### Checklist

- [ ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
