### PR TITLE
feat: send message to all the valid tabs which has receiving end

### DIFF
--- a/src/extension/background-script/actions/accounts/select.ts
+++ b/src/extension/background-script/actions/accounts/select.ts
@@ -47,20 +47,20 @@ export default select;
 // Send a notification message to the content script
 // which will then be posted to the window so websites can sync with the switched account
 async function notifyAccountChanged() {
-  try {
-    const tabs = await browser.tabs.query({});
-    // Send message to tabs with URLs starting with "http" or "https"
-    const validTabs = tabs.filter((tab) => {
-      const currentUrl = tab.url || "";
-      return currentUrl.startsWith("http") || currentUrl.startsWith("https");
-    });
+  const tabs = await browser.tabs.query({});
+  // Send message to tabs with URLs starting with "http" or "https"
+  const validTabs = tabs.filter((tab) => {
+    const currentUrl = tab.url || "";
+    return currentUrl.startsWith("http") || currentUrl.startsWith("https");
+  });
 
-    for (const tab of validTabs) {
+  for (const tab of validTabs) {
+    try {
       if (tab.id) {
         await browser.tabs.sendMessage(tab.id, { action: "accountChanged" });
       }
+    } catch (error) {
+      console.error("Failed to notify account changed", error);
     }
-  } catch (error) {
-    console.error("Failed to notify account changed", error);
   }
 }

--- a/src/extension/background-script/actions/accounts/select.ts
+++ b/src/extension/background-script/actions/accounts/select.ts
@@ -49,18 +49,20 @@ export default select;
 async function notifyAccountChanged() {
   const tabs = await browser.tabs.query({});
   // Send message to tabs with URLs starting with "http" or "https"
-  const validTabs = tabs.filter((tab) => {
-    const currentUrl = tab.url || "";
-    return currentUrl.startsWith("http") || currentUrl.startsWith("https");
-  });
+  if (tabs) {
+    const validTabs = tabs.filter((tab) => {
+      const currentUrl = tab.url || "";
+      return currentUrl.startsWith("http") || currentUrl.startsWith("https");
+    });
 
-  for (const tab of validTabs) {
-    try {
-      if (tab.id) {
-        await browser.tabs.sendMessage(tab.id, { action: "accountChanged" });
+    for (const tab of validTabs) {
+      try {
+        if (tab.id) {
+          await browser.tabs.sendMessage(tab.id, { action: "accountChanged" });
+        }
+      } catch (error) {
+        console.error("Failed to notify account changed", error);
       }
-    } catch (error) {
-      console.error("Failed to notify account changed", error);
     }
   }
 }


### PR DESCRIPTION
### Describe the changes you have made in this PR

we query active tabs and iterate over them. if we have the tab that doesn't have the content script for such tab when we do postMessage. the error, receiving end does not exist will be thrown and we will get out of the function. this can lead to not notifying to active tabs

for eg. [tab not having content script, tab having content script]

tab having a content script is in the second place of the array. when we iterate and post message. we will get error for tab present in first position. and hence no notification logic will be executed  for tab which is on second position of the array.

solution would be. handle errors inside for loop instead of top level function


![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/81fc99f9-8352-4f83-9743-586b085eaa73)


### Link this PR to an issue [optional]

Fixes _#ISSUE-NUMBER_

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)




### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
