### PR TITLE
feat: add account-context balanceLoading

### DIFF
--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -25,6 +25,7 @@ interface AccountContextType {
     accountBalance: string;
   };
   loading: boolean;
+  balanceLoading: boolean;
   unlock: (user: string, callback: VoidFunction) => Promise<void>;
   lock: (callback: VoidFunction) => void;
   /**
@@ -51,6 +52,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
 
   const [account, setAccount] = useState<AccountContextType["account"]>(null);
   const [loading, setLoading] = useState(true);
+  const [balanceLoading, setBalanceLoading] = useState(true);
   const [accountBalance, setAccountBalance] = useState("");
   const [fiatBalance, setFiatBalance] = useState("");
 
@@ -94,6 +96,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
   };
 
   const fetchAccountInfo = async (options?: { accountId?: string }) => {
+    setBalanceLoading(true);
     const id = options?.accountId || account?.id;
     if (!id) return;
 
@@ -103,6 +106,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
     };
 
     const accountInfo = await api.swr.getAccountInfo(id, callback);
+    setBalanceLoading(false);
 
     return { ...accountInfo, fiatBalance, accountBalance };
   };
@@ -164,6 +168,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
     },
     fetchAccountInfo,
     loading,
+    balanceLoading,
     lock,
     setAccountId,
     unlock,


### PR DESCRIPTION
### Describe the changes you have made in this PR

Add balanceLoading to be used in #2318 BalanceBox. The current AccountContext "loading" is not viable, because the balance is loaded async.

### Link this PR to an issue [optional]

Adds to #2236 

### Checklist

- [ ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
