### PR TITLE
fix: add y overflow to the modal

### DIFF
--- a/src/app/components/Modal/index.tsx
+++ b/src/app/components/Modal/index.tsx
@@ -25,7 +25,7 @@ export default function Modal({
       onRequestClose={closeModal}
       contentLabel={contentLabel}
       overlayClassName="bg-black bg-opacity-50 fixed inset-0 flex justify-center items-center cursor-pointer"
-      className="rounded-lg shadow-xl bg-white dark:bg-surface-02dp w-full max-w-md overflow-hidden relative p-5 cursor-auto mx-5"
+      className="rounded-lg shadow-xl bg-white dark:bg-surface-02dp w-full max-w-md overflow-x-hidden relative p-5 cursor-auto mx-5"
       style={{ content: { maxHeight: "90vh" } }}
     >
       {title && (

--- a/src/app/components/TransactionsTable/TransactionModal.tsx
+++ b/src/app/components/TransactionsTable/TransactionModal.tsx
@@ -178,7 +178,7 @@ export default function TransactionModal({
 }
 
 const Dt = ({ children }: { children: React.ReactNode }) => (
-  <dt className="w-28 text-gray-400 dark:text-neutral-500 text-right">
+  <dt className="w-24 text-gray-400 dark:text-neutral-500 text-right">
     {children}
   </dt>
 );


### PR DESCRIPTION
### Describe the changes you have made in this PR

Long transaction descriptions (such as in satograms) did make the modal unusable due to the overflow-hidden in the modal. 

Also made the first column in the TransactionDetailRow a bit smaller so the descriptions have more space. 