### PR TITLE
fix: webln request supported methods check

### DIFF
--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -172,13 +172,6 @@ describe("ln request", () => {
 
   describe("directly calls requestMethod of Connector with method and params", () => {
     test("if permission for this request exists and is enabled", async () => {
-      (utils.openPrompt as jest.Mock).mockResolvedValueOnce({
-        data: { enabled: true, blocked: false },
-      });
-
-      connector = {
-        ...fullConnector,
-      };
       // prepare DB with matching permission
       await db.permissions.bulkAdd([permissionInDB]);
 

--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -45,7 +45,7 @@ const permissionInDB = {
   allowanceId: allowanceInDB.id,
   createdAt: "1487076708000",
   host: allowanceInDB.host,
-  method: "webln/lnd/makeinvoice",
+  method: "webln/lnd/listchannels",
   blocked: false,
   enabled: true,
 };
@@ -54,7 +54,7 @@ const message: MessageGenericRequest = {
   action: "request",
   origin: { host: allowanceInDB.host } as OriginData,
   args: {
-    method: "makeInvoice",
+    method: "listchannels",
     params: {},
   },
 };
@@ -68,9 +68,8 @@ const fullConnector = {
   requestMethod: jest.fn(() => Promise.resolve(requestResponse)),
   supportedMethods: [
     // saved and compared in lowercase
-    "request.getinfo",
-    "request.makeinvoice",
-    "request.sendpayment",
+    "request.listchannels",
+    "request.listpeers",
   ],
 } as unknown as Connector;
 
@@ -91,14 +90,14 @@ describe("ln request", () => {
     test("if connector does not support requestMethod", async () => {
       connector = {
         ...fullConnector,
-        supportedMethods: ["request.getinfo"],
+        supportedMethods: ["request.routermc"],
       };
 
       const result = await request(message);
 
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(result).toStrictEqual({
-        error: "makeinvoice is not supported by your account",
+        error: "listchannels is not supported by your account",
       });
     });
 
@@ -203,7 +202,7 @@ describe("ln request", () => {
         args: {
           requestPermission: {
             method: message.args.method.toLowerCase(),
-            description: "lnd.makeinvoice",
+            description: "lnd.listchannels",
           },
         },
         origin: message.origin,
@@ -230,7 +229,7 @@ describe("ln request", () => {
         args: {
           requestPermission: {
             method: message.args.method.toLowerCase(),
-            description: "lnd.makeinvoice",
+            description: "lnd.listchannels",
           },
         },
         origin: message.origin,
@@ -252,36 +251,36 @@ describe("ln request", () => {
       // prepare DB with a permission
       await db.permissions.bulkAdd([permissionInDB]);
 
-      const messageWithGetInfo = {
+      const listPeersMessage = {
         ...message,
         args: {
           ...message.args,
-          method: "getInfo",
+          method: "listpeers",
         },
       };
 
       expect(await db.permissions.toArray()).toHaveLength(1);
       expect(
-        await db.permissions.get({ method: "webln/lnd/getinfo" })
+        await db.permissions.get({ method: "webln/lnd/listpeers" })
       ).toBeUndefined();
 
-      const result = await request(messageWithGetInfo);
+      const result = await request(listPeersMessage);
 
       expect(utils.openPrompt).toHaveBeenCalledTimes(1);
 
       expect(connector.requestMethod).toHaveBeenCalledWith(
-        messageWithGetInfo.args.method.toLowerCase(),
-        messageWithGetInfo.args.params
+        listPeersMessage.args.method.toLowerCase(),
+        listPeersMessage.args.params
       );
 
       expect(await db.permissions.toArray()).toHaveLength(2);
 
       const addedPermission = await db.permissions.get({
-        method: "webln/lnd/getinfo",
+        method: "webln/lnd/listchannels",
       });
       expect(addedPermission).toEqual(
         expect.objectContaining({
-          method: "webln/lnd/getinfo",
+          method: "webln/lnd/listchannels",
           enabled: true,
           allowanceId: allowanceInDB.id,
           host: allowanceInDB.host,
@@ -303,13 +302,13 @@ describe("ln request", () => {
         ...message,
         args: {
           ...message.args,
-          method: "sendPayment",
+          method: "listpeers",
         },
       };
 
       expect(await db.permissions.toArray()).toHaveLength(1);
       expect(
-        await db.permissions.get({ method: "webln/lnd/sendpayment" })
+        await db.permissions.get({ method: "webln/lnd/listpeers" })
       ).toBeUndefined();
 
       const result = await request(messageWithOtherPermission);
@@ -320,7 +319,7 @@ describe("ln request", () => {
 
       expect(await db.permissions.toArray()).toHaveLength(1);
       expect(
-        await db.permissions.get({ method: "webln/lnd/sendpayment" })
+        await db.permissions.get({ method: "webln/lnd/listpeers" })
       ).toBeUndefined();
 
       expect(result).toHaveProperty("error");
@@ -333,31 +332,31 @@ describe("ln request", () => {
       // prepare DB with a permission
       await db.permissions.bulkAdd([permissionInDB]);
 
-      const messageWithOtherPermission = {
+      const listPeersMessage = {
         ...message,
         args: {
           ...message.args,
-          method: "sendPayment",
+          method: "listpeers",
         },
       };
 
       expect(await db.permissions.toArray()).toHaveLength(1);
       expect(
-        await db.permissions.get({ method: "webln/lnd/sendpayment" })
+        await db.permissions.get({ method: "webln/lnd/listpeers" })
       ).toBeUndefined();
 
-      const result = await request(messageWithOtherPermission);
+      const result = await request(listPeersMessage);
 
       expect(utils.openPrompt).toHaveBeenCalledTimes(1);
 
       expect(connector.requestMethod).toHaveBeenCalledWith(
-        messageWithOtherPermission.args.method.toLowerCase(),
-        messageWithOtherPermission.args.params
+        listPeersMessage.args.method.toLowerCase(),
+        listPeersMessage.args.params
       );
 
       expect(await db.permissions.toArray()).toHaveLength(1);
       expect(
-        await db.permissions.get({ method: "webln/lnd/sendpayment" })
+        await db.permissions.get({ method: "webln/lnd/listpeers" })
       ).toBeUndefined();
 
       expect(result).toStrictEqual(requestResponse);

--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -68,9 +68,9 @@ const fullConnector = {
   requestMethod: jest.fn(() => Promise.resolve(requestResponse)),
   supportedMethods: [
     // saved and compared in lowercase
-    "getinfo",
-    "makeinvoice",
-    "sendpayment",
+    "request.getinfo",
+    "request.makeinvoice",
+    "request.sendpayment",
   ],
 } as unknown as Connector;
 
@@ -91,7 +91,7 @@ describe("ln request", () => {
     test("if connector does not support requestMethod", async () => {
       connector = {
         ...fullConnector,
-        supportedMethods: ["getinfo"],
+        supportedMethods: ["request.getinfo"],
       };
 
       const result = await request(message);
@@ -172,6 +172,13 @@ describe("ln request", () => {
 
   describe("directly calls requestMethod of Connector with method and params", () => {
     test("if permission for this request exists and is enabled", async () => {
+      (utils.openPrompt as jest.Mock).mockResolvedValueOnce({
+        data: { enabled: true, blocked: false },
+      });
+
+      connector = {
+        ...fullConnector,
+      };
       // prepare DB with matching permission
       await db.permissions.bulkAdd([permissionInDB]);
 

--- a/src/extension/background-script/actions/ln/request.ts
+++ b/src/extension/background-script/actions/ln/request.ts
@@ -37,7 +37,7 @@ const request = async (
       !connector.requestMethod ||
       !supportedMethods.includes(requestMethodName)
     ) {
-      throw new Error(`${requestMethodName} is not supported by your account`);
+      throw new Error(`${methodInLowerCase} is not supported by your account`);
     }
 
     const allowance = await db.allowances
@@ -61,7 +61,7 @@ const request = async (
     const hasPermission = await hasPermissionFor(weblnMethod, origin.host);
 
     // request method is allowed to be called
-    if (hasPermission && supportedMethods.includes(methodInLowerCase)) {
+    if (hasPermission) {
       const response = await connector.requestMethod(
         methodInLowerCase,
         args.params

--- a/src/extension/background-script/actions/ln/request.ts
+++ b/src/extension/background-script/actions/ln/request.ts
@@ -25,6 +25,7 @@ const request = async (
     }
 
     const methodInLowerCase = args.method.toLowerCase();
+    const requestMethodName = `request.${methodInLowerCase}`;
 
     // Check if the current connector support the call
     // connectors maybe do not support `requestMethod` at all
@@ -34,9 +35,9 @@ const request = async (
     const supportedMethods = connector.supportedMethods || []; // allow the connector to control which methods can be called
     if (
       !connector.requestMethod ||
-      !supportedMethods.includes(methodInLowerCase)
+      !supportedMethods.includes(requestMethodName)
     ) {
-      throw new Error(`${methodInLowerCase} is not supported by your account`);
+      throw new Error(`${requestMethodName} is not supported by your account`);
     }
 
     const allowance = await db.allowances


### PR DESCRIPTION
### Describe the changes you have made in this PR

webln.request always fails because provided method does not match supported methods (prefixed with `request.`)

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Manually, with webln sandbox (also needs a fix there)

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [ ] Darkmode
- [ ] Responsive layout
