### PR TITLE
feat: update depricated artifacts for workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,13 @@ jobs:
         run: yarn build:chrome
 
       - name: Archive firefox production zip file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firefox.xpi
           path: dist/production/firefox.xpi
 
       - name: Archive chrome production zip file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chrome.zip
           path: dist/production/chrome.zip

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,7 +33,7 @@ jobs:
           args: npx playwright test
 
       - name: Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-artifcats


### PR DESCRIPTION
upload and download artifacts for v3 are depricated needs to be uploaded to v4