### PR TITLE
fix: primary button overflow

### DIFF
--- a/src/app/components/Button/index.tsx
+++ b/src/app/components/Button/index.tsx
@@ -63,7 +63,7 @@ const Button = forwardRef(
             "hover:bg-gray-50 dark:hover:bg-surface-16dp",
           disabled ? "cursor-default opacity-60" : "cursor-pointer",
           flex && "flex-1",
-          "inline-flex justify-center items-center gap-1 font-medium bg-origin-border shadow rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary transition duration-150",
+          "inline-flex justify-center items-center gap-1 font-medium bg-origin-border shadow rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary transition duration-150 whitespace-nowrap",
           !!className && className
         )}
         onClick={onClick}

--- a/src/app/components/ConnectorPath/index.tsx
+++ b/src/app/components/ConnectorPath/index.tsx
@@ -16,8 +16,8 @@ function ConnectorPath({ title, icon, description, content, actions }: Props) {
         </h1>
       </div>
       <p className="mb-8">{description}</p>
-      <div className="flex flex-col space-y-4 text-sm">{content}</div>
-      <div className="flex gap-4 flex-col sm:flex-row mt-12">{actions}</div>
+      <div className="flex flex-col space-y-4 text-sm mb-8">{content}</div>
+      <div className="flex gap-4 flex-col sm:flex-row mt-auto">{actions}</div>
     </div>
   );
 }


### PR DESCRIPTION
fix primary button text overflow happens usually when loading state comes in and button has long text