### PR TITLE
fix: caching getInfo calls

### DIFF
--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -117,11 +117,12 @@ export default class Alby implements Connector {
   async getInfo(): Promise<
     GetInfoResponse<WebLNNode & GetAccountInformationResponse>
   > {
-    const cacheValue = this._cache.get("getInfo");
-    if (cacheValue) {
-      return cacheValue as GetInfoResponse<
-        WebLNNode & GetAccountInformationResponse
-      >;
+    const cacheKey = "getInfo";
+    const cacheValue = this._cache.get(cacheKey) as GetInfoResponse<
+      WebLNNode & GetAccountInformationResponse
+    >;
+    if (cacheValue !== null) {
+      return cacheValue;
     }
 
     try {
@@ -134,7 +135,7 @@ export default class Alby implements Connector {
           alias: "🐝 getalby.com",
         },
       };
-      this._cache.set("getInfo", returnValue);
+      this._cache.set(cacheKey, returnValue);
 
       return returnValue;
     } catch (error) {

--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -42,6 +42,7 @@ export default class Alby implements Connector {
   private config: Config;
   private _client: Client | undefined;
   private _authUser: auth.OAuth2User | undefined;
+  private _cache = new Map<string, object>();
 
   constructor(account: Account, config: Config) {
     this.account = account;
@@ -116,16 +117,26 @@ export default class Alby implements Connector {
   async getInfo(): Promise<
     GetInfoResponse<WebLNNode & GetAccountInformationResponse>
   > {
+    const cacheValue = this._cache.get("getInfo");
+    if (cacheValue) {
+      return cacheValue as GetInfoResponse<
+        WebLNNode & GetAccountInformationResponse
+      >;
+    }
+
     try {
       const info = await this._request((client) =>
         client.accountInformation({})
       );
-      return {
+      const returnValue = {
         data: {
           ...info,
           alias: "🐝 getalby.com",
         },
       };
+      this._cache.set("getInfo", returnValue);
+
+      return returnValue;
     } catch (error) {
       console.error(error);
       throw error;

--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -121,7 +121,7 @@ export default class Alby implements Connector {
     const cacheValue = this._cache.get(cacheKey) as GetInfoResponse<
       WebLNNode & GetAccountInformationResponse
     >;
-    if (cacheValue !== null) {
+    if (cacheValue) {
       return cacheValue;
     }
 


### PR DESCRIPTION
### Describe the changes you have made in this PR

Cache `getInfo()` calls on connector level for the lifetime of the connector. (changing accounts will reload the info as every time a new instance is created)