### PR TITLE
fix: support for non-square avatars

### DIFF
--- a/src/app/components/Avatar/index.tsx
+++ b/src/app/components/Avatar/index.tsx
@@ -15,6 +15,10 @@ const Avatar = (props: Props) => {
   }
 };
 
+// NOTE: avatar images are all square since this commit from 26 July 2023:
+//   https://github.com/getAlby/getalby.com/commit/079710187ed4b09c405f23e6b35ec6a82a97759b
+//   Legacy avatars created before this commit can have non-square dimensions and have not
+//   been converted, that's why we need `object-cover` and not `object-fill`.
 const AvatarImage = (props: Props) => {
   return (
     <div
@@ -23,7 +27,10 @@ const AvatarImage = (props: Props) => {
         height: `${props.size}px`,
       }}
     >
-      <img className="rounded-full object-fill w-full h-full" src={props.url} />
+      <img
+        className="rounded-full object-cover w-full h-full"
+        src={props.url}
+      />
     </div>
   );
 };

--- a/src/app/components/Avatar/index.tsx
+++ b/src/app/components/Avatar/index.tsx
@@ -15,10 +15,8 @@ const Avatar = (props: Props) => {
   }
 };
 
-// NOTE: avatar images are all square since this commit from 26 July 2023:
-//   https://github.com/getAlby/getalby.com/commit/079710187ed4b09c405f23e6b35ec6a82a97759b
-//   Legacy avatars created before this commit can have non-square dimensions and have not
-//   been converted, that's why we need `object-cover` and not `object-fill`.
+// Use object-cover to support non-square avatars that might be loaded by
+// different connectors
 const AvatarImage = (props: Props) => {
   return (
     <div


### PR DESCRIPTION
# Scenario
+ I have a legacy, non-square avatar that was uploaded before https://github.com/getAlby/getalby.com/commit/079710187ed4b09c405f23e6b35ec6a82a97759b:
  https://uploads.getalby-assets.com/uploads/lightning_address/avatar/2893/thumb_jan-koegel_yours-truly.jpg

## Notes
+ semi-tested, I only modified the CSS via my web inspector but did not rebuild the extension on my machine.
+ `.object-cover` is documented here: https://tailwindcss.com/docs/object-fit

## Before
<img width="232" alt="image" src="https://github.com/getAlby/lightning-browser-extension/assets/100707419/a830ce65-dd83-46a2-85b1-3e3b6da14658">


## After
<img width="98" alt="image" src="https://github.com/getAlby/lightning-browser-extension/assets/100707419/3aff820d-3bc7-4b96-bd67-6eb0fd6d386e">
