### PR TITLE
feat(context-menu) : enable right-click menu to pay invoices and address

### DIFF
--- a/src/app/screens/Send/index.tsx
+++ b/src/app/screens/Send/index.tsx
@@ -5,7 +5,7 @@ import IconButton from "@components/IconButton";
 import TextField from "@components/form/TextField";
 import { PopiconsChevronLeftLine } from "@popicons/react";
 import lightningPayReq from "bolt11-signet";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import QrcodeAdornment from "~/app/components/QrcodeAdornment";
@@ -18,10 +18,34 @@ function Send() {
   const { t } = useTranslation("translation", { keyPrefix: "send" });
   const { t: tCommon } = useTranslation("common");
   const location = useLocation();
+
   // location.state used to access the decoded QR coming from ScanQRCode screen
   const [invoice, setInvoice] = useState(location.state?.decodedQR || "");
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
+
+ 
+  // Extract invoice from URL parameters (if available)
+  // This is passed when a user selects "Pay with Alby" from the browser's context menu
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const invoiceParam = params.get("invoice");
+    if (invoiceParam) {
+      setInvoice(invoiceParam);
+
+      // Clear query params without reloading the page
+      params.delete("invoice");
+      const newSearch = params.toString();
+      const newUrl =
+        window.location.origin +
+        window.location.pathname +
+        (newSearch ? `?${newSearch}` : "") +
+        window.location.hash;
+
+      // Update URL in address bar without page reload
+      window.history.replaceState(null, "", newUrl);
+    }
+  }, []);
 
   function isPubKey(str: string) {
     return str.length == 66 && (str.startsWith("02") || str.startsWith("03"));

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,6 +19,9 @@
     "storage",
     "tabs",
     "unlimitedStorage",
+    "contextMenus",
+    "clipboardWrite",
+    "scripting",
     "*://*/*"
   ],
   "__chrome__permissions": [
@@ -27,7 +30,9 @@
     "scripting",
     "storage",
     "tabs",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "contextMenus",
+    "clipboardWrite"
   ],
   "__chrome__host_permissions": ["*://*/*"],
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",


### PR DESCRIPTION

### Describe the changes you have made in this PR

Hi @pavanjoshi914   This PR introduces a new context menu in the `background-script/index.ts` file, allowing users to either:

* **Pay a Bitcoin or Lightning invoice**
* **Copy the selected invoice or address**

To support this feature, the necessary permissions were added in `manifest.json`.

Additionally, I updated the **Send** screen so that it automatically sets the invoice from the URL query parameter when the page mounts.

---

### Link this PR to an issue \[optional]

Fixes *#3015* 
This solves the proposed feature I suggested in my proposal from SoB (summer of Bitcoin)

---

### Type of change

* `feat`: New feature (non-breaking change which adds functionality)

---

### Screenshots of the changes \[optional]

Right-click on a Lightning invoice, Bitcoin address, LNURL, or pubkey to bring up this menu:
![context-menu](https://github.com/user-attachments/assets/d826981d-bf31-4b20-aa59-67f2c376cc14)

Clicking **"Pay with Bitcoin or Lightning"** opens the send screen:
![send-payment-from-context-menu](https://github.com/user-attachments/assets/209b8425-c2d4-4eb2-a298-b281e8fefc35)

---

### How has this been tested?

* Tested manually in a Chromium-based browser.
* Verified that right-clicking on an invoice or address shows the context menu.
* Confirmed that clicking “Pay with Bitcoin or Lightning” opens the send screen with the invoice pre-filled.

---

### Checklist

* [x] Self-review of code changes
* [x] Manual testing completed
* [ ] Added automated tests (if applicable)
* [ ] Documentation or guides updated (if needed)
* [ ] Dark mode support (for UI changes)
* [ ] Responsive layout (for UI changes)


