### PR TITLE
Add Coincards.com to websites.json

### DIFF
--- a/src/app/screens/Discover/websites.json
+++ b/src/app/screens/Discover/websites.json
@@ -60,6 +60,12 @@
         "subtitle": "Collection of stores and websites accepting bitcoin",
         "logo": "https://cdn.getalby-assets.com/alby-extension-website-screen/lightning-network-stores_thumbnail.png",
         "url": "https://lightningnetworkstores.com/"
+      },
+      {
+        "title": "Coincards",
+        "subtitle": "Shop for Gift Cards, Mobile Top-ups & Prepaid Vouchers for hundreds of retailers",
+        "logo": "https://assets.coincards.com/wp-content/uploads/2023/05/08102339/56logo.png",
+        "url": "https://coincards.com/"
       }
     ]
   },


### PR DESCRIPTION
### Describe the changes you have made in this PR

This adds Coincards.com to the shopping section of the [Discover] tab. Coincards.com has been lightning enabled since 2018 and as it uses btcpay, it is compatible with Alby. 

![FvKN_P4akAAJBsC](https://user-images.githubusercontent.com/3916318/236892779-0ff9c3d1-d762-448d-ab2d-6eec0d761b82.png)

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)