### PR TITLE
fix: broken url to documentation in error toast

### DIFF
--- a/src/app/components/toasts/ConnectionErrorToast.tsx
+++ b/src/app/components/toasts/ConnectionErrorToast.tsx
@@ -37,7 +37,7 @@ export default function ConnectionErrorToast({
         )}
         <li>
           <a
-            href="https://guides.getalby.com/overall-guide/alby-browser-extension/connect-lightning-wallets-and-nodes-to-alby-extension"
+            href="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-browser-extension/connect-lightning-wallets-and-nodes-to-the-alby-extension"
             className="underline"
             target="_blank"
             rel="noreferrer noopener"


### PR DESCRIPTION
### Describe the changes you have made in this PR

Fixing broken url in the error toast for new account creation 

Broken url:
https://guides.getalby.com/user-guide/alby-browser-extension/connect-lightning-wallets-and-nodes-to-alby-extension
New url:
https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-browser-extension/connect-lightning-wallets-and-nodes-to-the-alby-extension


### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

![image](https://github.com/getAlby/lightning-browser-extension/assets/4439523/48216157-c641-4b94-aff8-4163f6510eed)

### How has this been tested?

No extensive testing done - its just an url change

### Checklist

- [ ] Self-review of changed code
- [x ] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [ ] Darkmode
- [ ] Responsive layout
