### PR TITLE
fix: getInvoices method for cln (NaN amount)

### DIFF
--- a/src/extension/background-script/connectors/commando.ts
+++ b/src/extension/background-script/connectors/commando.ts
@@ -81,13 +81,19 @@ type CommandoListInvoiceResponse = {
 
 type CommandoInvoice = {
   label: string;
+  payment_hash: string;
   status: string;
-  description: string;
-  amount_msat: number;
-  bolt11: string;
+  expires_at: number;
+  description?: string;
+  amount_msat?: number;
+  bolt11?: string;
+  bolt12?: string;
+  local_offer_id?: number;
+  invreq_payer_note?: string;
+  pay_index: number;
+  amount_received_msat: number;
   payment_preimage: string;
   paid_at: number;
-  payment_hash: string;
 };
 
 type CommandoPayment = {
@@ -236,7 +242,7 @@ export default class Commando implements Connector {
               payment_hash: invoice.payment_hash,
               settleDate: invoice.paid_at * 1000,
               type: "received",
-              totalAmount: Math.floor(invoice.amount_msat / 1000),
+              totalAmount: Math.floor(invoice.amount_received_msat / 1000),
             })
           )
           .filter((invoice) => invoice.settled);


### PR DESCRIPTION
### Describe the changes you have made in this PR

https://cdecker-lightning.readthedocs.io/lightning-listinvoices.7.html#return-value

amount_msat is optional and may not be included in the payments like keysends. as we filter and show only paid transactions ```amount_received_msat``` is always present. 

if there is no key value pair for amount in transactions. it shows either 0 or NaN 

tried multiple types payments i see keysends don't contains amount_msat field


checked outgoingpayment parameters. transaction list shall be fine by now

### Link this PR to an issue [optional]

Fixes  #2910 

### Type of change

(Remove other not matching type)


- `feat`: New feature (non-breaking change which adds functionality)



### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
