### PR TITLE
chore: also wait for migrations before finishing init

### DIFF
--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -156,8 +156,8 @@ async function init() {
 
   events.subscribe();
   console.info("Events subscribed");
-  console.info("Running any migrations");
   if (isRecentlyUpdated) {
+    console.info("Running any pending migrations");
     await migrate();
   }
   console.info("Loading completed");

--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -9,7 +9,7 @@ import { router } from "./router";
 import state from "./state";
 
 let isFirstInstalled = false;
-// let isRecentlyUpdated = false;
+let isRecentlyUpdated = false;
 const {
   promise: isInitialized,
   resolve: resolveInit,
@@ -84,7 +84,7 @@ const handleInstalled = (details: { reason: string }) => {
   }
   if (details.reason === "update") {
     console.info("Alby was recently updated");
-    // isRecentlyUpdated = true;
+    isRecentlyUpdated = true;
   }
 };
 
@@ -157,7 +157,9 @@ async function init() {
   events.subscribe();
   console.info("Events subscribed");
   console.info("Running any migrations");
-  await migrate();
+  if (isRecentlyUpdated) {
+    await migrate();
+  }
   console.info("Loading completed");
 }
 

--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -9,7 +9,7 @@ import { router } from "./router";
 import state from "./state";
 
 let isFirstInstalled = false;
-let isRecentlyUpdated = false;
+// let isRecentlyUpdated = false;
 const {
   promise: isInitialized,
   resolve: resolveInit,
@@ -84,7 +84,7 @@ const handleInstalled = (details: { reason: string }) => {
   }
   if (details.reason === "update") {
     console.info("Alby was recently updated");
-    isRecentlyUpdated = true;
+    // isRecentlyUpdated = true;
   }
 };
 
@@ -156,7 +156,8 @@ async function init() {
 
   events.subscribe();
   console.info("Events subscribed");
-
+  console.info("Running any migrations");
+  await migrate();
   console.info("Loading completed");
 }
 
@@ -168,9 +169,6 @@ init()
     }
     if (isFirstInstalled && !state.getState().getAccount()) {
       utils.openUrl("welcome.html");
-    }
-    if (isRecentlyUpdated) {
-      migrate();
     }
   })
   .catch((err) => {


### PR DESCRIPTION
(Merging into draft PR https://github.com/getAlby/lightning-browser-extension/pull/2364)

I believe the migrations should also run before the init() function finishes.

the migrate() function already checks whether it should run migrations, so I don't believe we only need to run it on update