### PR TITLE
refactor: use customization of auth url provided by alby-js-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@scure/btc-signer": "^0.5.1",
     "@tailwindcss/forms": "^0.5.4",
     "@vespaiach/axios-fetch-adapter": "^0.3.0",
-    "alby-js-sdk": "^2.1.0",
+    "alby-js-sdk": "^2.1.2",
     "axios": "^0.27.2",
     "bech32": "^2.0.0",
     "bolt11": "^1.4.1",

--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -251,14 +251,9 @@ export default class Alby implements Connector {
 
       let authUrl = authClient.generateAuthURL({
         code_challenge_method: "S256",
+        authorizeUrl: process.env.ALBY_OAUTH_AUTHORIZE_URL,
       });
-      // TODO: make authorize URL in alby-js-sdk customizable
-      if (process.env.ALBY_OAUTH_AUTHORIZE_URL) {
-        authUrl = authUrl.replace(
-          "https://getalby.com/oauth",
-          process.env.ALBY_OAUTH_AUTHORIZE_URL
-        );
-      }
+
       authUrl += "&webln=false"; // stop getalby.com login modal launching lnurl auth
       const authResult = await this.launchWebAuthFlow(authUrl);
       const code = new URL(authResult).searchParams.get("code");


### PR DESCRIPTION

### Describe the changes you have made in this PR
use authorizeURl parameter to customize auth url for different environments in extension. no need to do this explicitly



### Type of change

(Remove other not matching type)


- `feat`: New feature (non-breaking change which adds functionality)


### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
