### PR TITLE
feat: avoid overflow for continuous strings in description

### DIFF
--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -42,7 +42,7 @@ const Dt = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="text-lg text-gray-600 dark:text-neutral-400 whitespace-prewrap overflow-hidden text-ellipsis">
+  <dd className="text-lg text-gray-600 dark:text-neutral-400 break-words">
     {children}
   </dd>
 );

--- a/src/app/components/PaymentSummary/index.tsx
+++ b/src/app/components/PaymentSummary/index.tsx
@@ -42,7 +42,9 @@ const Dt = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Dd = ({ children }: { children: React.ReactNode }) => (
-  <dd className="text-lg text-gray-600 dark:text-neutral-400">{children}</dd>
+  <dd className="text-lg text-gray-600 dark:text-neutral-400 whitespace-prewrap overflow-hidden text-ellipsis">
+    {children}
+  </dd>
 );
 
 export default PaymentSummary;


### PR DESCRIPTION
### Describe the changes you have made in this PR
avoid overflow for continuous strings

### Link this PR to an issue [optional]

Fixes #3009 

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)


### Screenshots of the changes [optional]

single continuous string:
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/8051a944-15aa-4498-a345-65af934a2365)

non continuous strings:
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/2d1b92f7-0b93-4c64-872a-aaa160e47264)

noncontinuous strings having some larger continuous strings:
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/2ad760c1-fde9-417b-a873-6eb4036f07f1)



### How has this been tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

### Checklist

- [ ] Self-review of changed code
- [ ] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [ ] Darkmode
- [ ] Responsive layout
