### PR TITLE
feat: add Wallet Settings to main menu for improved accessibility

### DIFF
--- a/src/app/components/UserMenu/index.tsx
+++ b/src/app/components/UserMenu/index.tsx
@@ -47,6 +47,19 @@ export default function UserMenu() {
         <PopiconsBarsSolid className="h-5 w-5" />
       </Menu.Button>
       <Menu.List position="left">
+        {auth.account && (
+          <>
+            <Menu.ItemButton
+              onClick={() => {
+                openOptions(`accounts/${auth.account?.id}`);
+              }}
+            >
+              <PopiconsSettingsMinimalLine className="h-5 w-5 mr-2 text-gray-800 dark:text-neutral-200 shrink-0" />
+              {tCommon("wallet_settings")}
+            </Menu.ItemButton>
+            <Menu.Divider />
+          </>
+        )}
         <div className="lg:hidden">
           <Menu.ItemButton
             onClick={() => {
@@ -65,16 +78,6 @@ export default function UserMenu() {
             {tCommon("connected_sites")}
           </Menu.ItemButton>
         </div>
-        {auth.account && (
-          <Menu.ItemButton
-            onClick={() => {
-              openOptions(`accounts/${auth.account?.id}`);
-            }}
-          >
-            <PopiconsSettingsMinimalLine className="h-5 w-5 mr-2 text-gray-800 dark:text-neutral-200 shrink-0" />
-            {tCommon("wallet_settings")}
-          </Menu.ItemButton>
-        )}
         <Menu.ItemButton
           onClick={() => {
             openOptions("settings");

--- a/src/app/components/UserMenu/index.tsx
+++ b/src/app/components/UserMenu/index.tsx
@@ -11,6 +11,7 @@ import {
   PopiconsCommentLine,
   PopiconsExpandLine,
   PopiconsLockLine,
+  PopiconsSettingsMinimalLine,
 } from "@popicons/react";
 import Menu from "../Menu";
 
@@ -64,6 +65,16 @@ export default function UserMenu() {
             {tCommon("connected_sites")}
           </Menu.ItemButton>
         </div>
+        {auth.account && (
+          <Menu.ItemButton
+            onClick={() => {
+              openOptions(`accounts/${auth.account?.id}`);
+            }}
+          >
+            <PopiconsSettingsMinimalLine className="h-5 w-5 mr-2 text-gray-800 dark:text-neutral-200 shrink-0" />
+            {tCommon("wallet_settings")}
+          </Menu.ItemButton>
+        )}
         <Menu.ItemButton
           onClick={() => {
             openOptions("settings");


### PR DESCRIPTION
### Describe the changes you have made in this PR

Added "Wallet Settings" option to the main menu to improve accessibility while maintaining the existing access point in the account menu. Many users were struggling to find the wallet settings which were only accessible through a small icon in the account menu. This change makes the feature more discoverable by placing it where users naturally look for it.

### Link this PR to an issue

Fixes  #3300

### Type of change


- `feat`: New feature (non-breaking change which adds functionality)


### How has this been tested?

I've manually tested the changes by:

1. Verifying the "Wallet Settings" option appears in the main menu
2. Confirming it correctly navigates to the account settings page when clicked
3. Ensuring the existing wallet settings icon in the account menu still works
4. Testing with different account types to ensure proper functionality


### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
-  For UI-related changes
- [x] Darkmode
- [x] Responsive layout
