### PR TITLE
fix: move card component

### DIFF
--- a/src/app/screens/Options/TestConnection/card.tsx
+++ b/src/app/screens/Options/TestConnection/card.tsx
@@ -6,7 +6,7 @@ type Props = {
   currency?: string;
 };
 
-export default function Card({
+export default function TestConnectionResultCard({
   alias,
   satoshis,
   fiat,

--- a/src/app/screens/Options/TestConnection/index.tsx
+++ b/src/app/screens/Options/TestConnection/index.tsx
@@ -1,5 +1,4 @@
 import Button from "@components/Button";
-import Card from "@components/Card";
 import Loading from "@components/Loading";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -7,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 import { useSettings } from "~/app/context/SettingsContext";
+import TestConnectionResultCard from "~/app/screens/Options/TestConnection/card";
 import api from "~/common/lib/api";
 import msg from "~/common/lib/msg";
 import type { AccountInfo } from "~/types";
@@ -121,7 +121,7 @@ export default function TestConnection() {
                 <p className="mt-6 dark:text-neutral-400">{t("ready")}</p>
 
                 <div className="mt-6">
-                  <Card
+                  <TestConnectionResultCard
                     color="bg-gray-100"
                     alias={`${accountInfo.name} - ${accountInfo.alias}`}
                     satoshis={


### PR DESCRIPTION
### Describe the changes you have made in this PR

The card component currently is only used for the test connection screen. Moved this component as it's not intended for general use anyway.