### PR TITLE
feat: generate a random lightning address for new alby accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dayjs": "^1.11.7",
     "dexie": "^3.2.3",
     "elliptic": "^6.5.4",
+    "haikunator": "^2.1.2",
     "html5-qrcode": "^2.3.8",
     "i18next": "^22.4.15",
     "i18next-browser-languagedetector": "^7.0.1",

--- a/src/app/screens/connectors/AlbyWallet/index.tsx
+++ b/src/app/screens/connectors/AlbyWallet/index.tsx
@@ -48,7 +48,7 @@ export default function AlbyWallet({ variant }: Props) {
   const [generatedLightningAddress] = useState(
     new Haikunator().haikunate({
       delimiter: "",
-      tokenLength: 3,
+      tokenLength: 2,
     })
   );
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -77,10 +77,11 @@
           }
         },
         "optional_lightning_note": {
-          "part1": "Your Alby Account also comes with an optional",
+          "part1": "Your Alby Account also comes with a",
           "part2": "lightning address",
           "part3": ". This is a simple way for anyone to send you bitcoin on the lightning network.",
-          "part4": "learn more"
+          "part4": "learn more",
+          "footer": "A lightning address has already been generated for you. You can change it at any time from your account dashboard."
         },
         "optional_lightning_address": {
           "label": "Choose your Lightning Address (optional)",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -413,8 +413,7 @@
         "title1": "Account Information",
         "title2": "Edit Account",
         "name": {
-          "title": "Name",
-          "placeholder": "Account Name"
+          "title": "Display Name"
         },
         "export": {
           "title": "Export Account",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,11 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/random-seed@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/random-seed/-/random-seed-0.3.3.tgz#7741f7b0a4513198a9396ce4ad25832f799a6727"
+  integrity sha512-kHsCbIRHNXJo6EN5W8EA5b4i1hdT6jaZke5crBPLUcLqaLdZ0QBq8QVMbafHzhjFF83Cl9qlee2dChD18d/kPg==
+
 "@types/range-parser@*":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
@@ -4913,6 +4918,15 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
+haikunator@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/haikunator/-/haikunator-2.1.2.tgz#4e9c8105c22f05e4e28b54a7f74736e24af95a27"
+  integrity sha512-8xTQw2yomVQWG1mLJKD7RrwXN8PkgRYKDShOBhtlu2MqOTboc4O5dVYhPgLigcKMAtwJ0GZty5N44EbLGZN3FA==
+  dependencies:
+    "@types/random-seed" "^0.3.3"
+    lodash.defaults "^4.2.0"
+    random-seed "^0.3.0"
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz"
@@ -6202,6 +6216,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
 json5@^1.0.1:
   version "1.0.1"
@@ -7952,6 +7971,13 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+random-seed@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/random-seed/-/random-seed-0.3.0.tgz#d945f2e1f38f49e8d58913431b8bf6bb937556cd"
+  integrity sha512-y13xtn3kcTlLub3HKWXxJNeC2qK4mB59evwZ5EkeRlolx+Bp2ztF7LbcZmyCnOqlHQrLnfuNbi1sVmm9lPDlDA==
+  dependencies:
+    json-stringify-safe "^5.0.1"
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
### Describe the changes you have made in this PR

Generate a random lightning address for new Alby accounts, so the user sees it before their account is created. If nothing is entered, it will use the placeholder value.

### Type of change

(Remove other not matching type)

- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]
![image](https://github.com/getAlby/lightning-browser-extension/assets/33993199/80b2903e-f2c5-467e-9593-ee47254b1346)


_Add screenshots to make your changes easier to understand. You can also add a video here._

### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [ ] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
