### PR TITLE
fix: return correct value for amount and fees for cln send payment

### DIFF
--- a/src/extension/background-script/connectors/commando.ts
+++ b/src/extension/background-script/connectors/commando.ts
@@ -72,9 +72,14 @@ type CommandoListSendPaysResponse = {
 type CommandoPayInvoiceResponse = {
   payment_preimage: string;
   payment_hash: string;
-  msatoshi: number;
-  msatoshi_sent: number;
+  created_at: number;
+  parts: string;
+  amount_msat: number;
+  amount_sent_msat: number;
+  status: string;
+  destination?: string;
 };
+
 type CommandoListInvoiceResponse = {
   invoices: CommandoInvoice[];
 };
@@ -340,9 +345,9 @@ export default class Commando implements Connector {
             paymentHash: parsed.payment_hash,
             preimage: parsed.payment_preimage,
             route: {
-              total_amt: Math.floor(parsed.msatoshi_sent / 1000),
+              total_amt: Math.floor(parsed.amount_msat / 1000),
               total_fees: Math.floor(
-                (parsed.msatoshi_sent - parsed.msatoshi) / 1000
+                (parsed.amount_sent_msat - parsed.amount_msat) / 1000
               ),
             },
           },
@@ -377,9 +382,9 @@ export default class Commando implements Connector {
             paymentHash: parsed.payment_hash,
             preimage: parsed.payment_preimage,
             route: {
-              total_amt: Math.floor(parsed.msatoshi_sent / 1000),
+              total_amt: Math.floor(parsed.amount_msat / 1000),
               total_fees: Math.floor(
-                (parsed.msatoshi_sent - parsed.msatoshi) / 1000
+                (parsed.amount_sent_msat - parsed.amount_msat) / 1000
               ),
             },
           },


### PR DESCRIPTION
### Describe the changes you have made in this PR

https://cdecker-lightning.readthedocs.io/lightning-keysend.7.html#randomization

cln uses ```amount_msat``` and ```amount_sent_msat``` values and no more returns ```msatoshi ```value. we currently pass the wrong values in the total amount and fees to the extension which don't exist in response. resulting into ```NaN sats``` output for outgoing db transactions

### Link this PR to an issue [optional]


### Type of change

(Remove other not matching type)


- `feat`: New feature (non-breaking change which adds functionality)

### Screenshots of the changes [optional]


### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
