### PR TITLE
chore: bump Alby JS SDK to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@bitcoin-design/bitcoin-icons-react": "^0.1.10",
     "@bitcoinerlab/secp256k1": "^1.0.5",
-    "@getalby/sdk": "^3.3.0",
+    "@getalby/sdk": "^3.4.0",
     "@headlessui/react": "^1.7.18",
     "@lightninglabs/lnc-web": "^0.2.4-alpha",
     "@noble/curves": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,10 +673,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.52.0.tgz#78fe5f117840f69dc4a353adf9b9cd926353378c"
   integrity sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==
 
-"@getalby/sdk@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@getalby/sdk/-/sdk-3.3.0.tgz#176982faecf994bf677944f31ecbb8e0f4032ee1"
-  integrity sha512-Y/RwxIo7iYTsKDaTbDmZME1AuB8v5bw9CmqBN3u6fkI8ibYYi8RgeRW78orwCNKRZFB//ZF4MEpAJBGZ3vNNzQ==
+"@getalby/sdk@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@getalby/sdk/-/sdk-3.4.0.tgz#3251e17435caccc5b6f6448a89736034ed4c0c00"
+  integrity sha512-qzIx6GVs4uc9cFyP1fpqHrMxZqqNwi0dSMcgcFMXlb2QBV1syUaNhEvdyBuQo1s+Y38UkQnRToOMqBAX6jXGwQ==
   dependencies:
     events "^3.3.0"
     nostr-tools "^1.17.0"


### PR DESCRIPTION
This fixes error messages not being displayed from errors in the NWC connector due to Alby JS SDK previously not throwing proper error objects (therefore the `message` field being undefined and the error falling back to "Something went wrong")

![image](https://github.com/getAlby/lightning-browser-extension/assets/33993199/a46fe4a8-b224-4648-bc06-618b34fe186a)
