### PR TITLE
fix: unable to switch account if LNC connection fails

### DIFF
--- a/src/extension/background-script/connectors/lnc.ts
+++ b/src/extension/background-script/connectors/lnc.ts
@@ -166,12 +166,24 @@ class Lnc implements Connector {
 
   async init(): Promise<void> {
     console.info("init LNC");
-    await this.lnc.connect();
+    try {
+      await this.lnc.connect();
+    } catch (error) {
+      console.error("Init LNC failed", error);
+      this.unload();
+    }
   }
 
   async unload() {
-    console.info("LNC disconnect");
-    await this.lnc.disconnect();
+    if (!this.lnc) {
+      return;
+    }
+    try {
+      console.info("LNC disconnect");
+      await this.lnc.disconnect();
+    } catch (error) {
+      console.error("Unload LNC failed", error);
+    }
 
     delete this.lnc;
   }
@@ -198,9 +210,7 @@ class Lnc implements Connector {
   }
 
   getInfo(): Promise<GetInfoResponse> {
-    if (!this.lnc.isConnected) {
-      return Promise.reject(new Error("Account is still loading"));
-    }
+    this.checkConnection();
     return this.lnc.lnd.lightning.GetInfo().then((data: FixMe) => {
       return {
         data: {
@@ -213,9 +223,7 @@ class Lnc implements Connector {
   }
 
   getBalance(): Promise<GetBalanceResponse> {
-    if (!this.lnc.isConnected) {
-      return Promise.reject(new Error("Account is still loading"));
-    }
+    this.checkConnection();
     return this.lnc.lnd.lightning.ChannelBalance().then((data: FixMe) => {
       return {
         data: {
@@ -226,9 +234,7 @@ class Lnc implements Connector {
   }
 
   async getInvoices(): Promise<GetInvoicesResponse> {
-    if (!this.lnc.isConnected) {
-      throw new Error("Account is still loading");
-    }
+    this.checkConnection();
     const data = await this.lnc.lnd.lightning.ListInvoices({ reversed: true });
 
     const invoices: ConnectorInvoice[] = data.invoices
@@ -265,9 +271,7 @@ class Lnc implements Connector {
   }
 
   async checkPayment(args: CheckPaymentArgs): Promise<CheckPaymentResponse> {
-    if (!this.lnc.isConnected) {
-      throw new Error("Account is still loading");
-    }
+    this.checkConnection();
     return this.lnc.lnd.lightning
       .LookupInvoice({ r_hash_str: args.paymentHash })
       .then((data: FixMe) => {
@@ -280,9 +284,7 @@ class Lnc implements Connector {
   }
 
   sendPayment(args: SendPaymentArgs): Promise<SendPaymentResponse> {
-    if (!this.lnc.isConnected) {
-      return Promise.reject(new Error("Account is still loading"));
-    }
+    this.checkConnection();
     return this.lnc.lnd.lightning
       .SendPaymentSync({
         payment_request: args.paymentRequest,
@@ -304,9 +306,7 @@ class Lnc implements Connector {
       });
   }
   async keysend(args: KeysendArgs): Promise<SendPaymentResponse> {
-    if (!this.lnc.isConnected) {
-      throw new Error("Account is still loading");
-    }
+    this.checkConnection();
     //See: https://gist.github.com/dellagustin/c3793308b75b6b0faf134e64db7dc915
     const dest_pubkey_hex = args.pubkey;
     const dest_pubkey_base64 = Hex.parse(dest_pubkey_hex).toString(Base64);
@@ -350,9 +350,7 @@ class Lnc implements Connector {
   }
 
   signMessage(args: SignMessageArgs): Promise<SignMessageResponse> {
-    if (!this.lnc.isConnected) {
-      return Promise.reject(new Error("Account is still loading"));
-    }
+    this.checkConnection();
     return this.lnc.lnd.lightning
       .SignMessage({ msg: Base64.stringify(UTF8.parse(args.message)) })
       .then((data: FixMe) => {
@@ -366,9 +364,7 @@ class Lnc implements Connector {
   }
 
   makeInvoice(args: MakeInvoiceArgs): Promise<MakeInvoiceResponse> {
-    if (!this.lnc.isConnected) {
-      return Promise.reject(new Error("Account is still loading"));
-    }
+    this.checkConnection();
     return this.lnc.lnd.lightning
       .AddInvoice({ memo: args.memo, value: args.amount })
       .then((data: FixMe) => {
@@ -379,6 +375,15 @@ class Lnc implements Connector {
           },
         };
       });
+  }
+
+  private checkConnection() {
+    if (!this.lnc) {
+      throw new Error("Account failed to load");
+    }
+    if (!this.lnc.isConnected) {
+      throw new Error("Account is still loading");
+    }
   }
 }
 

--- a/src/extension/background-script/connectors/lnc.ts
+++ b/src/extension/background-script/connectors/lnc.ts
@@ -170,7 +170,7 @@ class Lnc implements Connector {
       await this.lnc.connect();
     } catch (error) {
       console.error("Init LNC failed", error);
-      this.unload();
+      await this.unload();
     }
   }
 
@@ -181,11 +181,10 @@ class Lnc implements Connector {
     try {
       console.info("LNC disconnect");
       await this.lnc.disconnect();
+      delete this.lnc;
     } catch (error) {
       console.error("Unload LNC failed", error);
     }
-
-    delete this.lnc;
   }
 
   get supportedMethods() {


### PR DESCRIPTION
### Describe the changes you have made in this PR

Allows you to switch accounts even if the LNC connection fails. Note: the connector is in a useless state here which should be fixed in [another PR](https://github.com/getAlby/lightning-browser-extension/issues/2468). 

### Link this PR to an issue [optional]

Fixes _#2426_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]


### How has this been tested?

Manually

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
