### PR TITLE
feat: handle case when user goes to onboard but doesn't setup master key

### DIFF
--- a/src/extension/content-script/liquid.js
+++ b/src/extension/content-script/liquid.js
@@ -16,6 +16,7 @@ const disabledCalls = ["liquid/enable"];
 
 let isEnabled = false; // store if liquid is enabled for this content page
 let isRejected = false; // store if the liquid enable call failed. if so we do not prompt again
+let account;
 
 const SCOPE = "liquid";
 
@@ -68,10 +69,11 @@ async function init() {
       };
 
       // Overrides the enable action so the user can go through onboarding to setup their keys
-
-      const account = await api.getAccount();
-      if (!account.hasMnemonic) {
-        messageWithOrigin.action = `public/liquid/onboard`;
+      if (!account || !account.hasMnemonic) {
+        const account = await api.getAccount();
+        if (!account.hasMnemonic) {
+          messageWithOrigin.action = `public/liquid/onboard`;
+        }
       }
 
       const replyFunction = (response) => {

--- a/src/extension/content-script/liquid.js
+++ b/src/extension/content-script/liquid.js
@@ -16,7 +16,6 @@ const disabledCalls = ["liquid/enable"];
 
 let isEnabled = false; // store if liquid is enabled for this content page
 let isRejected = false; // store if the liquid enable call failed. if so we do not prompt again
-let account = null;
 
 const SCOPE = "liquid";
 
@@ -69,11 +68,10 @@ async function init() {
       };
 
       // Overrides the enable action so the user can go through onboarding to setup their keys
-      if (!account) {
-        account = await api.getAccount();
-        if (!account.hasMnemonic) {
-          messageWithOrigin.action = `public/liquid/onboard`;
-        }
+
+      const account = await api.getAccount();
+      if (!account.hasMnemonic) {
+        messageWithOrigin.action = `public/liquid/onboard`;
       }
 
       const replyFunction = (response) => {

--- a/src/extension/content-script/nostr.js
+++ b/src/extension/content-script/nostr.js
@@ -23,7 +23,6 @@ const disabledCalls = ["nostr/enable"];
 
 let isEnabled = false; // store if nostr is enabled for this content page
 let isRejected = false; // store if the nostr enable call failed. if so we do not prompt again
-let account = null;
 
 async function init() {
   const inject = await shouldInject();
@@ -85,11 +84,10 @@ async function init() {
       };
 
       // Overrides the enable action so the user can go through onboarding to setup their keys
-      if (!account) {
-        account = await api.getAccount();
-        if (!account.nostrEnabled) {
-          messageWithOrigin.action = ev.data.action = `public/nostr/onboard`;
-        }
+
+      const account = await api.getAccount();
+      if (!account.nostrEnabled) {
+        messageWithOrigin.action = ev.data.action = `public/nostr/onboard`;
       }
 
       const replyFunction = (response) => {

--- a/src/extension/content-script/nostr.js
+++ b/src/extension/content-script/nostr.js
@@ -23,6 +23,7 @@ const disabledCalls = ["nostr/enable"];
 
 let isEnabled = false; // store if nostr is enabled for this content page
 let isRejected = false; // store if the nostr enable call failed. if so we do not prompt again
+let account;
 
 async function init() {
   const inject = await shouldInject();
@@ -84,10 +85,11 @@ async function init() {
       };
 
       // Overrides the enable action so the user can go through onboarding to setup their keys
-
-      const account = await api.getAccount();
-      if (!account.nostrEnabled) {
-        messageWithOrigin.action = ev.data.action = `public/nostr/onboard`;
+      if (!account || !account.nostrEnabled) {
+        account = await api.getAccount();
+        if (!account.nostrEnabled) {
+          messageWithOrigin.action = ev.data.action = `public/nostr/onboard`;
+        }
       }
 
       const replyFunction = (response) => {

--- a/src/extension/content-script/webbtc.js
+++ b/src/extension/content-script/webbtc.js
@@ -15,7 +15,6 @@ const disabledCalls = ["webbtc/enable"];
 
 let isEnabled = false; // store if webbtc is enabled for this content page
 let isRejected = false; // store if the webbtc enable call failed. if so we do not prompt again
-let account = null;
 const SCOPE = "webbtc";
 
 async function init() {
@@ -67,11 +66,10 @@ async function init() {
       };
 
       // Overrides the enable action so the user can go through onboarding to setup their keys
-      if (!account) {
-        account = await api.getAccount();
-        if (!account.hasMnemonic) {
-          messageWithOrigin.action = `public/webbtc/onboard`;
-        }
+
+      const account = await api.getAccount();
+      if (!account.hasMnemonic) {
+        messageWithOrigin.action = `public/webbtc/onboard`;
       }
 
       const replyFunction = (response) => {

--- a/src/extension/content-script/webbtc.js
+++ b/src/extension/content-script/webbtc.js
@@ -15,6 +15,7 @@ const disabledCalls = ["webbtc/enable"];
 
 let isEnabled = false; // store if webbtc is enabled for this content page
 let isRejected = false; // store if the webbtc enable call failed. if so we do not prompt again
+let account;
 const SCOPE = "webbtc";
 
 async function init() {
@@ -66,10 +67,11 @@ async function init() {
       };
 
       // Overrides the enable action so the user can go through onboarding to setup their keys
-
-      const account = await api.getAccount();
-      if (!account.hasMnemonic) {
-        messageWithOrigin.action = `public/webbtc/onboard`;
+      if (!account || !account.hasMnemonic) {
+        const account = await api.getAccount();
+        if (!account.hasMnemonic) {
+          messageWithOrigin.action = `public/webbtc/onboard`;
+        }
       }
 
       const replyFunction = (response) => {


### PR DESCRIPTION
### Describe the changes you have made in this PR

user makes a call. starts the onboarding process but doesn't setup the click. now the user makes the call again. in this case route will not be overridden because of account check. also i feel we don't need that


### Type of change

(Remove other not matching type)

- `feat!`: Breaking change (fix or feature that would cause existing functionality to not work as expected)





### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
