### PR TITLE
Added Music Side Project and CurioCaster  to the "Discover" page

### DIFF
--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -3,6 +3,18 @@
     "title": "entertainment",
     "items": [
       {
+        "title": "CurioCaster",
+        "subtitle": "Podcast web player",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/curiocaster_thumbnail.png",
+        "url": "https://curiocaster.com"
+      },
+      {
+        "title": "Music Side Project",
+        "subtitle": "Music web player",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/musicsideproject_thumbnail.png",
+        "url": "https://musicsideproject.com/"
+      },
+      {
         "title": "Podverse",
         "subtitle": "Podcast player with bitcoin payments",
         "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/podverse_thumbnail.png",
@@ -25,18 +37,6 @@
         "subtitle": "Articles about the Lightning Network",
         "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/yalls.png",
         "url": "https://yalls.org/"
-      },
-      {
-        "title": "Music Side Project",
-        "subtitle": "Music web player",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/musicsideproject_thumbnail.png",
-        "url": "https://musicsideproject.com/"
-      },
-      {
-        "title": "CurioCaster",
-        "subtitle": "Podcast web player",
-        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/curiocaster_thumbnail.png",
-        "url": "https://curiocaster.com"
       }
     ]
   },

--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -29,13 +29,13 @@
       {
         "title": "Music Side Project",
         "subtitle": "Music web player",
-        "logo": "https://user-images.githubusercontent.com/100958893/232284397-765976b4-4ce4-44a7-ba6f-668c2fff2520.png",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/musicsideproject_thumbnail.png",
         "url": "https://musicsideproject.com/"
       },
       {
         "title": "CurioCaster",
         "subtitle": "Podcast web player",
-        "logo": "https://user-images.githubusercontent.com/100958893/232284035-0dce1c80-54d2-4910-a71d-2552bc9510a8.png",
+        "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/curiocaster_thumbnail.png",
         "url": "https://curiocaster.com"
       }
     ]

--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -25,6 +25,18 @@
         "subtitle": "Articles about the Lightning Network",
         "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/yalls.png",
         "url": "https://yalls.org/"
+      },
+      {
+        "title": "Music Side Project",
+        "subtitle": "Music web player",
+        "logo": "https://user-images.githubusercontent.com/100958893/232284397-765976b4-4ce4-44a7-ba6f-668c2fff2520.png",
+        "url": "https://musicsideproject.com/"
+      },
+      {
+        "title": "CurioCaster",
+        "subtitle": "Podcast web player",
+        "logo": "https://user-images.githubusercontent.com/100958893/232284035-0dce1c80-54d2-4910-a71d-2552bc9510a8.png",
+        "url": "https://curiocaster.com"
       }
     ]
   },


### PR DESCRIPTION
### Describe the changes you have made in this PR
Added https://musicsideproject.com/ and https://curiocaster.com/  to the "Discover" page under entertainment section. 

### Link this PR to an issue [optional]

Fixes _ #2353 by @MoritzKa 

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]
Current Discover Page -
![image](https://user-images.githubusercontent.com/100958893/232286204-b200737d-eb32-4327-9f70-b5ebfbfd47f9.png)

Updated Discover Page- 
![image](https://user-images.githubusercontent.com/100958893/232286326-d5cb24fb-b90b-4803-8417-f2c0fa507c9f.png)

### Note

I have not yet uploaded the logos to the Content Delivery Network (CDN). Currently, I am using GitHub links. Could you please assist me with uploading them to the CDN as I am not familiar with the process?

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
