### PR TITLE
fix: remove shadow from DualCurrencyField

### DIFF
--- a/src/app/components/form/DualCurrencyField/index.tsx
+++ b/src/app/components/form/DualCurrencyField/index.tsx
@@ -34,7 +34,7 @@ export default function DualCurrencyField({
 }: React.InputHTMLAttributes<HTMLInputElement> & Props) {
   const inputEl = useRef<HTMLInputElement>(null);
   const outerStyles =
-    "shadow-sm rounded-md border border-gray-300 dark:border-gray-800 bg-white dark:bg-black transition duration-300";
+    "rounded-md border border-gray-300 dark:border-gray-800 bg-white dark:bg-black transition duration-300";
 
   const inputNode = (
     <input


### PR DESCRIPTION
### Describe the changes you have made in this PR

DualCurrencyField has a drop shadow while all other input fields have no shadow anymore.
This PR removes the inconsistent shadow styling.

### Screenshots of the changes [optional]

Before: (Amount with shadow)
<img width="385" alt="Scherm­afbeelding 2023-06-28 om 12 54 25" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/6ae12d0c-64d4-485f-8c18-13e684795b11">

After:
<img width="387" alt="Scherm­afbeelding 2023-06-28 om 12 54 03" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/85f9e03e-008e-483a-ad28-a619034ee74e">
