### PR TITLE
fix: pubkey prompt even after reasonable preset set

### DIFF
--- a/src/extension/background-script/permissions/hasPermissionFor.ts
+++ b/src/extension/background-script/permissions/hasPermissionFor.ts
@@ -1,6 +1,10 @@
 import db from "~/extension/background-script/db";
 import state from "~/extension/background-script/state";
 
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function hasPermissionFor(method: string, host: string) {
   if (!host) {
     return false;
@@ -20,6 +24,8 @@ export async function hasPermissionFor(method: string, host: string) {
   if (!accountId) {
     throw new Error("Account doesn't exist");
   }
+
+  await delay(1000);
 
   const findPermission = await db.permissions.get({
     host,


### PR DESCRIPTION
when there are more number of permissions in db. for new connected sites. it seems that public key prompt is triggered even after selecting reasonable sets of permissions.

one of the easy solution here to add a second of delay before fetching permissions so that we get latest permissions 