### PR TITLE
fix: add explicit enable call for window.liquid

### DIFF
--- a/src/extension/providers/liquid/index.ts
+++ b/src/extension/providers/liquid/index.ts
@@ -13,22 +13,27 @@ export default class LiquidProvider {
     this.enabled = false;
   }
 
-  async enable() {
+  async enable(): Promise<void> {
     if (this.enabled) {
-      return { enabled: true };
+      return;
     }
     const result = await this.execute("enable");
     if (typeof result.enabled === "boolean") {
       this.enabled = result.enabled;
     }
-    return result;
   }
 
   async getAddress() {
+    if (!this.enabled) {
+      throw new Error("Provider must be enabled before calling getAddress");
+    }
     return await this.execute("getAddressOrPrompt");
   }
 
   async signPset(pset: string) {
+    if (!this.enabled) {
+      throw new Error("Provider must be enabled before calling signPset");
+    }
     return this.execute("signPsetWithPrompt", { pset });
   }
 

--- a/src/extension/providers/liquid/index.ts
+++ b/src/extension/providers/liquid/index.ts
@@ -25,12 +25,10 @@ export default class LiquidProvider {
   }
 
   async getAddress() {
-    await this.enable();
     return await this.execute("getAddressOrPrompt");
   }
 
   async signPset(pset: string) {
-    await this.enable();
     return this.execute("signPsetWithPrompt", { pset });
   }
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

Require clients to explicitly call enable() before any other method calls. (this is also how Marina wallet seems to do it right now) 