### PR TITLE
fix: align onboarding cards to max-w-xl (576px) #2615

### DIFF
--- a/src/app/screens/Onboard/PinExtension/index.tsx
+++ b/src/app/screens/Onboard/PinExtension/index.tsx
@@ -37,17 +37,23 @@ export default function PinExtension() {
           {t("description")}
         </p>
         <div className="mt-4 w-full flex justify-center">{getImage()}</div>
-        <p className="text-gray-500 mt-6 dark:text-gray-400 flex items-center justify-center gap-2">
+        <p className="text-gray-500 mt-6 dark:text-gray-400">
           <Trans
             i18nKey={"explanation"}
             t={t}
             components={[
               // eslint-disable-next-line react/jsx-key
-              <img src="assets/icons/puzzle.svg" className="w-5 dark:invert" />,
+              <img
+                src="assets/icons/puzzle.svg"
+                className="w-5 inline dark:invert"
+              />,
               // eslint-disable-next-line react/jsx-key
               <br />,
               // eslint-disable-next-line react/jsx-key
-              <img src="assets/icons/alby_icon_yellow.svg" className="w-5" />,
+              <img
+                src="assets/icons/alby_icon_yellow.svg"
+                className="w-5 inline"
+              />,
             ]}
           />
         </p>

--- a/src/app/screens/Onboard/PinExtension/index.tsx
+++ b/src/app/screens/Onboard/PinExtension/index.tsx
@@ -21,13 +21,13 @@ export default function PinExtension() {
       <img
         src={`assets/images/pin_your_alby_extension_${imageType}_${theme}.png`}
         alt="Pin your Alby extension"
-        className="h-28"
+        className="h-32"
       />
     );
   };
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center text-lg">
       <div className="shadow-lg rounded-xl bg-white dark:bg-surface-02dp p-12 max-w-xl">
         <h1 className="text-2xl font-bold dark:text-white max-sm:text-center">
           {t("title")}

--- a/src/app/screens/Onboard/PinExtension/index.tsx
+++ b/src/app/screens/Onboard/PinExtension/index.tsx
@@ -37,23 +37,17 @@ export default function PinExtension() {
           {t("description")}
         </p>
         <div className="mt-4 w-full flex justify-center">{getImage()}</div>
-        <p className="text-gray-500 mt-6 dark:text-gray-400">
+        <p className="text-gray-500 mt-6 dark:text-gray-400 flex items-center justify-center gap-2">
           <Trans
             i18nKey={"explanation"}
             t={t}
             components={[
               // eslint-disable-next-line react/jsx-key
-              <img
-                src="assets/icons/puzzle.svg"
-                className="w-5 inline align-bottom dark:invert"
-              />,
+              <img src="assets/icons/puzzle.svg" className="w-5 dark:invert" />,
               // eslint-disable-next-line react/jsx-key
               <br />,
               // eslint-disable-next-line react/jsx-key
-              <img
-                src="assets/icons/alby_icon_yellow.svg"
-                className="w-5 inline align-bottom"
-              />,
+              <img src="assets/icons/alby_icon_yellow.svg" className="w-5" />,
             ]}
           />
         </p>

--- a/src/app/screens/Onboard/PinExtension/index.tsx
+++ b/src/app/screens/Onboard/PinExtension/index.tsx
@@ -28,7 +28,7 @@ export default function PinExtension() {
 
   return (
     <div className="flex flex-col items-center">
-      <div className="shadow-lg rounded-xl bg-white dark:bg-surface-02dp p-12 max-w-lg">
+      <div className="shadow-lg rounded-xl bg-white dark:bg-surface-02dp p-12 max-w-xl">
         <h1 className="text-2xl font-bold dark:text-white max-sm:text-center">
           {t("title")}
         </h1>


### PR DESCRIPTION
### Describe the changes you have made in this PR

Aligned all onboarding cards to `max-w-xl` (576px) for better consistency across different screen sizes.

### Link this PR to an issue 

Fixes #2615 

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

- Manually tested the onboarding cards on different screen sizes to ensure they align correctly.
- Verified that the alignment works in both light and dark modes.
- Checked responsiveness to confirm no UI breakage.

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
  - [x] Darkmode
  - [x] Responsive layout
