### PR TITLE
chore: update @getalby/js-sdk to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.1.1",
-    "@getalby/sdk": "^5.1.0",
+    "@getalby/sdk": "^6.0.0",
     "@headlessui/react": "^1.7.18",
     "@lightninglabs/lnc-web": "^0.3.1-alpha",
     "@noble/ciphers": "^0.5.1",

--- a/src/app/components/TransactionsTable/TransactionModal.tsx
+++ b/src/app/components/TransactionsTable/TransactionModal.tsx
@@ -1,4 +1,4 @@
-import { Nip47TransactionMetadata } from "@getalby/sdk/dist/nwc";
+import type { Nip47TransactionMetadata } from "@getalby/sdk";
 import {
   PopiconsArrowDownSolid,
   PopiconsArrowUpSolid,

--- a/src/app/components/TransactionsTable/index.tsx
+++ b/src/app/components/TransactionsTable/index.tsx
@@ -1,5 +1,5 @@
 import Loading from "@components/Loading";
-import { Nip47TransactionMetadata } from "@getalby/sdk/dist/nwc";
+import type { Nip47TransactionMetadata } from "@getalby/sdk";
 import {
   PopiconsArrowDownSolid,
   PopiconsArrowUpSolid,

--- a/src/app/screens/SendToBitcoinAddress/index.tsx
+++ b/src/app/screens/SendToBitcoinAddress/index.tsx
@@ -3,7 +3,7 @@ import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import Header from "@components/Header";
 import IconButton from "@components/IconButton";
 import DualCurrencyField from "@components/form/DualCurrencyField";
-import { CreateSwapResponse } from "@getalby/sdk/dist/oauth/types";
+import type { CreateSwapResponse } from "@getalby/sdk";
 import {
   PopiconsChevronLeftLine,
   PopiconsLinkExternalSolid,

--- a/src/app/screens/connectors/ConnectAlby/index.tsx
+++ b/src/app/screens/connectors/ConnectAlby/index.tsx
@@ -1,4 +1,4 @@
-import { GetAccountInformationResponse } from "@getalby/sdk/dist/oauth/types";
+import type { GetAccountInformationResponse } from "@getalby/sdk";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -1,4 +1,4 @@
-import { GetAccountInformationResponse } from "@getalby/sdk/dist/oauth/types";
+import type { GetAccountInformationResponse } from "@getalby/sdk";
 import { nip19 } from "nostr-tools";
 import { useSettings } from "~/app/context/SettingsContext";
 import api from "~/common/lib/api";

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   CreateSwapParams,
   CreateSwapResponse,
   SwapInfoResponse,
-} from "@getalby/sdk/dist/oauth/types";
+} from "@getalby/sdk";
 import { ACCOUNT_CURRENCIES } from "~/common/constants";
 import {
   ConnectPeerArgs,

--- a/src/extension/background-script/connectors/connector.interface.ts
+++ b/src/extension/background-script/connectors/connector.interface.ts
@@ -1,9 +1,9 @@
-import { Nip47TransactionMetadata } from "@getalby/sdk/dist/nwc";
-import {
+import type {
   CreateSwapParams,
   CreateSwapResponse,
+  Nip47TransactionMetadata,
   SwapInfoResponse,
-} from "@getalby/sdk/dist/oauth/types";
+} from "@getalby/sdk";
 import { ACCOUNT_CURRENCIES } from "~/common/constants";
 import { OAuthToken } from "~/types";
 

--- a/src/extension/background-script/connectors/nwc.ts
+++ b/src/extension/background-script/connectors/nwc.ts
@@ -1,4 +1,4 @@
-import { nwc } from "@getalby/sdk";
+import { NWCClient } from "@getalby/sdk";
 import lightningPayReq from "bolt11-signet";
 import Base64 from "crypto-js/enc-base64";
 import Hex from "crypto-js/enc-hex";
@@ -42,7 +42,7 @@ interface TlvRecord {
 
 class NWCConnector implements Connector {
   config: Config;
-  nwc: nwc.NWCClient;
+  nwc: NWCClient;
 
   get supportedMethods() {
     return [
@@ -59,7 +59,7 @@ class NWCConnector implements Connector {
 
   constructor(account: Account, config: Config) {
     this.config = config;
-    this.nwc = new nwc.NWCClient({
+    this.nwc = new NWCClient({
       nostrWalletConnectUrl: this.config.nostrWalletConnectUrl,
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   CreateSwapParams,
   GetAccountInformationResponse,
-} from "@getalby/sdk/dist/oauth/types";
+} from "@getalby/sdk";
 import { PaymentRequestObject } from "bolt11-signet";
 import { Runtime } from "webextension-polyfill";
 import { ACCOUNT_CURRENCIES, CURRENCIES } from "~/common/constants";

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,18 +675,18 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.52.0.tgz#78fe5f117840f69dc4a353adf9b9cd926353378c"
   integrity sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==
 
-"@getalby/lightning-tools@^5.1.2":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@getalby/lightning-tools/-/lightning-tools-5.2.0.tgz#5f71ce9b25c04adeb7e421e920d0a28dfe32e082"
-  integrity sha512-8kBvENBTMh541VjGKhw3I29+549/C02gLSh3AQaMfoMNSZaMxfQW+7dcMcc7vbFaCKEcEe18ST5bUveTRBuXCQ==
+"@getalby/lightning-tools@^5.2.0":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@getalby/lightning-tools/-/lightning-tools-5.2.1.tgz#861f025218e3d4dc5fb8fe55a16b33c66fb93a56"
+  integrity sha512-dxOmJLJAh6qJ8rsbA5/Bwj7MSI9X3RkxxqmCedl5rfP+yKwNSdfu8i4EiCZN/tk2hNBJb8GHSCcPRNZfwfmEHg==
 
-"@getalby/sdk@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@getalby/sdk/-/sdk-5.1.0.tgz#5e54d99b7c9470425ddcca529a95718f451efe0d"
-  integrity sha512-0ijo4enzoxZinyhOMFlR4h3qTQ9I0Se+dBkefk0ja5zOcpi61ZqT86n0T+7u94l8SH6/poysFBObdtN61u+6tQ==
+"@getalby/sdk@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@getalby/sdk/-/sdk-6.0.0.tgz#3f7b4965f7113b3a75752f96f88f4347a859518c"
+  integrity sha512-ix2ZFcYwxBy3r4o11C1jC4Hwlu2s8C9pz7Y/NWYw8sSEutioPjG2e0k5Nx1nTs6luQ2LKUBFg9/6f1akZiwYcw==
   dependencies:
-    "@getalby/lightning-tools" "^5.1.2"
-    nostr-tools "2.12.0"
+    "@getalby/lightning-tools" "^5.2.0"
+    nostr-tools "2.15.0"
 
 "@headlessui/react@^1.7.18":
   version "1.7.18"
@@ -7375,10 +7375,10 @@ normalize-range@^0.1.2:
   resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
   integrity "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI= sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
 
-nostr-tools@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/nostr-tools/-/nostr-tools-2.12.0.tgz#09f270e32453611a85c3670ff86ae856f3cbd21a"
-  integrity sha512-pUWEb020gTvt1XZvTa8AKNIHWFapjsv2NKyk43Ez2nnvz6WSXsrTFE0XtkNLSRBjPn6EpxumKeNiVzLz74jNSA==
+nostr-tools@2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nostr-tools/-/nostr-tools-2.15.0.tgz#cd119006681a861cabcdcf0200d29fd9864ddab8"
+  integrity sha512-Jj/+UFbu3JbTAWP4ipPFNuyD4W5eVRBNAP+kmnoRCYp3bLmTrlQ0Qhs5O1xSQJTFpjdZqoS0zZOUKdxUdjc+pw==
   dependencies:
     "@noble/ciphers" "^0.5.1"
     "@noble/curves" "1.2.0"
@@ -7386,7 +7386,6 @@ nostr-tools@2.12.0:
     "@scure/base" "1.1.1"
     "@scure/bip32" "1.3.1"
     "@scure/bip39" "1.2.1"
-  optionalDependencies:
     nostr-wasm "0.1.0"
 
 nostr-tools@^1.17.0:


### PR DESCRIPTION
### Describe the changes you have made in this PR

Updates `@getalby/sdk` to v6.0.0 to avoid importing types from dist folder

### Type of change

- `chore`

### How has this been tested?

Tested by checking both Alby account and NWC connector (rest all are type imports which work well)

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [x] Added automated tests where applicable
- [x] Update Docs & Guides
- For UI-related changes
- [x] Darkmode (N/A)
- [x] Responsive layout (N/A)
