### PR TITLE
fix: don't render the publisher widget if there is an allowance

### DIFF
--- a/src/app/screens/Home/DefaultView/index.tsx
+++ b/src/app/screens/Home/DefaultView/index.tsx
@@ -28,6 +28,7 @@ dayjs.extend(relativeTime);
 export type Props = {
   lnDataFromCurrentTab?: Battery[];
   currentUrl?: URL | null;
+  renderPublisherWidget?: boolean;
 };
 
 const DefaultView: FC<Props> = (props) => {
@@ -110,7 +111,7 @@ const DefaultView: FC<Props> = (props) => {
 
   return (
     <div className="w-full max-w-screen-sm h-full mx-auto overflow-y-auto no-scrollbar">
-      {!!props.lnDataFromCurrentTab?.length && (
+      {props.renderPublisherWidget && !!props.lnDataFromCurrentTab?.length && (
         <PublisherLnData lnData={props.lnDataFromCurrentTab[0]} />
       )}
       <div className="p-4">

--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect, useCallback } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import browser from "webextension-polyfill";
 import api from "~/common/lib/api";
 import type { Allowance, Battery } from "~/types";
@@ -11,6 +11,7 @@ const Home: FC = () => {
   const [currentUrl, setCurrentUrl] = useState<URL | null>(null);
   const [loadingAllowance, setLoadingAllowance] = useState(true);
   const [lnData, setLnData] = useState<Battery[]>([]);
+  const [renderDefaultView, setRenderDefaultView] = useState(false);
 
   const loadAllowance = useCallback(async () => {
     try {
@@ -84,19 +85,25 @@ const Home: FC = () => {
     return null;
   }
 
-  if (allowance) {
+  if (allowance && !renderDefaultView) {
     return (
       <AllowanceView
         allowance={allowance}
         lnDataFromCurrentTab={lnData}
-        onGoBack={() => setAllowance(null)}
+        onGoBack={() => setRenderDefaultView(true)}
         onEditComplete={loadAllowance}
         onDeleteComplete={() => setAllowance(null)}
       />
     );
   }
 
-  return <DefaultView currentUrl={currentUrl} lnDataFromCurrentTab={lnData} />;
+  return (
+    <DefaultView
+      renderPublisherWidget={!allowance}
+      currentUrl={currentUrl}
+      lnDataFromCurrentTab={lnData}
+    />
+  );
 };
 
 export default Home;


### PR DESCRIPTION
### Describe the changes you have made in this PR

When a user is on a page where there is an allowance, the publisher widget is rendered in two subsequent views: 

![image](https://github.com/getAlby/lightning-browser-extension/assets/100827540/f951c61e-b43a-4d6c-8933-fe2297840d83)
![image](https://github.com/getAlby/lightning-browser-extension/assets/100827540/fe6b91bd-6df1-4862-a05d-3e6ab169c081)

While the publisher widget makes sense on the home screen when there is NO allowance, I think it's duplicate when a user has already used the website before and should be hidden on the wallet page. 