### PR TITLE
fix: changing logical validations to form data input password and con…

### DIFF
--- a/src/app/components/PasswordForm/index.tsx
+++ b/src/app/components/PasswordForm/index.tsx
@@ -77,12 +77,20 @@ export default function PasswordForm<
     let passwordErrorMessage: errorMessage = "";
     let passwordConfirmationErrorMessage: errorMessage = "";
 
-    if (!formData.password) passwordErrorMessage = "enter_password";
-    if (confirm && !formData.passwordConfirmation) {
+    if (confirm && !formData.password && formData.passwordConfirmation) {
+      passwordErrorMessage = "enter_password";
+    }
+
+    if (confirm && formData.password && !formData.passwordConfirmation) {
       passwordConfirmationErrorMessage = "confirm_password";
-    } else if (confirm && formData.password !== formData.passwordConfirmation) {
+    } else if (
+      confirm &&
+      formData.passwordConfirmation &&
+      formData.password !== formData.passwordConfirmation
+    ) {
       passwordConfirmationErrorMessage = "mismatched_password";
     }
+
     setErrors({
       passwordErrorMessage,
       passwordConfirmationErrorMessage,


### PR DESCRIPTION
### Describe the changes you have made in this PR

Fixing check triggered when removing focus from input in change unlock password area.

As I commented in Issue #2221, the error is that the issue occurs when the focus is automatically on the input and is removed (such as when closing the modal), triggering error checks. Although this behavior is expected and not a bug, it can still lead to a poor user experience.

in the code, I modified the checks to occur at the correct times.

### Link this PR to an issue

Fixes #2221

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes

https://user-images.githubusercontent.com/62851165/230783413-9e7549f5-c1ea-4d0f-801d-6d0f9cf04ec0.mp4

### How has this been tested?

Manually. No others tests was created.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
