### PR TITLE
Fix/blink lightning address

### DIFF
--- a/src/app/screens/Receive/index.tsx
+++ b/src/app/screens/Receive/index.tsx
@@ -15,7 +15,6 @@ import QRCode from "~/app/components/QRCode";
 import SkeletonLoader from "~/app/components/SkeletonLoader";
 import toast from "~/app/components/Toast";
 import { useAccount } from "~/app/context/AccountContext";
-import { isAlbyOAuthAccount } from "~/app/utils";
 import api from "~/common/lib/api";
 import { IconLinkCard } from "../../components/IconLinkCard/IconLinkCard";
 
@@ -28,7 +27,6 @@ function Receive() {
   const [loadingLightningAddress, setLoadingLightningAddress] = useState(true);
 
   const [lightningAddress, setLightningAddress] = useState("");
-  const isAlbyOAuthUser = isAlbyOAuthAccount(auth.account?.connectorType);
 
   useEffect(() => {
     (async () => {
@@ -60,7 +58,7 @@ function Receive() {
       <div className="pt-4">
         <Container justifyBetween maxWidth="sm">
           <div className="flex flex-col gap-2 md:gap-3">
-            {isAlbyOAuthUser && (
+            {lightningAddress && (
               <div className="bg-white dark:bg-surface-01dp border-gray-200 dark:border-neutral-700 rounded border p-4 flex flex-col justify-center items-center gap-1 text-gray-800 dark:text-neutral-200">
                 <>
                   <div className="relative flex flex-grid">

--- a/src/extension/background-script/connectors/galoy.ts
+++ b/src/extension/background-script/connectors/galoy.ts
@@ -94,6 +94,9 @@ class Galoy implements Connector {
               id
               username
           }
+          globals {
+            lightningAddressDomain
+          }
         }
       `,
     };
@@ -106,9 +109,24 @@ class Galoy implements Connector {
       const alias = data.me.username
         ? data.me.username.substr(0, 10)
         : data.me.id.substr(0, 8);
+
+      let domain = data.globals?.lightningAddressDomain;
+      const username = data.me.username;
+
+      // legacy domain to blink.sv map
+      if (domain === "pay.bbw.sv") {
+        domain = "blink.sv";
+      }
+
+      let lightningAddress: string | undefined;
+      if (username && domain) {
+        lightningAddress = `${username}@${domain}`;
+      }
+
       return {
         data: {
           alias,
+          lightning_address: lightningAddress,
         },
       };
     });


### PR DESCRIPTION
Fixes #2993

## Problem
Previously, the "Receive" screen only displayed a Lightning Address QR code for Alby OAuth accounts. Blink (Galoy) wallets did not show a QR code because the `lightningAddress` was:
1. Not returned by the `Galoy` connector during setup.
2. Not persisted to `IndexedDB` in the `add` action.
3. Not exposed to the frontend via the `info` API endpoint.

### Visual Comparison

| Before Fix (Blink Wallet) | After Fix (Blink Wallet) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/36ff29f8-656a-48dc-a13c-b9558d4d885e" width="400" alt="Before Fix" /> | <img src="https://github.com/user-attachments/assets/f5869052-9cdb-4ca2-b9eb-e77219e08ec7" width="400" alt="After Fix" /> |
| *No QR code displayed* | *Lightning Address QR code is visible* |

## Solution
This PR implements a full-stack fix to persist and display the address for Galoy accounts:

### Backend / Connector
* **`src/types.ts`**: Extended `Account` interface to include `lightningAddress`.
* **`galoy.ts`**: Updated `getInfo()` to correctly derive the address (e.g., `user@blink.sv`) from the username and globals.
* **`add.ts`**: Updated account creation logic to fetch `connector.getInfo()` and persist the `lightningAddress` to storage immediately.
* **`info.ts`**: Updated the account info endpoint to bubble up the `lightningAddress` to the UI API response.

### Frontend
* **`Receive/index.tsx`**: Removed the strict `isAlbyOAuthUser` check. The component now displays the QR code for *any* account that has a valid `lightningAddress` available.

## Testing
* Verified that adding a new Blink wallet correctly saves the address to `IndexedDB` and Sync Storage.
* Verified that the Receive screen displays the QR code immediately after creation.
* Verified that refreshing the extension does not overwrite or lose the address data.