### PR TITLE
feat: remember permissions by default

### DIFF
--- a/src/app/screens/Bitcoin/ConfirmGetAddress/index.tsx
+++ b/src/app/screens/Bitcoin/ConfirmGetAddress/index.tsx
@@ -20,7 +20,7 @@ function BitcoinConfirmGetAddress() {
   const navState = useNavigationState();
   const origin = navState.origin as OriginData;
   const [loading, setLoading] = useState(false);
-  const [rememberPermission, setRememberPermission] = useState(false);
+  const [rememberPermission, setRememberPermission] = useState(true);
 
   function confirm() {
     setLoading(true);

--- a/src/app/screens/Liquid/ConfirmGetAddress.tsx
+++ b/src/app/screens/Liquid/ConfirmGetAddress.tsx
@@ -20,7 +20,7 @@ function LiquidConfirmGetAddress() {
   const navState = useNavigationState();
   const origin = navState.origin as OriginData;
   const [loading, setLoading] = useState(false);
-  const [rememberPermission, setRememberPermission] = useState(false);
+  const [rememberPermission, setRememberPermission] = useState(true);
 
   function confirm() {
     setLoading(true);

--- a/src/app/screens/Nostr/Confirm.tsx
+++ b/src/app/screens/Nostr/Confirm.tsx
@@ -21,7 +21,7 @@ function NostrConfirm() {
   const description = navState.args?.description;
   const details = navState.args?.details;
   const [loading, setLoading] = useState(false);
-  const [rememberPermission, setRememberPermission] = useState(false);
+  const [rememberPermission, setRememberPermission] = useState(true);
 
   function confirm() {
     setLoading(true);

--- a/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
+++ b/src/app/screens/Nostr/ConfirmGetPublicKey.tsx
@@ -20,7 +20,7 @@ function NostrConfirmGetPublicKey() {
   const navState = useNavigationState();
   const origin = navState.origin as OriginData;
   const [loading, setLoading] = useState(false);
-  const [rememberPermission, setRememberPermission] = useState(false);
+  const [rememberPermission, setRememberPermission] = useState(true);
 
   function confirm() {
     setLoading(true);


### PR DESCRIPTION
### Describe the changes you have made in this PR

Remember permissions by default for less critical operations to minimize popups seen during daily usage: 

 - `webbtc.getAddress()`
 - `liquid.getAddress()`
 - `nostr.getPublicKey()`
 - `nostr.nip04.encrypt()` and `nostr.nip04.decrypt()`