### PR TITLE
fix: make wallet page the startpage for the options view

### DIFF
--- a/src/app/router/Options/Options.tsx
+++ b/src/app/router/Options/Options.tsx
@@ -54,7 +54,7 @@ function Options() {
               </RequireAuth>
             }
           >
-            <Route index element={<Navigate to="/publishers" replace />} />
+            <Route index element={<Navigate to="/wallet" replace />} />
             <Route path="discover">
               <Route index element={<Discover />} />
             </Route>


### PR DESCRIPTION
### Describe the changes you have made in this PR

On the options.html page `/` currently redirects you to the websites. 
Since we redirect users to `/` when switching accounts this takes you to the websites page. 

I think it would be better to take users to the wallet page as it's probably the most commonly used one. 