### PR TITLE
fix(mnemonic): restrict input fields to 12

### DIFF
--- a/src/app/components/mnemonic/MnemonicInputs/index.tsx
+++ b/src/app/components/mnemonic/MnemonicInputs/index.tsx
@@ -27,6 +27,9 @@ export default function MnemonicInputs({
   while (words.length < 12) {
     words.push("");
   }
+  while (words.length > 12) {
+    words.pop();
+  }
 
   return (
     <div className="border border-gray-200 dark:border-neutral-700 rounded-lg p-6 flex flex-col gap-4 items-center justify-center">


### PR DESCRIPTION
### Describe the changes you have made in this PR

Pops the words after 12, so that we can restrict the mnemonic inputs to 12 max.

### Link this PR to an issue [optional]

Fixes #3038

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes [optional]

https://github.com/getAlby/lightning-browser-extension/assets/64399555/0df0c252-f706-4493-a083-4b42d9a68be8

### How has this been tested?

Tested Manually

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [x] Added automated tests where applicable (Not Applicable)
- [x] Update Docs & Guides (Not Applicable)
- For UI-related changes
- [x] Darkmode (Not Applicable)
- [x] Responsive layout (Not Applicable)
