### PR TITLE
fix: replace htmltotext function

### DIFF
--- a/src/extension/content-script/batteries/StackOverflow.ts
+++ b/src/extension/content-script/batteries/StackOverflow.ts
@@ -26,9 +26,8 @@ const battery = async (): Promise<void> => {
 };
 
 function htmlToText(html: string) {
-  const temp = document.createElement("div");
-  temp.innerHTML = html;
-  return temp.textContent;
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return doc.textContent;
 }
 
 async function handleQuestionPage(questionId: string): Promise<Battery | null> {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Replace the htmltotext function with DomParser to avoid JS injections. 

`htmlTotext("abc<svg><svg onload=alert(1)</svg></svg>123")`