### PR TITLE
feat: implement stablesats for galoy connector #2730

### DIFF
--- a/src/app/screens/connectors/ConnectGaloy/index.tsx
+++ b/src/app/screens/connectors/ConnectGaloy/index.tsx
@@ -1,5 +1,6 @@
 import ConnectorForm from "@components/ConnectorForm";
 import Input from "@components/form/Input";
+import Select from "@components/form/Select";
 import ConnectionErrorToast from "@components/toasts/ConnectionErrorToast";
 import fetchAdapter from "@vespaiach/axios-fetch-adapter";
 import axios from "axios";
@@ -54,9 +55,14 @@ export default function ConnectGaloy(props: Props) {
   });
   const [loading, setLoading] = useState(false);
   const [authToken, setAuthToken] = useState<string | undefined>();
+  const [currency, setCurrency] = useState<string>("BTC");
 
   function handleAuthTokenChange(event: React.ChangeEvent<HTMLInputElement>) {
     setAuthToken(event.target.value.trim());
+  }
+
+  function handleCurrencyChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    setCurrency(event.target.value.trim());
   }
 
   async function loginWithAuthToken(event: React.FormEvent<HTMLFormElement>) {
@@ -100,10 +106,10 @@ export default function ConnectGaloy(props: Props) {
       } else {
         // Find the BTC wallet and get its ID
         const btcWallet = meData.data.me.defaultAccount.wallets.find(
-          (w: Wallet) => w.walletCurrency === "BTC"
+          (w: Wallet) => w.walletCurrency === currency
         );
         const walletId = btcWallet.id;
-        saveAccount({ headers, walletId });
+        saveAccount({ headers, walletId, currency });
       }
     } catch (e: unknown) {
       console.error(e);
@@ -122,7 +128,11 @@ export default function ConnectGaloy(props: Props) {
     }
   }
 
