### PR TITLE
fix: add default for locale

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -10,7 +10,7 @@ export const DEFAULT_SETTINGS: SettingsStorage = {
   isUsingLegacyLnurlAuthKey: false,
   userName: "",
   userEmail: "",
-  locale: i18n.resolvedLanguage,
+  locale: i18n.resolvedLanguage ?? "en",
   theme: "system",
   showFiat: true,
   currency: CURRENCIES.USD,


### PR DESCRIPTION
### Describe the changes you have made in this PR

i18next changed `resolvedLanguage` to be optional in a recent upgrade which causes a type error. 