### PR TITLE
feat: Disable 'Create Invoice' button until an amount is entered

### DIFF
--- a/src/app/screens/ReceiveInvoice/index.tsx
+++ b/src/app/screens/ReceiveInvoice/index.tsx
@@ -264,7 +264,11 @@ function ReceiveInvoice() {
                   fullWidth
                   primary
                   loading={loadingInvoice}
-                  disabled={loadingInvoice}
+                  disabled={
+                    loadingInvoice ||
+                    !formData.amount ||
+                    formData.amount === "0"
+                  }
                 />
               </Container>
             </fieldset>


### PR DESCRIPTION
### Describe the changes you have made in this PR
The button is now disabled until the user enters a value in the 'Amount' field. This ensures that the user cannot create an invoice without specifying the amount first.

This change helps to prevent invalid or incomplete invoice creation.
### Link this PR to an issue [optional]

Fixes #2802

### Type of change
- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]
Current  - ( Button is active by default ) 

https://github.com/getAlby/lightning-browser-extension/assets/100958893/68f2fb21-60bb-445d-b43e-9a55d30e1873



After PR -( Button is disabled by default and enabled when user enters a value ) 

https://github.com/getAlby/lightning-browser-extension/assets/100958893/45cf92a0-1a5a-47e7-803d-c68c724a5bef



### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [x] Darkmode
- [x] Responsive layout
