### PR TITLE
feat(battery): add Mastodon tips

### DIFF
--- a/src/extension/content-script/batteries/Mastodon.ts
+++ b/src/extension/content-script/batteries/Mastodon.ts
@@ -1,0 +1,63 @@
+import getOriginData from "../originData";
+import { findLightningAddressInText, setLightningData } from "./helpers";
+
+// TODO: Detect Mastodon instance
+const urlMatcher = /^https:\/\/libretooth.gr\/@.*\/?$/;
+
+const battery = (): void => {
+  const profileBio = document.querySelector(
+    ".account__header__bio .account__header__content p"
+  );
+  if (!profileBio) {
+    return;
+  }
+  const text = profileBio.textContent || "";
+
+  let match;
+  let recipient;
+  let zapElement;
+
+  // Check for an LNURL
+  if ((match = text.match(/(lnurlp:)(\S+)/i))) {
+    recipient = match[2];
+  }
+  // If there is no LNURL, try to match an Alby link
+  else if ((match = findLightningAddressInText(text))) {
+    recipient = match;
+  }
+  // Mastodon converts zap emoji to img. Let's try to find it and get LNURL
+  else if ((zapElement = profileBio.querySelector('img[title=":zap:"'))) {
+    if (zapElement) {
+      const lnaddress = zapElement.nextSibling?.textContent as string;
+      const match = lnaddress.match(/(:?)\s?(\S+@\S+)/i);
+      if (match) recipient = match[2];
+      else return;
+    } else {
+      return;
+    }
+  } else {
+    return;
+  }
+
+  const name =
+    document.querySelector(".account__header__tabs__name h1 span")
+      ?.textContent || "";
+  const imageUrl =
+    document.querySelector<HTMLImageElement>(".account__avatar img")?.src || "";
+  setLightningData([
+    {
+      method: "lnurl",
+      address: recipient,
+      ...getOriginData(),
+      name,
+      icon: imageUrl,
+    },
+  ]);
+};
+
+const Mastodon = {
+  urlMatcher,
+  battery,
+};
+
+export default Mastodon;

--- a/src/extension/content-script/batteries/index.ts
+++ b/src/extension/content-script/batteries/index.ts
@@ -3,6 +3,7 @@ import api from "~/common/lib/api";
 import GeyserProject from "./GeyserProject";
 import GitHub from "./GitHub";
 import LinkTree from "./LinkTree";
+import Mastodon from "./Mastodon";
 import Medium from "./Medium";
 import Mixcloud from "./Mixcloud";
 import Monetization from "./Monetization";
@@ -27,6 +28,7 @@ const enhancements = [
   Peertube,
   VimeoVideo,
   LinkTree,
+  Mastodon,
   Medium,
   Mixcloud,
   GitHub,


### PR DESCRIPTION
### Describe the changes you have made in this PR

Add tipping for Mastodon instances.

### Link this PR to an issue [optional]

- https://github.com/getAlby/lightning-browser-extension/wiki/Bounties#add-tipping-support-for-mastodon-instances
- https://github.com/getAlby/lightning-browser-extension/issues/476
- https://github.com/getAlby/lightning-browser-extension/pull/826

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)


### How has this been tested?

Currently only on libretooth.gr. It's still WIP.

### Checklist

- [ ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
