### PR TITLE
chore: show QR with lowercase invoice value

### DIFF
--- a/src/app/screens/ReceiveInvoice/index.tsx
+++ b/src/app/screens/ReceiveInvoice/index.tsx
@@ -146,7 +146,7 @@ function ReceiveInvoice() {
               <div className="bg-white dark:bg-surface-01dp border-gray-200 dark:border-neutral-700  p-4 rounded-md border max-w-md">
                 <div className="relative flex items-center justify-center">
                   <QRCode
-                    value={invoice.paymentRequest.toUpperCase()}
+                    value={invoice.paymentRequest.toLowerCase()}
                     size={512}
                   />
                   {isAlbyOAuthUser ? (


### PR DESCRIPTION
### Describe the changes you have made in this PR

From unes on Telegram:
> when generating an invoice using the extension then scan the qr code using a mobile app or a centralized exchange the invoice url is in uppercase and some apps does not allow this

Is there any reason why we use `toUpperCase()`?

### Type of change

(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Manually

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [x] Added automated tests where applicable
- [x] Update Docs & Guides
- For UI-related changes
- [x] Darkmode
- [x] Responsive layout
