### PR TITLE
fix: credential loading for different builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,15 +29,9 @@ jobs:
       - run: yarn install
 
       - name: Build firefox
-        env:
-          ALBY_OAUTH_CLIENT_ID: ${{ vars.ALBY_OAUTH_CLIENT_ID_FIREFOX }}
-          ALBY_OAUTH_CLIENT_SECRET: ${{ vars.ALBY_OAUTH_CLIENT_SECRET_FIREFOX }}
         run: yarn build:firefox
 
       - name: Build chrome
-        env:
-          ALBY_OAUTH_CLIENT_ID: ${{ vars.ALBY_OAUTH_CLIENT_ID_CHROME }}
-          ALBY_OAUTH_CLIENT_SECRET: ${{ vars.ALBY_OAUTH_CLIENT_SECRET_CHROME }}
         run: yarn build:chrome
 
       - name: Archive firefox production zip file

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,16 +80,21 @@ if (clientId && clientSecret) {
   // setup ALBY_OAUTH_CLIENT_ID
   const selectedOAuthCredentials =
     oauthCredentials[process.env.NODE_ENV]?.[network]?.[oauthBrowser];
-  console.error("Using OAuth credentials for", oauthBrowser, network);
   if (!selectedOAuthCredentials) {
     throw new Error("No OAuth credentials found for current configuration");
   }
+  console.info(
+    "Using OAuth credentials for",
+    process.env.NODE_ENV,
+    oauthBrowser,
+    network
+  );
   process.env.ALBY_OAUTH_CLIENT_ID = selectedOAuthCredentials.id;
   process.env.ALBY_OAUTH_CLIENT_SECRET = selectedOAuthCredentials.secret;
 }
 
+// default value is set in the code where it is used
 if (!process.env.ALBY_OAUTH_AUTHORIZE_URL) {
-  // default value is set in the code where it is used
   process.env.ALBY_OAUTH_AUTHORIZE_URL = ""; // env variables are passed as string. empty strings are still falsy
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,10 +22,24 @@ if (!process.env.ALBY_API_URL) {
   network = "testnet";
 }
 
-if (
-  !process.env.ALBY_OAUTH_CLIENT_ID &&
-  !process.env.ALBY_OAUTH_CLIENT_SECRET
-) {
+// release build (check for explicitly set env variables)
+const oauthBrowser =
+  process.env.TARGET_BROWSER === "firefox" ? "firefox" : "chrome";
+const clientId =
+  process.env[`ALBY_OAUTH_CLIENT_ID_${oauthBrowser.toUpperCase()}`];
+const clientSecret =
+  process.env[`ALBY_OAUTH_CLIENT_SECRET_${oauthBrowser.toUpperCase()}`];
+
+if (clientId && clientSecret) {
+  process.env.ALBY_OAUTH_CLIENT_ID = clientId;
+  process.env.ALBY_OAUTH_CLIENT_SECRET = clientSecret;
+
+  console.info(
+    "Using oAuth credentials from environment:",
+    clientId,
+    clientSecret
+  );
+} else {
   const oauthCredentials = {
     development: {
       testnet: {
@@ -63,22 +77,19 @@ if (
     },
   };
 
-  const oauthBrowser =
-    process.env.TARGET_BROWSER === "firefox" ? "firefox" : "chrome";
-
   // setup ALBY_OAUTH_CLIENT_ID
   const selectedOAuthCredentials =
     oauthCredentials[process.env.NODE_ENV]?.[network]?.[oauthBrowser];
+  console.error("Using OAuth credentials for", oauthBrowser, network);
   if (!selectedOAuthCredentials) {
     throw new Error("No OAuth credentials found for current configuration");
   }
-  console.info("Using OAuth credentials for", oauthBrowser, network);
   process.env.ALBY_OAUTH_CLIENT_ID = selectedOAuthCredentials.id;
   process.env.ALBY_OAUTH_CLIENT_SECRET = selectedOAuthCredentials.secret;
 }
 
-// default value is set in the code where it is used
 if (!process.env.ALBY_OAUTH_AUTHORIZE_URL) {
+  // default value is set in the code where it is used
   process.env.ALBY_OAUTH_AUTHORIZE_URL = ""; // env variables are passed as string. empty strings are still falsy
 }
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

 - Remove build variables from GH actions (not needed anymore as they are maintained in our webpack config)
 - Added support for loading oAuth credentials from environment variables (for chrome & firefox simultaneously through running yarn package)