### PR TITLE
fix: remove "only connect with sites you trust"

### DIFF
--- a/src/app/screens/ConfirmPayment/index.tsx
+++ b/src/app/screens/ConfirmPayment/index.tsx
@@ -30,9 +30,6 @@ function ConfirmPayment() {
   const { t } = useTranslation("translation", {
     keyPrefix: "confirm_payment",
   });
-  const { t: tComponents } = useTranslation("components", {
-    keyPrefix: "confirm_or_cancel",
-  });
   const { t: tCommon } = useTranslation("common");
 
   const navState = useNavigationState();
@@ -184,9 +181,6 @@ function ConfirmPayment() {
                 onCancel={reject}
                 label={t("actions.pay_now")}
               />
-              <p className="mb-4 text-center text-sm text-gray-400">
-                <em>{tComponents("only_trusted")}</em>
-              </p>
             </div>
           </Container>
         </form>

--- a/src/app/screens/Enable/index.tsx
+++ b/src/app/screens/Enable/index.tsx
@@ -2,7 +2,7 @@ import { CheckIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import Container from "@components/Container";
 import PublisherCard from "@components/PublisherCard";
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import ScreenHeader from "~/app/components/ScreenHeader";
@@ -86,7 +86,7 @@ function Enable(props: Props) {
             isSmall={false}
           />
 
-          <div className="dark:text-white pt-6 mb-4">
+          <div className="dark:text-white pt-6">
             <p className="mb-2">{t("allow")}</p>
 
             <div className="mb-2 flex items-center">
@@ -99,7 +99,7 @@ function Enable(props: Props) {
             </div>
           </div>
         </div>
-        <div className="mb-4 text-center flex flex-col">
+        <div className="text-center flex flex-col">
           <ConfirmOrCancel
             disabled={loading}
             loading={loading}

--- a/src/app/screens/LNURLAuth/index.tsx
+++ b/src/app/screens/LNURLAuth/index.tsx
@@ -16,9 +16,6 @@ import type { LNURLAuthServiceResponse } from "~/types";
 
 function LNURLAuth() {
   const { t } = useTranslation("translation", { keyPrefix: "lnurlauth" });
-  const { t: tComponents } = useTranslation("components", {
-    keyPrefix: "confirm_or_cancel",
-  });
   const { t: tCommon } = useTranslation("common");
 
   const navigate = useNavigate();
@@ -115,20 +112,13 @@ function LNURLAuth() {
                 <p className="my-2 mx-5 text-red-500">{errorMessage}</p>
               )}
             </div>
-
-            <div>
-              <ConfirmOrCancel
-                label={t("submit")}
-                onConfirm={confirm}
-                onCancel={reject}
-                disabled={loading}
-                loading={loading}
-              />
-
-              <p className="mb-4 text-center text-sm text-gray-400">
-                <em>{tComponents("only_trusted")}</em>
-              </p>
-            </div>
+            <ConfirmOrCancel
+              label={t("submit")}
+              onConfirm={confirm}
+              onCancel={reject}
+              disabled={loading}
+              loading={loading}
+            />
           </Container>
         </>
       ) : (

--- a/src/app/screens/LNURLChannel/index.tsx
+++ b/src/app/screens/LNURLChannel/index.tsx
@@ -19,9 +19,6 @@ import type { LNURLChannelServiceResponse } from "~/types";
 
 function LNURLChannel() {
   const { t } = useTranslation("translation", { keyPrefix: "lnurlchannel" });
-  const { t: tComponents } = useTranslation("components", {
-    keyPrefix: "confirm_or_cancel",
-  });
   const { t: tCommon } = useTranslation("common");
 
   const navigate = useNavigate();
@@ -118,19 +115,12 @@ function LNURLChannel() {
               content={uri}
             />
           </div>
-
-          <div>
-            <ConfirmOrCancel
-              disabled={loadingConfirm || !uri}
-              loading={loadingConfirm}
-              onConfirm={confirm}
-              onCancel={reject}
-            />
-
-            <p className="mb-4 text-center text-sm text-gray-400">
-              <em>{tComponents("only_trusted")}</em>
-            </p>
-          </div>
+          <ConfirmOrCancel
+            disabled={loadingConfirm || !uri}
+            loading={loadingConfirm}
+            onConfirm={confirm}
+            onCancel={reject}
+          />
         </Container>
       ) : (
         <Container justifyBetween maxWidth="sm">

--- a/src/app/screens/MakeInvoice/index.tsx
+++ b/src/app/screens/MakeInvoice/index.tsx
@@ -41,7 +41,6 @@ function MakeInvoice() {
   const [fiatValue, setFiatValue] = useState("");
   const [memo, setMemo] = useState(invoiceAttributes.memo || "");
   const [error, setError] = useState("");
-  const { t: tComponents } = useTranslation("components");
   const { t: tCommon } = useTranslation("common");
   const { t } = useTranslation("translation", {
     keyPrefix: "make_invoice",
@@ -163,18 +162,11 @@ function MakeInvoice() {
               </div>
             </div>
           </div>
-
-          <div>
-            <ConfirmOrCancel
-              disabled={!valueSat || loading || Boolean(error)}
-              loading={loading}
-              onCancel={reject}
-            />
-
-            <p className="mb-4 text-center text-sm text-gray-400">
-              <em>{tComponents("confirm_or_cancel.only_trusted")}</em>
-            </p>
-          </div>
+          <ConfirmOrCancel
+            disabled={!valueSat || loading || Boolean(error)}
+            loading={loading}
+            onCancel={reject}
+          />
         </Container>
       </form>
     </div>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1009,9 +1009,6 @@
         "incoming": "Incoming"
       }
     },
-    "confirm_or_cancel": {
-      "only_trusted": "Only connect with sites you trust."
-    },
     "budget_control": {
       "remember": {
         "label": "Remember and set a budget",


### PR DESCRIPTION
### Describe the changes you have made in this PR

Removes warning from different prompts as you already connected with this site. The only place where this message would make sense is in the enable() screen. 

I found those messages do more harm than good and leave the user puzzled. What does it mean to "trust a website"? 
