### PR TITLE
feat: handle auth flow natively

### DIFF
--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -339,7 +339,7 @@ export default class Alby implements Connector {
       return null;
     }
     const urlSearchParams = new URLSearchParams(url.split("?")[1]);
-    return urlSearchParams.get("code") || null;
+    return urlSearchParams.get("code");
   }
 
   private async _request<T>(func: (client: Client) => T) {

--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -282,8 +282,6 @@ export default class Alby implements Connector {
         authorizeUrl: process.env.ALBY_OAUTH_AUTHORIZE_URL,
       });
 
-      console.log(authUrl);
-
       authUrl += "&webln=false"; // stop getalby.com login modal launching lnurl auth
 
       // Use the tabs API to create a new tab with the authorization URL
@@ -296,17 +294,8 @@ export default class Alby implements Connector {
           changeInfo: browser.Tabs.OnUpdatedChangeInfoType,
           tab: browser.Tabs.Tab
         ) => {
-          console.log(changeInfo.status);
           if (changeInfo.status === "complete" && tabId === createTab.id) {
-            // The tab has finished loading, you can check the tab URL for the authorization code
-            // Extract the code from the URL and proceed with token exchange
-
-            // Note: You might need to handle errors and corner cases depending on the authorization flow.
             const authorizationCode = this.extractCodeFromTabUrl(tab.url);
-
-            console.log(changeInfo);
-
-            console.log(authorizationCode);
 
             if (authorizationCode) {
               authClient
@@ -320,6 +309,7 @@ export default class Alby implements Connector {
                   reject(error);
                 })
                 .finally(() => {
+                  browser.tabs.remove(tabId);
                   // Remove the event listener once the code is received
                   browser.tabs.onUpdated.removeListener(handleUpdated);
                 });

--- a/src/extension/background-script/connectors/alby.ts
+++ b/src/extension/background-script/connectors/alby.ts
@@ -237,8 +237,7 @@ export default class Alby implements Connector {
         throw new Error("OAuth client credentials missing");
       }
 
-      const redirectURL =
-        "https://9dfeeffab3456fdb4be6e2296ca1a4c6b124ee94.extensions.allizom.org/";
+      const redirectURL = "https://getalby.com/extension/connect";
 
       const authClient = new auth.OAuth2User({
         request_options: this._getRequestOptions(),

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,6 @@
   "description": "Your Bitcoin Lightning wallet and companion for accessing Bitcoin and Nostr apps, payments across the globe and passwordless logins.",
   "homepage_url": "https://getAlby.com/",
   "permissions": [
-    "nativeMessaging",
     "notifications",
     "storage",
     "tabs",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,6 +14,7 @@
   "description": "Your Bitcoin Lightning wallet and companion for accessing Bitcoin and Nostr apps, payments across the globe and passwordless logins.",
   "homepage_url": "https://getAlby.com/",
   "permissions": [
+    "nativeMessaging",
     "notifications",
     "storage",
     "tabs",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,36 +51,24 @@ if (clientId && clientSecret) {
   );
 } else {
   const oauthCredentials = {
-    development: {
-      testnet: {
-        id: "TliTCTtJ49",
-        secret: "35RixI2gv0xloVYA0Iq3",
-      },
-      mainnet: {
-        id: "NT8bFB23Sk",
-        secret: "wWp7BPpYOm1H0GwSVVpY",
-      },
+    testnet: {
+      id: "TliTCTtJ49",
+      secret: "35RixI2gv0xloVYA0Iq3",
     },
-    production: {
-      testnet: {
-        id: "TliTCTtJ49",
-        secret: "35RixI2gv0xloVYA0Iq3",
-      },
-      mainnet: {
-        id: "NT8bFB23Sk",
-        secret: "wWp7BPpYOm1H0GwSVVpY",
-      },
+    mainnet: {
+      id: "NT8bFB23Sk",
+      secret: "wWp7BPpYOm1H0GwSVVpY",
     },
   };
 
   // setup ALBY_OAUTH_CLIENT_ID
-  const selectedOAuthCredentials = oauthCredentials[nodeEnv]?.[network];
+  const selectedOAuthCredentials = oauthCredentials[network];
   if (!selectedOAuthCredentials) {
     throw new Error(
-      `No OAuth credentials found for current configuration: NODE_ENV=${nodeEnv} network=${network} oauthBrowser=${oauthBrowser}`
+      `No OAuth credentials found for current configuration: network=${network}`
     );
   }
-  console.info("Using OAuth credentials for", nodeEnv, oauthBrowser, network);
+  console.info("Using OAuth credentials for", network);
   process.env.ALBY_OAUTH_CLIENT_ID = selectedOAuthCredentials.id;
   process.env.ALBY_OAUTH_CLIENT_SECRET = selectedOAuthCredentials.secret;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,50 +53,28 @@ if (clientId && clientSecret) {
   const oauthCredentials = {
     development: {
       testnet: {
-        chrome: {
-          id: "CLAp8AfS3W",
-          secret: "KwIxF0VbGX2ZHLbbbYgE",
-        },
-        firefox: {
-          id: "zWdxnF04Hd",
-          secret: "wY5uLJJDjNWrDlB6lAj8",
-        },
+        id: "TliTCTtJ49",
+        secret: "35RixI2gv0xloVYA0Iq3",
       },
       mainnet: {
-        chrome: {
-          id: "Zf7u3Zlyxl",
-          secret: "7wtcdVi61emqwzAH9Nm6",
-        },
-        firefox: {
-          id: "uQkyHFBkaC",
-          secret: "0agh0cKkGWQSXTGRz9oy",
-        },
+        id: "NT8bFB23Sk",
+        secret: "wWp7BPpYOm1H0GwSVVpY",
       },
     },
     production: {
       testnet: {
-        // only chrome is used for E2E tests
-        chrome: {
-          id: "mI5TEUKCwD",
-          secret: "47lxj2WNCJyVpxiy6vgq",
-        },
+        id: "TliTCTtJ49",
+        secret: "35RixI2gv0xloVYA0Iq3",
       },
       mainnet: {
-        chrome: {
-          id: "R7lZBSqfQt",
-          secret: "W4yWprd5ib6OSfq27InN",
-        },
-        firefox: {
-          id: "V682entasX",
-          secret: "GhL3g37I3NAwzavCB3A5",
-        },
+        id: "NT8bFB23Sk",
+        secret: "wWp7BPpYOm1H0GwSVVpY",
       },
     },
   };
 
   // setup ALBY_OAUTH_CLIENT_ID
-  const selectedOAuthCredentials =
-    oauthCredentials[nodeEnv]?.[network]?.[oauthBrowser];
+  const selectedOAuthCredentials = oauthCredentials[nodeEnv]?.[network];
   if (!selectedOAuthCredentials) {
     throw new Error(
       `No OAuth credentials found for current configuration: NODE_ENV=${nodeEnv} network=${network} oauthBrowser=${oauthBrowser}`


### PR DESCRIPTION
### Describe the changes you have made in this PR

one way we can eliminate identity api is to use completely native browser api so that we can support all the browsers including firefox for android

doesn't require any hacks or content script. just using tabs api and event listeners which works on all the browsers including android