### PR TITLE
fix: receive another payment button styles

### DIFF
--- a/src/app/screens/ReceiveInvoice/index.tsx
+++ b/src/app/screens/ReceiveInvoice/index.tsx
@@ -228,7 +228,9 @@ function ReceiveInvoice() {
         {t("title")}
       </Header>
       {invoice ? (
-        <Container maxWidth="sm">{renderInvoice()}</Container>
+        <Container justifyBetween maxWidth="sm">
+          {renderInvoice()}
+        </Container>
       ) : (
         <div className="pt-4 h-full">
           <form onSubmit={handleSubmit} className="h-full">


### PR DESCRIPTION
### Describe the changes you have made in this PR

Fix style issues #2816 - add justify-between for "receive another payment" button in "receive" screen.

### Link this PR to an issue [optional]

Fixes #2816

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

<img width="392" alt="Bildschirmfoto 2023-10-14 um 09 53 14" src="https://github.com/getAlby/lightning-browser-extension/assets/886152/066daa03-513d-42c5-9e26-a1a60af9a9c2">

### How has this been tested?

Manually

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [x] Darkmode
- [x] Responsive layout
