### PR TITLE
fix: move primary buttons above fold for smaller screen sizes

### DIFF
--- a/src/app/components/ConnectorForm/index.tsx
+++ b/src/app/components/ConnectorForm/index.tsx
@@ -83,7 +83,7 @@ function ConnectorForm({
         <div>{children}</div>
       </div>
 
-      <div className="mb-4 mt-8 md:my-8 flex flex-col-reverse justify-center gap-4 md:flex-row">
+      <div className="mb-4 mt-8 flex justify-center">
         <Button
           type="submit"
           label={submitLabel}

--- a/src/app/router/Welcome/Welcome.tsx
+++ b/src/app/router/Welcome/Welcome.tsx
@@ -86,27 +86,29 @@ function Layout() {
   });
 
   return (
-    <div>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center font-serif font-medium text-2xl my-10 dark:text-white">
-          <p>
-            {t("welcome.title")}
-            <img
-              src="assets/icons/alby_icon_yellow.svg"
-              alt="Alby"
-              className="dark:hidden inline align-middle w-6 ml-2"
-            />
-            <img
-              src="assets/icons/alby_icon_yellow_dark.svg"
-              alt="Alby"
-              className="hidden dark:inline align-middle w-6 ml-2"
-            />
-          </p>
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="w-full">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center font-serif font-medium text-2xl my-5 dark:text-white">
+            <p>
+              {t("welcome.title")}
+              <img
+                src="assets/icons/alby_icon_yellow.svg"
+                alt="Alby"
+                className="dark:hidden inline align-middle w-6 ml-2"
+              />
+              <img
+                src="assets/icons/alby_icon_yellow_dark.svg"
+                alt="Alby"
+                className="hidden dark:inline align-middle w-6 ml-2"
+              />
+            </p>
+          </div>
         </div>
+        <Container maxWidth="xl">
+          <Outlet />
+        </Container>
       </div>
-      <Container maxWidth="xl">
-        <Outlet />
-      </Container>
     </div>
   );
 }

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -48,10 +48,10 @@ export default function SetPassword() {
             {t("title")}
           </h1>
 
-          <p className="text-gray-500 mt-4 dark:text-gray-400">
+          <p className="text-gray-500 my-5 dark:text-gray-400">
             {t("description")}
           </p>
-          <div className="my-6 w-full flex justify-center">
+          <div className="w-full flex justify-center short:hidden my-5">
             {unlockScreenshot}
           </div>
           <div>

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -36,7 +36,7 @@ export default function SetPassword() {
     <img
       src="assets/images/unlock_passcode.png"
       alt="Unlock screen"
-      className="w-96"
+      className="h-44"
     />
   );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,9 @@ module.exports = {
         xxxs: ".5rem",
         xxs: ".625rem",
       },
+      screens: {
+        short: { raw: "(max-height: 800px)" },
+      },
       spacing: {
         18: "4.5rem",
       },


### PR DESCRIPTION
### Describe the changes you have made in this PR

Optimize height of welcome screens so they fit for smaller screen sizes without moving the main button below the fold:

![image](https://github.com/getAlby/lightning-browser-extension/assets/100827540/7448ed3d-c373-49f5-8e22-bf43841610b4)


For larger screen sizes the elements on the page are centered vertically. 