### PR TITLE
feat: add default keyboard focus style

### DIFF
--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -37,6 +37,10 @@ body {
   font-weight: normal;
 }
 
+:focus-visible {
+  @apply outline outline-2 outline-primary;
+}
+
 .ReactModal__Overlay {
   opacity: 0;
   transition: opacity 200ms ease;


### PR DESCRIPTION
### Describe the changes you have made in this PR

Currently some elements such as buttons have an explicit keyboard focus style with an orange ring.
Other things like links fallback to the default (blue) styling that the browser gives.
I think we should set a default here that matches with the explicit defined styles and overall brand (using the primary color).

### Screenshots of the changes [optional]
Before:
<img width="854" alt="Scherm­afbeelding 2023-06-30 om 10 34 54" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/e69666eb-0e83-4aeb-99ac-b0560bcb1ee7">

After:
<img width="857" alt="Scherm­afbeelding 2023-06-30 om 10 34 07" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/9b0b0f60-53f0-4681-863e-7b788af48b88">

