### PR TITLE
fix: show nsec format in nostr settings page

### DIFF
--- a/src/app/screens/Accounts/NostrSettings/index.tsx
+++ b/src/app/screens/Accounts/NostrSettings/index.tsx
@@ -21,7 +21,6 @@ function NostrSettings() {
   const navigate = useNavigate();
   const [hasMnemonic, setHasMnemonic] = useState(false);
   const [currentPrivateKey, setCurrentPrivateKey] = useState("");
-  const [currentNsec, setCurrentNsec] = useState("");
   const [nostrPrivateKey, setNostrPrivateKey] = useState("");
   const [nostrPrivateKeyVisible, setNostrPrivateKeyVisible] = useState(false);
   const [nostrPublicKey, setNostrPublicKey] = useState("");
@@ -35,7 +34,6 @@ function NostrSettings() {
       if (priv) {
         setCurrentPrivateKey(priv);
         const nsec = nostr.hexToNip19(priv);
-        setCurrentNsec(nsec);
         setNostrPrivateKey(nsec);
       }
       const accountResponse = await api.getAccount(id);
@@ -88,15 +86,8 @@ function NostrSettings() {
     setNostrPrivateKey(nostr.hexToNip19(derivedNostrPrivateKey));
   }
 
-  const keyUnchanged =
-    nostrPrivateKey === currentPrivateKey || nostrPrivateKey === currentNsec;
-
   // TODO: simplify this method - would be good to have a dedicated "remove nostr key" button
   async function handleSaveNostrPrivateKey() {
-    if (keyUnchanged) {
-      throw new Error("private key hasn't changed");
-    }
-
     if (
       currentPrivateKey &&
       prompt(
@@ -171,7 +162,7 @@ function NostrSettings() {
               </Alert>
             )}
 
-            {hasMnemonic && currentPrivateKey && keyUnchanged ? (
+            {hasMnemonic && currentPrivateKey ? (
               hasImportedNostrKey ? (
                 <Alert type="warn">
                   {t("nostr.settings.imported_key_warning")}
@@ -220,7 +211,7 @@ function NostrSettings() {
                     onClick={handleDeleteKeys}
                   />
                 )}
-                {hasImportedNostrKey && keyUnchanged && hasMnemonic && (
+                {hasImportedNostrKey && hasMnemonic && (
                   <Button
                     outline
                     label={t("nostr.settings.derive")}
@@ -232,12 +223,7 @@ function NostrSettings() {
           </ContentBox>
           <div className="flex justify-center my-6 gap-4">
             <Button label={tCommon("actions.cancel")} onClick={onCancel} />
-            <Button
-              type="submit"
-              label={tCommon("actions.save")}
-              disabled={keyUnchanged}
-              primary
-            />
+            <Button type="submit" label={tCommon("actions.save")} primary />
           </div>
         </Container>
       </form>


### PR DESCRIPTION
### Describe the changes you have made in this PR

show nsec format instead of hex for private key in nostr settings page

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

![image](https://github.com/getAlby/lightning-browser-extension/assets/33993199/50200fc0-93f9-4186-8be8-92fd39b07459)

### How has this been tested?

Manually
### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
