### PR TITLE
chore: drop json from eslint lint-staged

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "src/**/*.{js,jsx,ts,tsx,json}": [
+  "src/**/*.{js,jsx,ts,tsx}": [
     "eslint --fix --max-warnings 0",
     "prettier --write",
   ],


### PR DESCRIPTION
Stops lint-staged from invoking ESLint on JSON files. JSON formatting is already handled by the separate prettier rule, and the flat eslint.config.mjs has no parser/rules registered for *.json, so feeding it JSON only produced noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to refine how source files are processed during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->