### PR TITLE
feat: show lnaddress only when oauth  account settings are accessed

### DIFF
--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -26,7 +26,7 @@ import Toggle from "~/app/components/form/Toggle";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 import { useSettings } from "~/app/context/SettingsContext";
-import { classNames } from "~/app/utils";
+import { classNames, isAlbyOAuthAccount } from "~/app/utils";
 import api, { GetAccountRes } from "~/common/lib/api";
 import msg from "~/common/lib/msg";
 import nostr from "~/common/lib/nostr";
@@ -240,7 +240,7 @@ function AccountDetail() {
               </form>
               {/* show lnaddress setting only for OAuth accounts and active account settings */}
               {lightningAddress &&
-                account.connectorType == "alby" &&
+                isAlbyOAuthAccount(account.connectorType) &&
                 account.id === auth.account?.id && (
                   <>
                     <MenuDivider />

--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -26,7 +26,7 @@ import Toggle from "~/app/components/form/Toggle";
 import { useAccount } from "~/app/context/AccountContext";
 import { useAccounts } from "~/app/context/AccountsContext";
 import { useSettings } from "~/app/context/SettingsContext";
-import { classNames, isAlbyOAuthAccount } from "~/app/utils";
+import { classNames } from "~/app/utils";
 import api, { GetAccountRes } from "~/common/lib/api";
 import msg from "~/common/lib/msg";
 import nostr from "~/common/lib/nostr";
@@ -70,7 +70,6 @@ function AccountDetail() {
     url: "",
     lnAddress: "",
   });
-  const { account: authAccount } = useAccount();
 
   async function exportAccount({ id, name }: AccountAction) {
     setExportLoading(true);
@@ -238,41 +237,38 @@ function AccountDetail() {
                   />
                 </div>
               </form>
-              {lightningAddress &&
-                isAlbyOAuthAccount(authAccount?.connectorType) && (
-                  <>
-                    <MenuDivider />
-                    <div className="flex flex-col sm:flex-row justify-between items-center">
-                      <div className="sm:w-9/12 w-full">
-                        <p className="text-gray-800 dark:text-white font-medium">
-                          {t("lnaddress.title")}
-                        </p>
-                        <p className="text-gray-600 text-sm dark:text-neutral-400">
-                          {lightningAddress}
-                        </p>
-                      </div>
+              {lightningAddress && account.connectorType == "alby" && (
+                <>
+                  <MenuDivider />
+                  <div className="flex flex-col sm:flex-row justify-between items-center">
+                    <div className="sm:w-9/12 w-full">
+                      <p className="text-gray-800 dark:text-white font-medium">
+                        {t("lnaddress.title")}
+                      </p>
+                      <p className="text-gray-600 text-sm dark:text-neutral-400">
+                        {lightningAddress}
+                      </p>
+                    </div>
 
-                      <div className="flex-none sm:w-64 w-full pt-4 sm:pt-0">
-                        <div className="flex flex-row gap-2">
-                          <Button
-                            label={t("actions.change_lnaddress")}
-                            iconRight={
-                              <PopiconsExpandLine className="w-5 h-5" />
-                            }
-                            fullWidth
-                            primary
-                            onClick={() =>
-                              window.open(
-                                "https://getalby.com/lightning_addresses",
-                                "_blank"
-                              )
-                            }
-                          />
-                        </div>
+                    <div className="flex-none sm:w-64 w-full pt-4 sm:pt-0">
+                      <div className="flex flex-row gap-2">
+                        <Button
+                          label={t("actions.change_lnaddress")}
+                          iconRight={<PopiconsExpandLine className="w-5 h-5" />}
+                          fullWidth
+                          primary
+                          onClick={() =>
+                            window.open(
+                              "https://getalby.com/lightning_addresses",
+                              "_blank"
+                            )
+                          }
+                        />
                       </div>
                     </div>
-                  </>
-                )}
+                  </div>
+                </>
+              )}
               {account.connectorType == "lndhub" && (
                 <>
                   <MenuDivider />

--- a/src/app/screens/Accounts/Detail/index.tsx
+++ b/src/app/screens/Accounts/Detail/index.tsx
@@ -53,6 +53,7 @@ function AccountDetail() {
 
   const { account: accountInfo } = useAccount();
 
+  // lightning address is returned for current active account
   const lightningAddress = accountInfo?.lightningAddress || "";
 
   const [account, setAccount] = useState<GetAccountRes | null>(null);
@@ -237,38 +238,43 @@ function AccountDetail() {
                   />
                 </div>
               </form>
-              {lightningAddress && account.connectorType == "alby" && (
-                <>
-                  <MenuDivider />
-                  <div className="flex flex-col sm:flex-row justify-between items-center">
-                    <div className="sm:w-9/12 w-full">
-                      <p className="text-gray-800 dark:text-white font-medium">
-                        {t("lnaddress.title")}
-                      </p>
-                      <p className="text-gray-600 text-sm dark:text-neutral-400">
-                        {lightningAddress}
-                      </p>
-                    </div>
+              {/* show lnaddress setting only for OAuth accounts and active account settings */}
+              {lightningAddress &&
+                account.connectorType == "alby" &&
+                account.id === auth.account?.id && (
+                  <>
+                    <MenuDivider />
+                    <div className="flex flex-col sm:flex-row justify-between items-center">
+                      <div className="sm:w-9/12 w-full">
+                        <p className="text-gray-800 dark:text-white font-medium">
+                          {t("lnaddress.title")}
+                        </p>
+                        <p className="text-gray-600 text-sm dark:text-neutral-400">
+                          {lightningAddress}
+                        </p>
+                      </div>
 
-                    <div className="flex-none sm:w-64 w-full pt-4 sm:pt-0">
-                      <div className="flex flex-row gap-2">
-                        <Button
-                          label={t("actions.change_lnaddress")}
-                          iconRight={<PopiconsExpandLine className="w-5 h-5" />}
-                          fullWidth
-                          primary
-                          onClick={() =>
-                            window.open(
-                              "https://getalby.com/lightning_addresses",
-                              "_blank"
-                            )
-                          }
-                        />
+                      <div className="flex-none sm:w-64 w-full pt-4 sm:pt-0">
+                        <div className="flex flex-row gap-2">
+                          <Button
+                            label={t("actions.change_lnaddress")}
+                            iconRight={
+                              <PopiconsExpandLine className="w-5 h-5" />
+                            }
+                            fullWidth
+                            primary
+                            onClick={() =>
+                              window.open(
+                                "https://getalby.com/lightning_addresses",
+                                "_blank"
+                              )
+                            }
+                          />
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </>
-              )}
+                  </>
+                )}
               {account.connectorType == "lndhub" && (
                 <>
                   <MenuDivider />


### PR DESCRIPTION
### Describe the changes you have made in this PR

show lnaddress only when oauth account settings are accessed






- `feat`: New feature (non-breaking change which adds functionality)






### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
