### PR TITLE
fix: pubkey prompt triggering even if reasonable permissions set

### DIFF
--- a/src/extension/background-script/actions/nostr/enable.ts
+++ b/src/extension/background-script/actions/nostr/enable.ts
@@ -132,8 +132,8 @@ const enable = async (message: MessageAllowanceEnable, sender: Sender) => {
           ];
           // when addding multiple permissions at once, the flow shall wait until all asynchronous addPermissionFor calls are completed.
           await Promise.all(
-            reasonableEventKindIds.map(async (kindId) => {
-              await addPermissionFor(
+            reasonableEventKindIds.map((kindId) => {
+              addPermissionFor(
                 PermissionMethodNostr.NOSTR_SIGNMESSAGE + "/" + kindId,
                 host,
                 false


### PR DESCRIPTION
we need to wait for all promises to be resolved while adding permissions at once via addPermissionFor