### PR TITLE
fix: remove access-control-allow-origin

### DIFF
--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -35,7 +35,6 @@ export const galoyUrls = {
 
 const defaultHeaders = {
   Accept: "application/json",
-  "Access-Control-Allow-Origin": "*",
   "Content-Type": "application/json",
 };
 

--- a/src/app/screens/connectors/ConnectKollider/index.tsx
+++ b/src/app/screens/connectors/ConnectKollider/index.tsx
@@ -79,7 +79,6 @@ export default function ConnectKollidier({ variant }: Props) {
       if (variant === "create") {
         const headers = new Headers();
         headers.append("Accept", "application/json");
-        headers.append("Access-Control-Allow-Origin", "*");
         headers.append("Content-Type", "application/json");
         headers.append("X-User-Agent", "alby-extension");
         const body = JSON.stringify({

--- a/src/extension/background-script/connectors/galoy.ts
+++ b/src/extension/background-script/connectors/galoy.ts
@@ -340,7 +340,6 @@ class Galoy implements Connector {
       responseType: "json",
       headers: {
         Accept: "application/json",
-        "Access-Control-Allow-Origin": "*",
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.config.accessToken}`,
       },

--- a/src/extension/background-script/connectors/kollider.ts
+++ b/src/extension/background-script/connectors/kollider.ts
@@ -45,7 +45,6 @@ interface KolliderAccount {
 
 const defaultHeaders = {
   Accept: "application/json",
-  "Access-Control-Allow-Origin": "*",
   "Content-Type": "application/json",
 };
 

--- a/src/extension/background-script/connectors/lndhub.ts
+++ b/src/extension/background-script/connectors/lndhub.ts
@@ -39,7 +39,6 @@ const HMAC_VERIFY_HEADER_KEY =
 
 const defaultHeaders = {
   Accept: "application/json",
-  "Access-Control-Allow-Origin": "*",
   "Content-Type": "application/json",
   "X-User-Agent": "alby-extension",
 };

--- a/src/extension/background-script/connectors/nativelndhub.ts
+++ b/src/extension/background-script/connectors/nativelndhub.ts
@@ -45,7 +45,6 @@ export default class NativeLndHub extends NativeConnector {
   async authorize() {
     const headers = {
       Accept: "application/json",
-      "Access-Control-Allow-Origin": "*",
       "Content-Type": "application/json",
     };
     const url = new URL(this.config.url);
@@ -94,7 +93,6 @@ export default class NativeLndHub extends NativeConnector {
 
     const headers = {
       Accept: "application/json",
-      "Access-Control-Allow-Origin": "*",
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.access_token}`,
     };


### PR DESCRIPTION
### Describe the changes you have made in this PR

This header is a response header. Sending it from a client makes no sense. 

> The Access-Control-Allow-Origin header is included in the response from one website to a request originating from another website, and identifies the permitted origin of the request. A web browser compares the Access-Control-Allow-Origin with the requesting website's origin and permits access to the response if they match. 