### PR TITLE
fix: nwc keysend method and custom record conversion when custom records is not passed

### DIFF
--- a/src/extension/background-script/connectors/nwc.ts
+++ b/src/extension/background-script/connectors/nwc.ts
@@ -163,7 +163,9 @@ class NWCConnector implements Connector {
     const data = await this.nwc.payKeysend({
       pubkey: args.pubkey,
       amount: args.amount * 1000,
-      tlv_records: this.customRecordsToTlv(args.customRecords),
+      ...(args.customRecords && {
+        tlv_records: this.customRecordsToTlv(args.customRecords),
+      }),
     });
 
     const paymentHash = SHA256(data.preimage).toString(Hex);
@@ -220,12 +222,8 @@ class NWCConnector implements Connector {
   }
 
   private customRecordsToTlv(
-    customRecords: Record<string, string> | undefined
-  ): TlvRecord[] | undefined {
-    if (!customRecords) {
-      return undefined;
-    }
-
+    customRecords: Record<string, string>
+  ): TlvRecord[] {
     return Object.entries(customRecords).map(([key, value]) => ({
       type: parseInt(key),
       value: UTF8.parse(value).toString(Hex),

--- a/src/extension/background-script/connectors/nwc.ts
+++ b/src/extension/background-script/connectors/nwc.ts
@@ -220,8 +220,12 @@ class NWCConnector implements Connector {
   }
 
   private customRecordsToTlv(
-    customRecords: Record<string, string>
-  ): TlvRecord[] {
+    customRecords: Record<string, string> | undefined
+  ): TlvRecord[] | undefined {
+    if (!customRecords) {
+      return undefined;
+    }
+
     return Object.entries(customRecords).map(([key, value]) => ({
       type: parseInt(key),
       value: UTF8.parse(value).toString(Hex),


### PR DESCRIPTION

### Describe the changes you have made in this PR

currently if we paste node id in send screen. the custom_records will be undefined. and keysend thrws error while converting it to tlv records. keysend shall be successfully even if custom_records are undefined


(Remove other not matching type)

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
go to send -> paste node id -> keysend will be successfull
### Checklist

- [X] Self-review of changed code
- [X] Manual testing
- [X] Added automated tests where applicable
- [X] Update Docs & Guides
- For UI-related changes
- [X] Darkmode
- [X] Responsive layout
