### PR TITLE
fix: show copy lightning address button only for oauth users

### DIFF
--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -57,9 +57,12 @@ function Receive() {
   const [paid, setPaid] = useState(false);
   const [pollingForPayment, setPollingForPayment] = useState(false);
   const mounted = useRef(false);
-  const isAlbyUser =
-    isAlbyOAuthAccount(auth.account?.connectorType) ||
-    isAlbyLNDHubAccount(auth.account?.alias, auth.account?.connectorType);
+  const isAlbyLNDHubUser = isAlbyLNDHubAccount(
+    auth.account?.alias,
+    auth.account?.connectorType
+  );
+  const isAlbyOAuthUser = isAlbyOAuthAccount(auth.account?.connectorType);
+  const isAlbyUser = isAlbyOAuthUser || isAlbyLNDHubUser;
 
   useEffect(() => {
     mounted.current = true;
@@ -316,48 +319,50 @@ function Receive() {
                   }}
                 />
               </div>
-              {isAlbyUser && (
-                <>
-                  <div className="mb-4">
-                    <Button
-                      type="button"
-                      label={copyLightningAddressLabel}
-                      disabled={loadingLightningAddress}
-                      fullWidth
-                      onClick={async () => {
-                        try {
-                          if (!lightningAddress) {
-                            throw new Error(
-                              "User does not have a lightning address"
-                            );
-                          }
-                          navigator.clipboard.writeText(lightningAddress);
-                          setCopyLightningAddressLabel(tCommon("copied"));
-                          setTimeout(() => {
-                            setCopyLightningAddressLabel(
-                              t("actions.copy_lightning_address")
-                            );
-                          }, 1000);
-                        } catch (e) {
-                          if (e instanceof Error) {
-                            toast.error(e.message);
-                          }
+
+              {isAlbyOAuthUser && (
+                <div className="mb-4">
+                  <Button
+                    type="button"
+                    label={copyLightningAddressLabel}
+                    disabled={loadingLightningAddress}
+                    fullWidth
+                    onClick={async () => {
+                      try {
+                        if (!lightningAddress) {
+                          throw new Error(
+                            "User does not have a lightning address"
+                          );
                         }
-                      }}
-                      icon={<CopyIcon className="w-6 h-6 mr-2" />}
-                    />
-                  </div>
-                  <div className="mb-4">
-                    <Button
-                      type="button"
-                      label={t("receive_via_bitcoin_address")}
-                      fullWidth
-                      onClick={() => {
-                        navigate("/onChainReceive");
-                      }}
-                    />
-                  </div>
-                </>
+                        navigator.clipboard.writeText(lightningAddress);
+                        setCopyLightningAddressLabel(tCommon("copied"));
+                        setTimeout(() => {
+                          setCopyLightningAddressLabel(
+                            t("actions.copy_lightning_address")
+                          );
+                        }, 1000);
+                      } catch (e) {
+                        if (e instanceof Error) {
+                          toast.error(e.message);
+                        }
+                      }
+                    }}
+                    icon={<CopyIcon className="w-6 h-6 mr-2" />}
+                  />
+                </div>
+              )}
+
+              {isAlbyUser && (
+                <div className="mb-4">
+                  <Button
+                    type="button"
+                    label={t("receive_via_bitcoin_address")}
+                    fullWidth
+                    onClick={() => {
+                      navigate("/onChainReceive");
+                    }}
+                  />
+                </div>
               )}
             </Container>
           </div>


### PR DESCRIPTION


### Describe the changes you have made in this PR

do not show copy lightning address button for lndhub accounts

### Link this PR to an issue [optional]

Fixes #2618 

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/933da081-565a-42a2-a239-8036cb304b74)


### How has this been tested?

by checking on lndhub account
### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
