### PR TITLE
fix: web accessible resources are not set properly for firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -143,5 +143,5 @@
       ]
     }
   ],
-  "firefox__web_accessible_resources": ["js/inpageScript.bundle.js"]
+  "__firefox__web_accessible_resources": ["js/inpageScript.bundle.js"]
 }


### PR DESCRIPTION
### Describe the changes you have made in this PR
set web accessible resources for firefox to avoid warning 

![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/4148b39e-2718-4eff-9969-1bb4ccdc0651)

### Link this PR to an issue [optional]

Fixes _#ISSUE-NUMBER_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)



