### PR TITLE
fix: add validation to the account name input field 

### DIFF
--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -201,6 +201,7 @@ function AccountDetail() {
                   onChange={(event) => {
                     setAccountName(event.target.value);
                   }}
+                  required
                 />
               </div>
               <div className="w-1/5 flex-none mx-4 d-none"></div>


### PR DESCRIPTION
### Describe the changes you have made in this PR

Added the validation for not allowing empty account names using the required attribute.

### Link this PR to an issue [optional]

Fixes #2528 

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

![chrome_SxHzEGIXUw](https://github.com/getAlby/lightning-browser-extension/assets/99183441/f6742db3-6785-4ab2-b19d-66a7ffabae18)

### How has this been tested?

tested manually by trying to save empty account name.

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
