### PR TITLE
fix: lnaddress containing lnurl prefixes

### DIFF
--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -33,7 +33,8 @@ function Send() {
       setLoading(true);
 
       let lnurl = lnurlLib.findLnurl(invoice);
-      if (!lnurl && lnurlLib.isLightningAddress(invoice)) {
+
+      if (lnurlLib.isLightningAddress(invoice)) {
         lnurl = invoice;
       }
 


### PR DESCRIPTION
Fixes #3227 

before:
if its not lnurl then we check for lnaddress. but sometimes lnaddress containing "lnurl" in it makes isLnurl = true leading to potential errors 

after: 
 we check for both lnaddress and lnurl separately.