### PR TITLE
feat: show nav on md and improve spacing

### DIFF
--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -12,9 +12,7 @@ export default function Navbar({ children }: Props) {
         <div className="flex">
           <UserMenu />
           {children && (
-            <nav className="ml-5 lg:ml-8 space-x-5 lg:space-x-8 hidden md:flex">
-              {children}
-            </nav>
+            <nav className="ml-8 space-x-8 hidden md:flex">{children}</nav>
           )}
         </div>
         <AccountMenu />

--- a/src/app/components/Navbar/Navbar.tsx
+++ b/src/app/components/Navbar/Navbar.tsx
@@ -12,7 +12,7 @@ export default function Navbar({ children }: Props) {
         <div className="flex">
           <UserMenu />
           {children && (
-            <nav className="ml-5 space-x-4 lg:space-x-8 hidden lg:flex">
+            <nav className="ml-5 lg:ml-8 space-x-5 lg:space-x-8 hidden md:flex">
               {children}
             </nav>
           )}


### PR DESCRIPTION
### Describe the changes you have made in this PR

Visibility on medium sizes was removed by this PR: https://github.com/getAlby/lightning-browser-extension/pull/2289 when the AccountMenu was using more space at the time. Now with the new design (without balance etc.) the nav can be shown again on medium screen sizes.

Also the spacing between the UserMenu and nav seems off.

### Screenshots of the changes [optional]

Md before:
<img width="785" alt="Scherm­afbeelding 2023-06-28 om 12 16 37" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/f002ab5b-0244-475a-81e4-230bd7393dae">

Md after:
<img width="785" alt="Scherm­afbeelding 2023-06-28 om 12 16 51" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/f5f15c64-ce53-4520-a836-28377faee740">

Spacing before (discover too close to hamburger menu):
<img width="1167" alt="Scherm­afbeelding 2023-06-28 om 12 08 19" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/e2a1a183-3590-43f5-801b-b6823e4b7e99">

Spacing after:
<img width="1168" alt="Scherm­afbeelding 2023-06-28 om 12 08 35" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/6406bf68-330c-4df7-b586-449fa6c0227e">
