### PR TITLE
chore: prompt for oauth credentials during build

### DIFF
--- a/create-packages.sh
+++ b/create-packages.sh
@@ -3,6 +3,38 @@
 # Extract version from package.json
 VERSION=$(node -pe "require('./package.json').version")
 
+if [ -z ${ALBY_OAUTH_CLIENT_ID_CHROME+x} ];
+then
+    echo "OAuth client id for Chrome:"
+    read ALBY_OAUTH_CLIENT_ID_CHROME
+fi
+
+if [ -z ${ALBY_OAUTH_CLIENT_SECRET_CHROME+x} ];
+then
+    echo "OAuth client secret for Chrome:"
+    read ALBY_OAUTH_CLIENT_SECRET_CHROME
+fi
+
+if [ -z ${ALBY_OAUTH_CLIENT_ID_FIREFOX+x} ];
+then
+    echo "OAuth client id for Firefox:"
+    read ALBY_OAUTH_CLIENT_ID_FIREFOX
+fi
+
+if [ -z ${ALBY_OAUTH_CLIENT_SECRET_FIREFOX+x} ];
+then
+    echo "OAuth client secret for Firefox:"
+    read ALBY_OAUTH_CLIENT_SECRET_FIREFOX
+fi
+
+if [ -z ${ALBY_API_URL+x} ];
+then
+    ALBY_API_URL="https://api.getalby.com"
+fi
+
+echo "Creating the build for v$VERSION"
+yarn build
+
 echo "Creating zip packages for v$VERSION"
 cd dist/production
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:firefox": "NODE_ENV=production TARGET_BROWSER=firefox webpack",
     "build:opera": "NODE_ENV=production TARGET_BROWSER=opera webpack",
     "build": "yarn build:chrome && yarn build:firefox && yarn build:opera",
-    "package": "yarn build && ./create-packages.sh",
+    "package": "./create-packages.sh",
     "lint": "yarn lint:js && yarn tsc:compile && yarn format:fix",
     "lint:js": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 0",
     "lint:js:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix",


### PR DESCRIPTION
This prompts the user for the OAuth credentials if they are not provided during the yarn package script

This makes it easier for new users and makes sure that OAuth credentials are provided.
