### PR TITLE
fix(toast): allow toast to handle long error messages and improve its responsiveness

### DIFF
--- a/src/app/components/Toast/index.tsx
+++ b/src/app/components/Toast/index.tsx
@@ -1,5 +1,5 @@
-import { PopiconsXLine } from "@popicons/react";
 import { Transition } from "@headlessui/react";
+import { PopiconsXLine } from "@popicons/react";
 import { ReactNode } from "react";
 import {
   CheckmarkIcon,
@@ -40,23 +40,21 @@ const toast: ToastMethods = {
           show={t.visible}
         >
           <div className="bg-white dark:bg-surface-02dp px-4 py-3 drop-shadow-lg rounded-lg overflow-hidden flex flex-row items-center gap-3 text-gray-800 dark:text-neutral-200 max-w-sm sm:max-w-lg w-full break-words">
-            <div className="flex items-start gap-2 w-full">
-              <div className="shrink-0">
-                {type == "success" && <CheckmarkIcon />}
-                {type == "error" && <ErrorIcon />}
-              </div>
-              <div className="flex-1 text-sm max-h-[200px] overflow-auto">
-                {children}
-              </div>
-              {/* Add close icons for toasts that are displayed for a longer time or with longer legnth*/}
-              {(options?.duration && options?.duration > 10_000) ||
-              (typeof children === "string" && children.length > 50) ? (
-                <PopiconsXLine
-                  className="w-4 h-4 cursor-pointer mt-1 shrink-0 hover:opacity-80 transition-opacity"
-                  onClick={() => hotToast.dismiss(t.id)}
-                />
-              ) : null}
+            <div className="shrink-0">
+              {type == "success" && <CheckmarkIcon />}
+              {type == "error" && <ErrorIcon />}
             </div>
+            <div className="flex-1 text-sm max-h-[200px] overflow-auto">
+              {children}
+            </div>
+            {/* Add close icons for toasts that are displayed for a longer time or with longer legnth*/}
+            {(options?.duration && options?.duration > 10_000) ||
+            (typeof children === "string" && children.length > 50) ? (
+              <PopiconsXLine
+                className="w-4 h-4 cursor-pointer mt-1 shrink-0 hover:opacity-80 transition-opacity"
+                onClick={() => hotToast.dismiss(t.id)}
+              />
+            ) : null}
           </div>
         </Transition>
       ),

--- a/src/app/components/Toast/index.tsx
+++ b/src/app/components/Toast/index.tsx
@@ -39,19 +39,24 @@ const toast: ToastMethods = {
           leaveTo="opacity-0 scale-0"
           show={t.visible}
         >
-          <div className="bg-white dark:bg-surface-02dp px-4 py-3 drop-shadow-lg rounded-lg overflow-hidden flex flex-row items-center gap-3 text-gray-800 dark:text-neutral-200">
-            <div className="shrink-0">
-              {type == "success" && <CheckmarkIcon />}
-              {type == "error" && <ErrorIcon />}
+          <div className="bg-white dark:bg-surface-02dp px-4 py-3 drop-shadow-lg rounded-lg overflow-hidden flex flex-row items-center gap-3 text-gray-800 dark:text-neutral-200 max-w-sm sm:max-w-lg w-full break-words">
+            <div className="flex items-start gap-2 w-full">
+              <div className="shrink-0">
+                {type == "success" && <CheckmarkIcon />}
+                {type == "error" && <ErrorIcon />}
+              </div>
+              <div className="flex-1 text-sm max-h-[200px] overflow-auto">
+                {children}
+              </div>
+              {/* Add close icons for toasts that are displayed for a longer time or with longer legnth*/}
+              {(options?.duration && options?.duration > 10_000) ||
+              (typeof children === "string" && children.length > 50) ? (
+                <PopiconsXLine
+                  className="w-4 h-4 cursor-pointer mt-1 shrink-0 hover:opacity-80 transition-opacity"
+                  onClick={() => hotToast.dismiss(t.id)}
+                />
+              ) : null}
             </div>
-            <div>{children}</div>
-            {/* Add close icons for toasts that are displayed for a longer time */}
-            {options?.duration && options?.duration > 10_000 && (
-              <PopiconsXLine
-                className="w-4 h-4 cursor-pointer"
-                onClick={() => hotToast.dismiss(t.id)}
-              />
-            )}
           </div>
         </Transition>
       ),

--- a/src/app/components/Toast/index.tsx
+++ b/src/app/components/Toast/index.tsx
@@ -47,13 +47,15 @@ const toast: ToastMethods = {
             <div className="flex-1 text-sm max-h-[200px] overflow-auto">
               {children}
             </div>
-            {/* Add close icons for toasts that are displayed for a longer time or with longer legnth*/}
+            {/* Add close icons for toasts that are displayed for a longer time or with longer length*/}
             {(options?.duration && options?.duration > 10_000) ||
             (typeof children === "string" && children.length > 50) ? (
-              <PopiconsXLine
-                className="w-4 h-4 cursor-pointer mt-1 shrink-0 hover:opacity-80 transition-opacity"
-                onClick={() => hotToast.dismiss(t.id)}
-              />
+              <div className="absolute right-2 top-2 text-gray-600 cursor-button dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300">
+                <PopiconsXLine
+                  className="w-5 h-5"
+                  onClick={() => hotToast.dismiss(t.id)}
+                />
+              </div>
             ) : null}
           </div>
         </Transition>


### PR DESCRIPTION
### changes made in this PR

- Improved the toast UI to gracefully handle long error messages.
- Ensured error messages break properly on small screens.
- Added a dismiss button for long toasts or toasts with extended durations.


Fixes #3334

### Type of change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)

### Screenshots of the changes
![Internet Speed Test _ Fast com - Google Chrome 4_11_2025 3_29_24 AM](https://github.com/user-attachments/assets/77391801-868b-4e77-af26-9de039013479)
![Internet Speed Test _ Fast com - Google Chrome 4_11_2025 3_28_49 AM](https://github.com/user-attachments/assets/e0d066d5-4c94-4e65-9303-add0d014e028)
![Alby Extension - Google Chrome 4_11_2025 4_52_27 AM](https://github.com/user-attachments/assets/515061ae-cbe2-40ed-a923-201fe757b822)



### How has this been tested?

- Manually triggered error toasts with long LNURL error messages.
- Verified layout on mobile and desktop.
- Confirmed dismiss button shows conditionally and works.

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides

#### For UI-related changes

- [x] Darkmode
- [x] Responsive layout
