### PR TITLE
feat: add companion download link in addAccount prompt

### DIFF
--- a/src/app/components/CompanionDownloadInfo.tsx
+++ b/src/app/components/CompanionDownloadInfo.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import getOS from "~/common/utils/os";
 
 type Props = {
   hasTorCallback: (hasTor: boolean) => void;
@@ -10,14 +11,6 @@ function CompanionDownloadInfo({ hasTorCallback }: Props) {
   const { t } = useTranslation("components", {
     keyPrefix: "companion_download_info",
   });
-
-  function getOS() {
-    const userAgent = navigator.userAgent;
-    if (userAgent.indexOf("Win") !== -1) return "Windows";
-    if (userAgent.indexOf("Mac") !== -1) return "MacOS";
-    if (userAgent.indexOf("X11") !== -1) return "UNIX";
-    if (userAgent.indexOf("Linux") !== -1) return "Linux";
-  }
 
   function onChangeConnectionMode(isTor: boolean) {
     setIsTor(isTor);

--- a/src/app/components/Hyperlink/index.tsx
+++ b/src/app/components/Hyperlink/index.tsx
@@ -6,6 +6,7 @@ type Props = {
   onClick?: () => void;
   children: ReactNode;
   className?: string;
+  target?: "_blank" | undefined;
 };
 
 export default function Hyperlink({
@@ -13,6 +14,7 @@ export default function Hyperlink({
   children,
   href,
   className,
+  target,
 }: Props) {
   return (
     <a
@@ -22,6 +24,7 @@ export default function Hyperlink({
       )}
       href={href}
       onClick={onClick}
+      target={target}
     >
       {children}
     </a>

--- a/src/app/screens/ConfirmAddAccount/index.tsx
+++ b/src/app/screens/ConfirmAddAccount/index.tsx
@@ -58,13 +58,15 @@ function ConfirmAddAccount() {
             url={origin.host}
           />
           {/* TODO: Replace with Alert component */}
-          <div className="mt-4 rounded-md font-medium p-4 text-blue-700 bg-blue-50 dark:text-blue-400 dark:bg-blue-900">
+          <div className="mt-4 rounded-md font-medium p-4 text-blue-700 bg-blue-50 dark:text-blue-200 dark:bg-blue-900">
             <p>
               In order to connect through the TOR network you need to first
               install the Alby companion app:
               <br />
               <br />
-              <Hyperlink>⬇️ Download</Hyperlink>
+              <Hyperlink className="text-white hover:text-gray-300">
+                ⬇️ Download
+              </Hyperlink>
             </p>
           </div>
           <ContentMessage

--- a/src/app/screens/ConfirmAddAccount/index.tsx
+++ b/src/app/screens/ConfirmAddAccount/index.tsx
@@ -5,6 +5,7 @@ import PublisherCard from "@components/PublisherCard";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
+import Hyperlink from "~/app/components/Hyperlink";
 import ScreenHeader from "~/app/components/ScreenHeader";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
@@ -56,6 +57,16 @@ function ConfirmAddAccount() {
             image={origin.icon}
             url={origin.host}
           />
+          {/* TODO: Replace with Alert component */}
+          <div className="mt-4 rounded-md font-medium p-4 text-blue-700 bg-blue-50 dark:text-blue-400 dark:bg-blue-900">
+            <p>
+              In order to connect through the TOR network you need to first
+              install the Alby companion app:
+              <br />
+              <br />
+              <Hyperlink>⬇️ Download</Hyperlink>
+            </p>
+          </div>
           <ContentMessage
             heading={t("content", {
               connector: tCommon(

--- a/src/app/screens/ConfirmAddAccount/index.tsx
+++ b/src/app/screens/ConfirmAddAccount/index.tsx
@@ -10,6 +10,7 @@ import ScreenHeader from "~/app/components/ScreenHeader";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
+import getOS from "~/common/utils/os";
 import type { OriginData } from "~/types";
 
 function ConfirmAddAccount() {
@@ -24,6 +25,7 @@ function ConfirmAddAccount() {
   const config = navState.args?.config as unknown;
   const origin = navState.origin as OriginData;
   const [loading, setLoading] = useState(false);
+  const isTor = connector.startsWith("native");
 
   async function confirm() {
     try {
@@ -58,17 +60,21 @@ function ConfirmAddAccount() {
             url={origin.host}
           />
           {/* TODO: Replace with Alert component */}
-          <div className="mt-4 rounded-md font-medium p-4 text-blue-700 bg-blue-50 dark:text-blue-200 dark:bg-blue-900">
-            <p>
-              In order to connect through the TOR network you need to first
-              install the Alby companion app:
-              <br />
-              <br />
-              <Hyperlink className="text-white hover:text-gray-300">
-                ⬇️ Download
-              </Hyperlink>
-            </p>
-          </div>
+          {isTor && (
+            <div className="mt-4 rounded-md font-medium p-4 text-blue-700 bg-blue-50 dark:text-blue-200 dark:bg-blue-900">
+              <p>
+                {t("tor_info")}
+                <br />
+                <br />
+                <Hyperlink
+                  className="text-white hover:text-gray-300"
+                  href={`https://getalby.com/install/companion/${getOS()}`}
+                >
+                  ⬇️ {tCommon("actions.download")}
+                </Hyperlink>
+              </p>
+            </div>
+          )}
           <ContentMessage
             heading={t("content", {
               connector: tCommon(

--- a/src/common/utils/os.ts
+++ b/src/common/utils/os.ts
@@ -1,0 +1,9 @@
+function getOS() {
+  const userAgent = navigator.userAgent;
+  if (userAgent.indexOf("Win") !== -1) return "Windows";
+  if (userAgent.indexOf("Mac") !== -1) return "MacOS";
+  if (userAgent.indexOf("X11") !== -1) return "UNIX";
+  if (userAgent.indexOf("Linux") !== -1) return "Linux";
+}
+
+export default getOS;

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -744,7 +744,8 @@
     },
     "confirm_add_account": {
       "title": "Add account",
-      "content": "This website wants to add an account ({{connector}}):"
+      "content": "This website wants to add an account ({{connector}}):",
+      "tor_info": "In order to connect through the TOR network you need to first install the Alby companion app:"
     },
     "nostr": {
       "title": "Nostr",
@@ -842,7 +843,8 @@
       "copy_invoice": "Copy Invoice",
       "log_in": "Log in",
       "remember": "Remember my choice and don't ask again",
-      "more": "More"
+      "more": "More",
+      "download": "Download"
     },
     "connectors": {
       "lnd": "LND",


### PR DESCRIPTION
### Describe the changes you have made in this PR

![image](https://github.com/getAlby/lightning-browser-extension/assets/100827540/74a5ae16-f366-4484-8203-311c21152944)

Adds an info box to the `addAccount` screen prompting users to install the companion app for TOR connectors. 

Waits on #2338 

TODO:
- [x] Translations
- [x] Check if current connector is TOR
- [x] Conditional download link for different OS