### PR TITLE
feat: DefaultView reverse send/receive buttons order

### DIFF
--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -160,21 +160,21 @@ const DefaultView: FC<Props> = (props) => {
         <div className="flex mb-6 space-x-4">
           <Button
             fullWidth
-            icon={<SendIcon className="w-6 h-6" />}
-            label={tCommon("actions.send")}
-            direction="column"
-            onClick={() => {
-              navigate("/send");
-            }}
-          />
-
-          <Button
-            fullWidth
             icon={<ReceiveIcon className="w-6 h-6" />}
             label={tCommon("actions.receive")}
             direction="column"
             onClick={() => {
               navigate("/receive");
+            }}
+          />
+
+          <Button
+            fullWidth
+            icon={<SendIcon className="w-6 h-6" />}
+            label={tCommon("actions.send")}
+            direction="column"
+            onClick={() => {
+              navigate("/send");
             }}
           />
         </div>


### PR DESCRIPTION
### Describe the changes you have made in this PR

In order to have designs consistent for #2334 this PR reverses the order of DefaultView send/receive buttons

### Link this PR to an issue

Fixes #2334

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

<img width="382" alt="Bildschirmfoto 2023-04-10 um 16 48 47" src="https://user-images.githubusercontent.com/886152/231005883-a4ca3001-cfa6-45ba-ac84-a062ddd8fbdb.png">

### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
