### PR TITLE
fix: double slash in url

### DIFF
--- a/src/app/screens/connectors/ConnectUmbrel/index.tsx
+++ b/src/app/screens/connectors/ConnectUmbrel/index.tsx
@@ -31,7 +31,8 @@ export default function ConnectUmbrel() {
       let lndconnect = new URL(lndconnectUrl);
       lndconnect.protocol = "http:";
       lndconnect = new URL(lndconnect.toString());
-      const url = `https://${lndconnect.host}${lndconnect.pathname}`;
+      const pathname = lndconnect.pathname.replace(/\/$/, "");
+      const url = `https://${lndconnect.host}${pathname}`;
       let macaroon = lndconnect.searchParams.get("macaroon") || "";
       macaroon = utils.urlSafeBase64ToHex(macaroon);
       // const cert = lndconnect.searchParams.get("cert"); // TODO: handle LND certs with the native connector


### PR DESCRIPTION
### Describe the changes you have made in this PR

I got an error trying to connect my Umbrel. The error toast currently shows me a URL that contains a double slash: "https://umbrel.local:8080//v1/getinfo". Should be -> https://umbrel.local:8080/v1/getinfo