### PR TITLE
fix: remove fixed height when no image available

### DIFF
--- a/src/app/components/PublisherCard/index.tsx
+++ b/src/app/components/PublisherCard/index.tsx
@@ -32,7 +32,6 @@ export default function PublisherCard({
       className={classNames(
         isSmall ? "p-2" : "flex-col justify-center p-4",
         isCard && "drop-shadow rounded-lg mt-4",
-        !image && "h-16",
         "flex items-center bg-white dark:bg-surface-02dp"
       )}
     >


### PR DESCRIPTION
### Describe the changes you have made in this PR

Currently the Publisher card is only showing a tipping button (and the rest is hidden) when there is no image to display.
This happens because of a fixed height being set when there is no image.
I think this is some legacy code?

### Screenshots of the changes [optional]
While visiting: https://github.com/getAlby/lightning-browser-extension

Before:
<img width="384" alt="Scherm­afbeelding 2023-06-30 om 11 10 40" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/7efe8162-ad18-43e6-9615-87d5428577fa">

After:
<img width="384" alt="Scherm­afbeelding 2023-06-30 om 11 10 06" src="https://github.com/getAlby/lightning-browser-extension/assets/12894112/9af0a09d-1262-41c8-b369-1ee924fd9793">

