### PR TITLE
fix: firefox suggesting unlock passcode on nostr private keys

### DIFF
--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -473,6 +473,7 @@ function AccountDetail() {
                 {/* We use a hidden field to hint Firefox's password manager
                     that this password field is for an account different
                     than the unlock passcode (no username)
+                    See: https://github.com/getAlby/lightning-browser-extension/issues/2489
                 */}
                 <input value={accountName} style={{ display: "none" }} />
                 <TextField

--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -475,7 +475,7 @@ function AccountDetail() {
                     than the unlock passcode (no username)
                     See: https://github.com/getAlby/lightning-browser-extension/issues/2489
                 */}
-                <input value={accountName} style={{ display: "none" }} />
+                <input value={accountName} className="hidden" />
                 <TextField
                   id="nostrPrivateKey"
                   label={t("nostr.private_key.label")}

--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -470,6 +470,11 @@ function AccountDetail() {
               className="mb-4 flex justify-between items-end"
             >
               <div className="w-7/12">
+                {/* We use a hidden field to hint Firefox's password manager
+                    that this password field is for an account different
+                    than the unlock passcode (no username)
+                */}
+                <input value={accountName} style={{ display: "none" }} />
                 <TextField
                   id="nostrPrivateKey"
                   label={t("nostr.private_key.label")}


### PR DESCRIPTION
### Describe the changes you have made in this PR

Hints Firefox password manager that the Nostr private keys are not password for the same (no user) that is the unlock password.

### Link this PR to an issue [optional]

Fixes #2489

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

On Firefox (Linux) I have set up 3 accounts with 3 different nostr private keys, later I opened `about:logins` and searched for "moz". Firefox didn't replace my unlock passcode, the password for the `(no username)` user.

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
- [ ] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
