### PR TITLE
feat: add context menu to open npubs

### DIFF
--- a/src/extension/background-script/index.ts
+++ b/src/extension/background-script/index.ts
@@ -86,6 +86,13 @@ const handleInstalled = (details: { reason: string }) => {
     console.info("Alby was recently updated");
     isRecentlyUpdated = true;
   }
+
+  browser.contextMenus.create({
+    id: "test",
+    title: "Open on nostr",
+    type: "normal",
+    contexts: ["selection"],
+  });
 };
 
 // listen to calls from the content script and calls the actions through the router
@@ -138,7 +145,15 @@ browser.tabs.onUpdated.addListener(extractLightningData);
 // When we subscribe to that event asynchronously in the init() function it is too late and we miss the event.
 browser.runtime.onInstalled.addListener(handleInstalled);
 
-async function init() {
+browser.contextMenus.onClicked.addListener(function (info) {
+  // TODO check if npub
+  browser.tabs.create({
+    active: true,
+    url: `https://snort.social/${info.selectionText}`,
+  });
+});
+
+async function init(): Promise<void> {
   console.info("Loading background script");
 
   await state.getState().init();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,7 +40,8 @@
     "tabs",
     "unlimitedStorage",
     "*://*/*",
-    "identity"
+    "identity",
+    "contextMenus"
   ],
   "__chrome__permissions": [
     "activeTab",
@@ -49,7 +50,8 @@
     "storage",
     "tabs",
     "unlimitedStorage",
-    "identity"
+    "identity",
+    "contextMenus"
   ],
   "__chrome__host_permissions": ["*://*/*"],
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",


### PR DESCRIPTION
### Describe the changes you have made in this PR

Allows you to open npubs (and possibly other types such as nevent...) directly.

**TODO**
 - [ ] How to configure clients? Just open `web+nostr`? What is the best approach here? 
 - [ ] Should we add some validation on our end? 