### PR TITLE
fix: made the QR code scannable for even shorter lightning addresses

### DIFF
--- a/src/app/components/QRCode/index.tsx
+++ b/src/app/components/QRCode/index.tsx
@@ -19,7 +19,7 @@ export default function QRCode({ value, size, className }: Props) {
       className={classNames("rounded-md", className ?? "")}
       fgColor={fgColor}
       bgColor={bgColor}
-      level="M"
+      level="Q"
     />
   );
 }


### PR DESCRIPTION
### Describe the changes you have made in this PR

The QR code in the receive screen is not scannable when the lightning address name is <=3 characters. The issue might be due to the addition of avatar on the QR code. Few changes to fix this issue might be - increase the QR size, decrease the avatar size, Increase the error correction.
I increased the EC level as this seemed to be the best approach for it.

### Link this PR to an issue

Fixes #2774 

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

These are few lightning addresses which can be used to test whether the QR is working after this change(hardcoded).
<p float="left">
  <img src="https://github.com/getAlby/lightning-browser-extension/assets/99183441/77725a47-fb09-410e-b12d-f5cd9d32db72" width="320" />
  <img src="https://github.com/getAlby/lightning-browser-extension/assets/99183441/b9c7c1c0-6677-4fa3-a5ff-3a13940d0a07" width="320" /> 
</p>

### How has this been tested?

Hardcoded the lightning address and checked whether it is working for lightning addresses with less than three characters.

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
