### PR TITLE
feat:store additional data with permissions

### DIFF
--- a/src/app/components/SitePreferences/index.tsx
+++ b/src/app/components/SitePreferences/index.tsx
@@ -247,6 +247,10 @@ function SitePreferences({ launcherType, allowance, onEdit, onDelete }: Props) {
                         }}
                       />
                     </Setting>
+
+                    {permission.metadata && (
+                      <h1>{JSON.stringify(permission.metadata, null, 2)}</h1>
+                    )}
                   </Fragment>
                 ))}
               </div>

--- a/src/extension/background-script/actions/nostr/getPublicKeyOrPrompt.ts
+++ b/src/extension/background-script/actions/nostr/getPublicKeyOrPrompt.ts
@@ -38,7 +38,8 @@ const getPublicKeyOrPrompt = async (
       if (promptResponse.data.rememberPermission) {
         await addPermissionFor(
           PermissionMethodNostr["NOSTR_GETPUBLICKEY"],
-          host
+          host,
+          { kind: 4, deny: true, allow: false }
         );
       }
 

--- a/src/extension/background-script/db.ts
+++ b/src/extension/background-script/db.ts
@@ -55,6 +55,10 @@ export class DB extends Dexie {
       allowances:
         "++id,&host,name,imageURL,tag,enabled,*enabledFor,totalBudget,remainingBudget,lastPaymentAt,lnurlAuth,createdAt",
     });
+    this.version(7).stores({
+      permissions:
+        "++id,accountId,allowanceId,host,method,enabled,blocked,createdAt,metadata",
+    });
 
     this.on("ready", this.loadFromStorage.bind(this));
     this.allowances = this.table("allowances");

--- a/src/extension/background-script/permissions/addPermissionFor.ts
+++ b/src/extension/background-script/permissions/addPermissionFor.ts
@@ -1,7 +1,11 @@
 import db from "~/extension/background-script/db";
 import state from "~/extension/background-script/state";
 
-export async function addPermissionFor(method: string, host: string) {
+export async function addPermissionFor(
+  method: string,
+  host: string,
+  metadata?: object
+) {
   const accountId = state.getState().currentAccountId;
   const allowance = await db.allowances.get({
     host,
@@ -18,6 +22,7 @@ export async function addPermissionFor(method: string, host: string) {
     method: method,
     enabled: true,
     blocked: false,
+    metadata: metadata ? metadata : undefined,
   });
 
   return !!permissionIsAdded && (await db.saveToStorage());

--- a/src/types.ts
+++ b/src/types.ts
@@ -766,6 +766,7 @@ export enum PermissionMethodLiquid {
 export enum PermissionMethodNostr {
   NOSTR_SIGNMESSAGE = "nostr/signMessage",
   NOSTR_SIGNSCHNORR = "nostr/signSchnorr",
+  // this can be nostr login
   NOSTR_GETPUBLICKEY = "nostr/getPublicKey",
   NOSTR_NIP04DECRYPT = "nostr/nip04decrypt",
   NOSTR_NIP04ENCRYPT = "nostr/nip04encrypt",
@@ -780,6 +781,7 @@ export interface DbPermission {
   method: string | PermissionMethodNostr;
   enabled: boolean;
   blocked: boolean;
+  metadata?: object;
 }
 
 export interface Permission extends Omit<DbPermission, "id"> {


### PR DESCRIPTION
### Describe the changes you have made in this PR

prototype to store nostr permssions in db.

looking over the designs and code  i think we don't need to add additional data in the db for permissions and we can achieve it without such changes. as such changes will also need migrations.


1. we declare our permsision types in such enum, we can just add new permissions and change names of permssions according to which we want to display it in site preferences dialogue

```
export enum PermissionMethodNostr {
  NOSTR_SIGNMESSAGE = "nostr/signMessage",
  NOSTR_SIGNSCHNORR = "nostr/signSchnorr",
  // this can be nostr login
  NOSTR_GETPUBLICKEY = "nostr/getPublicKey",
  NOSTR_NIP04DECRYPT = "nostr/nip04decrypt",
  NOSTR_NIP04ENCRYPT = "nostr/nip04encrypt",
}

```

2. we store ```enabled``` property to true when we add permissions and set it to false when we revoke permissions so we don't need to store allow and deny as well we can use this variable and just change ui to use buttons which to allow or revoke a permissions

3. type definitions: type definitions are incomplete for event kinds we need to add type definitions

From the above explanation, i think we can achieve permission management without storing additional metadata. wdyt @reneaaron 

