### PR TITLE
Bug Fix: testconnection showing details of existing account instead of newly added account

### DIFF
--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -41,7 +41,9 @@ interface AccountContextType {
   /**
    * Fetch the additional account info: alias/balance and update account
    */
-  fetchAccountInfo: () => Promise<AccountInfo | undefined>;
+  fetchAccountInfo: (options?: {
+    accountId?: string;
+  }) => Promise<AccountInfo | undefined>;
 }
 
 const AccountContext = createContext({} as AccountContextType);

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -45,7 +45,11 @@ export default function TestConnection() {
     try {
       const { currentAccountId } = await api.getStatus();
       setAccountId(currentAccountId);
-      const accountInfo = await fetchAccountInfo();
+
+      const accountInfo = await fetchAccountInfo({
+        accountId: currentAccountId,
+      });
+
       if (accountInfo) {
         setAccountInfo({
           alias: accountInfo.alias,


### PR DESCRIPTION


### Describe the changes you have made in this PR

fix the test connection screen which loads existing account details instead of showing newly added account details

### Link this PR to an issue [optional]

Fixes #2550
### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)


### Screenshots of the changes [optional]
Before:
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/9be43201-3ff0-4ab0-88e6-5ba731fd7d52)

After
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/4963ca72-2a68-4615-9ae6-70fdd2208896)




### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
