### PR TITLE
fix: rename account settings heading

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -371,7 +371,7 @@
     "accounts": {
       "title": "Accounts",
       "account_view": {
-        "title1": "Account Information",
+        "title1": "Account Settings",
         "title2": "Account",
         "name": {
           "title": "Display Name",


### PR DESCRIPTION
### Describe the changes you have made in this PR

Rename "account information" to "account settings".