### PR TITLE
fix: don't allow to bypass unlock screen and access welcome screen

### DIFF
--- a/src/app/context/AccountContext.tsx
+++ b/src/app/context/AccountContext.tsx
@@ -143,10 +143,9 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
         if (!response.configured && !onWelcomePage) {
           utils.openPage("welcome.html");
           window.close();
+        } else if (response.configured && onWelcomePage) {
+          utils.redirectPage("options.html");
         } else if (response.unlocked) {
-          if (response.configured && onWelcomePage) {
-            utils.redirectPage("options.html");
-          }
           selectAccount(response.currentAccountId, true);
         } else {
           setAccount(null);

--- a/src/app/router/Welcome/Welcome.tsx
+++ b/src/app/router/Welcome/Welcome.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { Outlet, Route, HashRouter as Router, Routes } from "react-router-dom";
 import Container from "~/app/components/Container";
 import Toaster from "~/app/components/Toast/Toaster";
+import { AccountProvider } from "~/app/context/AccountContext";
 import { SettingsProvider } from "~/app/context/SettingsContext";
 import { getConnectorRoutes, renderRoutes } from "~/app/router/connectorRoutes";
 import ChooseConnectorPath from "~/app/screens/connectors/ChooseConnectorPath";
@@ -17,34 +18,36 @@ const connectorRoutes = getConnectorRoutes();
 function Welcome() {
   return (
     <SettingsProvider>
-      <Router>
-        <Toaster />
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<SetPassword />} />
-            <Route path="choose-path">
-              <Route index={true} element={<ChooseConnectorPath />}></Route>
-              <Route path="choose-connector">
-                <Route
-                  index={true}
-                  element={
-                    <ChooseConnector
-                      title={i18n.t("translation:choose_connector.title")}
-                      description={i18n.t(
-                        "translation:choose_connector.description"
-                      )}
-                      connectorRoutes={connectorRoutes}
-                    />
-                  }
-                ></Route>
-                {renderRoutes(connectorRoutes)}
+      <AccountProvider>
+        <Router>
+          <Toaster />
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<SetPassword />} />
+              <Route path="choose-path">
+                <Route index={true} element={<ChooseConnectorPath />}></Route>
+                <Route path="choose-connector">
+                  <Route
+                    index={true}
+                    element={
+                      <ChooseConnector
+                        title={i18n.t("translation:choose_connector.title")}
+                        description={i18n.t(
+                          "translation:choose_connector.description"
+                        )}
+                        connectorRoutes={connectorRoutes}
+                      />
+                    }
+                  ></Route>
+                  {renderRoutes(connectorRoutes)}
+                </Route>
               </Route>
+              <Route path="test-connection" element={<TestConnection />} />
+              <Route path="pin-extension" element={<PinExtension />} />
             </Route>
-            <Route path="test-connection" element={<TestConnection />} />
-            <Route path="pin-extension" element={<PinExtension />} />
-          </Route>
-        </Routes>
-      </Router>
+          </Routes>
+        </Router>
+      </AccountProvider>
     </SettingsProvider>
   );
 }


### PR DESCRIPTION



### Describe the changes you have made in this PR

security fix to not allow to bypass unlock screen and read unsensitive data


### Link this PR to an issue [optional]

Fixes  #2915 

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)





### How has this been tested?

try to access welcome.html when the extension is unlocked and locked. 
### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
