### PR TITLE
fix: remove obsolete activetab permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,6 @@
   "description": "The Bitcoin Lightning wallet for direct payments across the globe, Bitcoin Lightning applications and passwordless logins.",
   "homepage_url": "https://getAlby.com/",
   "permissions": [
-    "activeTab",
     "nativeMessaging",
     "notifications",
     "storage",
@@ -24,7 +23,6 @@
     "identity"
   ],
   "__chrome__permissions": [
-    "activeTab",
     "nativeMessaging",
     "notifications",
     "scripting",


### PR DESCRIPTION
### Describe the changes you have made in this PR

This permission is not needed anymore, since we use host_permissions that allow us to inject / read from any website (not only the active tab). 

`activeTab` would allow temporary access to do those kind of things AFTER the user opened the extension popup on this particular site. 