-  async function saveAccount(config: { headers: Headers; walletId: string }) {
+  async function saveAccount(config: {
+    headers: Headers;
+    walletId: string;
+    currency: string;
+  }) {
     setLoading(true);
 
     const account = {
@@ -132,6 +142,7 @@ export default function ConnectGaloy(props: Props) {
         headers: config.headers,
         walletId: config.walletId,
         apiCompatibilityMode,
+        currency: config.currency,
       },
       connector: "galoy",
     };
@@ -212,6 +223,28 @@ export default function ConnectGaloy(props: Props) {
               onChange={handleAuthTokenChange}
               autoFocus={true}
             />
+          </div>
+        </div>
+      }
+      {
+        <div className="mt-6">
+          <label
+            htmlFor="currency"
+            className="block font-medium text-gray-800 dark:text-white"
+          >
+            {t(`${i18nPrefix}.currency.label`)}
+          </label>
+          <div className="mt-1">
+            <Select
+              id="currency"
+              name="currency"
+              required
+              onChange={handleCurrencyChange}
+              autoFocus={false}
+            >
+              <option value="BTC">BTC</option>
+              <option value="USD">USD (Stablesats)</option>
+            </Select>
           </div>
         </div>
       }

--- a/src/extension/background-script/connectors/galoy.ts
+++ b/src/extension/background-script/connectors/galoy.ts
@@ -1,16 +1,18 @@
 import fetchAdapter from "@vespaiach/axios-fetch-adapter";
 import axios, { AxiosRequestConfig } from "axios";
 import lightningPayReq from "bolt11";
+import { ACCOUNT_CURRENCIES, CURRENCIES } from "~/common/constants";
+import { getCurrencyRateWithCache } from "~/extension/background-script/actions/cache/getCurrencyRate";
 import { Account } from "~/types";
 
 import Connector, {
   CheckPaymentArgs,
   CheckPaymentResponse,
   ConnectPeerResponse,
+  ConnectorTransaction,
   GetBalanceResponse,
   GetInfoResponse,
   GetTransactionsResponse,
-  ConnectorTransaction,
   KeysendArgs,
   MakeInvoiceArgs,
   MakeInvoiceResponse,
@@ -20,12 +22,15 @@ import Connector, {
   SignMessageResponse,
 } from "./connector.interface";
 
+type GaloyCurrencies = Extract<ACCOUNT_CURRENCIES, "BTC" | "USD">;
+
 interface Config {
   walletId: string;
   url: string;
   headers?: Headers; // optional for backward compatibility
   apiCompatibilityMode?: boolean; // optional for backward compatibility
   accessToken?: string; // only present in old connectors
+  currency?: GaloyCurrencies; // default is BTC
 }
 
 class Galoy implements Connector {
@@ -60,6 +65,14 @@ class Galoy implements Connector {
 
   unload() {
     return Promise.resolve();
+  }
+
+  toFiatInt(amount: number, currency: GaloyCurrencies): number {
+    return Math.round(amount * 100);
+  }
+
+  toFiatFloat(amount: number, currency: GaloyCurrencies): number {
+    return amount / 100;
   }
 
   get supportedMethods() {
@@ -187,36 +200,45 @@ class Galoy implements Connector {
       const targetWallet = wallets.find((w) => w.id === this.config.walletId);
 
       if (targetWallet) {
-        if (targetWallet.walletCurrency === "USD") {
-          throw new Error("USD currency support is not yet implemented.");
+        if (targetWallet.walletCurrency !== (this.config.currency || "BTC")) {
+          throw new Error(
+            "Wallet currency does not match the account currency. " +
+              targetWallet.walletCurrency +
+              " != " +
+              (this.config.currency || "BTC")
+          );
         }
 
-        targetWallet.transactions.edges.forEach(
-          (edge: { cursor: string; node: TransactionNode }) => {
-            const tx = edge.node;
-            // Determine transaction type based on the direction field
-            const transactionType: "received" | "sent" =
-              tx.direction === "RECEIVE" ? "received" : "sent";
-            // Do not display a double negative if sent
-            const absSettlementAmount = Math.abs(tx.settlementAmount);
-            // Convert createdAt from UNIX timestamp to Date
-            const createdAtDate = new Date(tx.createdAt * 1000);
-
-            transactions.push({
-              id: edge.cursor,
-              memo: tx.memo,
-              preimage:
-                tx.settlementVia.preImage ||
-                tx.settlementVia.paymentSecret ||
-                "",
-              payment_hash: tx.initiationVia.paymentHash || "",
-              settled: tx.status === "SUCCESS",
-              settleDate: createdAtDate.getTime(),
-              totalAmount: absSettlementAmount, // Assuming this is in the correct unit
-              type: transactionType,
-            });
+        for (const edge of targetWallet.transactions.edges) {
+          const tx = edge.node;
+          // Determine transaction type based on the direction field
+          const transactionType: "received" | "sent" =
+            tx.direction === "RECEIVE" ? "received" : "sent";
+          // Do not display a double negative if sent
+          let absSettlementAmount = Math.abs(tx.settlementAmount);
+          // Convert createdAt from UNIX timestamp to Date
+          const createdAtDate = new Date(tx.createdAt * 1000);
+          const currency = targetWallet.walletCurrency || "BTC";
+          if (currency !== "BTC") {
+            // Convert to sats if fiat
+            const rate = await getCurrencyRateWithCache(CURRENCIES[currency]);
+            absSettlementAmount = Math.floor(
+              this.toFiatFloat(absSettlementAmount, currency) / rate
+            );
           }
-        );
+
+          transactions.push({
+            id: edge.cursor,
+            memo: tx.memo,
+            preimage:
+              tx.settlementVia.preImage || tx.settlementVia.paymentSecret || "",
+            payment_hash: tx.initiationVia.paymentHash || "",
+            settled: tx.status === "SUCCESS",
+            settleDate: createdAtDate.getTime(),
+            totalAmount: absSettlementAmount, // Assuming this is in the correct unit
+            type: transactionType,
+          });
+        }
       }
 
       hasNextPage = targetWallet?.transactions.pageInfo.hasNextPage || false;
@@ -255,12 +277,25 @@ class Galoy implements Connector {
         (w: GaloyWallet) => w.id === this.config.walletId
       );
       if (targetWallet) {
-        if (targetWallet.walletCurrency === "USD") {
-          throw new Error("USD currency support is not yet implemented.");
+        if (targetWallet.walletCurrency !== (this.config.currency || "BTC")) {
+          throw new Error(
+            "Wallet currency does not match the account currency. " +
+              targetWallet.walletCurrency +
+              " != " +
+              (this.config.currency || "BTC")
+          );
         }
+
+        const currency = targetWallet.walletCurrency;
+        const balance =
+          currency !== "BTC"
+            ? this.toFiatFloat(targetWallet.balance, currency)
+            : targetWallet.balance;
+
         return {
           data: {
-            balance: targetWallet.balance,
+            balance,
+            currency,
           },
         };
       } else {
@@ -419,8 +454,13 @@ class Galoy implements Connector {
         if (wallet === undefined) {
           throw new Error("Bad data received.");
         }
-        if (wallet.walletCurrency === "USD") {
-          throw new Error("USD currency support is not yet implemented.");
+        if (wallet.walletCurrency !== (this.config.currency || "BTC")) {
+          throw new Error(
+            "Wallet currency does not match the account currency. " +
+              wallet.walletCurrency +
+              " != " +
+              (this.config.currency || "BTC")
+          );
         }
 
         const txEdges = wallet.transactions.edges;
@@ -453,10 +493,26 @@ class Galoy implements Connector {
   }
 
   async makeInvoice(args: MakeInvoiceArgs): Promise<MakeInvoiceResponse> {
+    const mutationName =
+      this.config.currency == "USD" ? "LnUsdInvoiceCreate" : "lnInvoiceCreate";
+    const inputTypeName =
+      this.config.currency == "USD"
+        ? "LnUsdInvoiceCreateInput"
+        : "LnInvoiceCreateInput";
+    const fun =
+      this.config.currency == "USD" ? "lnUsdInvoiceCreate" : "lnInvoiceCreate";
+    const currency = this.config.currency || "BTC";
+
+    let amount = Number(args.amount);
+    if (currency !== "BTC") {
+      const rate = await getCurrencyRateWithCache(CURRENCIES[currency]);
+      amount = this.toFiatInt(amount * rate, currency);
+    }
+
     const query = {
       query: `
-        mutation lnInvoiceCreate($input: LnInvoiceCreateInput!) {
-          lnInvoiceCreate(input: $input) {
+        mutation ${mutationName}($input: ${inputTypeName}!) {
+          ${fun}(input: $input) {
             invoice {
               paymentRequest
               paymentHash
@@ -472,21 +528,21 @@ class Galoy implements Connector {
       variables: {
         input: {
           walletId: this.config.walletId,
-          amount: args.amount,
+          amount,
           memo: args.memo,
         },
       },
     };
     return this.request(query).then(({ data, errors }) => {
-      const errs = errors || data.lnInvoiceCreate.errors;
+      const errs = errors || data[fun].errors;
       if (errs && errs.length) {
         throw new Error(errs[0].message || JSON.stringify(errs));
       }
 
       return {
         data: {
-          paymentRequest: data.lnInvoiceCreate.invoice.paymentRequest,
-          rHash: data.lnInvoiceCreate.invoice.paymentHash,
+          paymentRequest: data[fun].invoice.paymentRequest,
+          rHash: data[fun].invoice.paymentHash,
         },
       };
     });

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -228,7 +228,10 @@
         },
         "token": {
           "label": "Enter your API key",
-          "info": "To connect your wallet generate an API key in the <0>Blink Dashboard (dashboard.blink.sv)</0>:<br>- log in with email or phone number if you are using Blink already<br>- if you have no account yet can create a new one by logging in with a phone number<br>- create a new key on the API Keys tab<br>- give it a Name and choose the Read and Write Scope<br>- leave the default no expiry or choose a long timeframe to avoid needing to reconnect your wallet periodically<br>- copy the key (starting with blink_ ) and paste it to the textbox below.<br><br>The integration currently only supports using the BTC wallet.<br>"
+          "info": "To connect your wallet generate an API key in the <0>Blink Dashboard (dashboard.blink.sv)</0>:<br>- log in with email or phone number if you are using Blink already<br>- if you have no account yet can create a new one by logging in with a phone number<br>- create a new key on the API Keys tab<br>- give it a Name and choose the Read and Write Scope<br>- leave the default no expiry or choose a long timeframe to avoid needing to reconnect your wallet periodically<br>- copy the key (starting with blink_ ) and paste it to the textbox below.<br>"
+        },
+        "currency": {
+          "label": "Select wallet"
         }
       },
       "bitcoin_jungle": {
@@ -239,6 +242,9 @@
         "token": {
           "label": "Enter your Access token",
           "info": "The {{label}} integration with Alby is in alpha and only recommended for advanced users.<br><br>You can grab your Access token by going into the mobile app, clicking on the settings icon, and then tapping 3 times on the build number to open the developer menu.<br><br>The access token can be copied from here.<br><br>"
+        },
+        "currency": {
+          "label": "Select wallet"
         }
       },
       "galoy": {


### PR DESCRIPTION
### Describe the changes you have made in this PR
This is my submission for the galoy bounty https://github.com/GaloyMoney/galoy/discussions/3950  and feature request #2730 
The PR adds support for stable sats in the galoy connector.

### Link this PR to an issue [optional]
Implements #2730 

### Type of change


- `feat`: New feature (non-breaking change which adds functionality)


### Screenshots of the changes [optional]

![image](https://github.com/getAlby/lightning-browser-extension/assets/4943530/6717cae7-4535-4eec-ba49-99a49be06265)
![image](https://github.com/getAlby/lightning-browser-extension/assets/4943530/b048891f-326b-455e-a85e-25306cd38686)

### How has this been tested?
1. Connect a Blink account
2. When prompted select the `USD (Stablesats)` wallet
3. Send and receive stablesats to and from another lightning wallet


### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [ ] Darkmode
- [ ] Responsive layout
