### PR TITLE
fix: remove e2e test instructions from setup docs

### DIFF
--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -89,15 +89,6 @@ Most logs are written to the background script. Make sure to "inspect" the backg
 
 ### :white_check_mark: Tests
 
-#### E2E tests via [playwright](https://playwright.dev) ([using testing-library](https://testing-library.com/docs/pptr-testing-library/intro/))
-
-```bash
-yarn run dev:chrome
-yarn test:e2e
-```
-
-:tipping_hand_woman: For now we only do E2E tests for Chrome
-
 #### Unit tests tests via [Jest](https://jestjs.io)
 
 ```bash

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -95,12 +95,6 @@ Most logs are written to the background script. Make sure to "inspect" the backg
 yarn test:unit
 ```
 
-#### Run all tests
-
-```bash
-yarn test
-```
-
 ### ⌨️ Production package files
 
 - `yarn run package` builds the extension for all the browsers to `dist/production` directory respectively.


### PR DESCRIPTION
remove e2e test instructions from setup guide