### PR TITLE
feat: handle longer descriptions + buttons always visible in viewport

### DIFF
--- a/src/app/components/ContentMessage/index.tsx
+++ b/src/app/components/ContentMessage/index.tsx
@@ -11,7 +11,7 @@ function ContentMessage({ heading, content }: Props) {
           {heading}
         </dt>
         {content && (
-          <dd className="text-lg text-gray-600 dark:text-neutral-400 break-all">
+          <dd className="text-lg text-gray-600 dark:text-neutral-400 break-all line-clamp-[8]">
             {content}
           </dd>
         )}


### PR DESCRIPTION
fix contentMessage component for longer descriptions
make sure buttons always visible in viewport

before: 
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/1656f57a-2907-4cde-a0b6-3dc09bebe418)


after: 
![image](https://github.com/getAlby/lightning-browser-extension/assets/55848322/f20694f9-a5f9-44b4-b4f4-f4ad4aa9fc01)
