### PR TITLE
feat: centralise image and icon for smaller screens

### DIFF
--- a/src/app/components/ConnectorPath/index.tsx
+++ b/src/app/components/ConnectorPath/index.tsx
@@ -9,9 +9,11 @@ type Props = {
 function ConnectorPath({ title, icon, description, content, actions }: Props) {
   return (
     <div className="flex flex-col p-10 border border-neutral-200 dark:border-neutral-700 rounded-2xl bg-white dark:bg-surface-02dp">
-      <div className="flex flex-row items-center mb-4 space-x-3">
+      <div className="flex flex-col sm:flex-row items-center mb-4 space-x-3">
         {icon}
-        <h1 className="text-xl font-bold dark:text-white">{title}</h1>
+        <h1 className="text-xl font-bold dark:text-white text-center">
+          {title}
+        </h1>
       </div>
       <p className="text-gray-800 dark:text-neutral-200 mb-6">{description}</p>
       <div className="flex flex-col space-y-4 text-sm mb-8 dark:text-white">


### PR DESCRIPTION
### Describe the changes you have made in this PR

centralise image and icon for smaller screens 



(Remove other not matching type)


- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]

before:
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/b423e806-0a7e-42ba-aec7-d8b8983d617d)

after:

![WhatsApp Image 2023-12-27 at 15 35 55](https://github.com/getAlby/lightning-browser-extension/assets/55848322/e444c90e-4e67-400e-b8d9-91cfe26da99a)




### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
