### PR TITLE
fix: scrollbar on extension popup

### DIFF
--- a/static/views/popup.html
+++ b/static/views/popup.html
@@ -13,6 +13,7 @@
 
   <body
     class="w-96 max-w-full overflow-x-hidden h-[600px] no-scrollbar min-h-screen bg-gray-50 dark:bg-surface-00dp slashed-zero"
+    style="scrollbar-width: auto"
   >
     <div id="popup-root" class="h-full"></div>
   </body>


### PR DESCRIPTION
fix scrollbar and shift of view in popup for latest chromium browsers

before: 
![image](https://github.com/user-attachments/assets/33ee3ebd-a559-47d4-b5f2-a4c1ac5948ff)

now: 
![image](https://github.com/user-attachments/assets/300ec0ce-7139-4874-82cb-35460bd75721)
