### PR TITLE
fix: remove signMessage from alby connector

### DIFF
--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -57,7 +57,7 @@ export default class Alby implements Connector {
   }
 
   get supportedMethods() {
-    return ["getInfo", "keysend", "makeInvoice", "sendPayment", "signMessage"];
+    return ["getInfo", "keysend", "makeInvoice", "sendPayment"];
   }
 
   // not yet implemented


### PR DESCRIPTION
### Describe the changes you have made in this PR

Removes `signMessage` from list of supported methods for the Alby connector.