### PR TITLE
fix: require current password before changing password

### DIFF
--- a/src/app/screens/Settings/index.tsx
+++ b/src/app/screens/Settings/index.tsx
@@ -35,6 +35,7 @@ function Settings() {
 
   function closeModal() {
     setModalIsOpen(false);
+    setFormData(initialFormData);
   }
 
   async function updateAccountPassword() {
@@ -46,7 +47,6 @@ function Settings() {
 
       toast.success(t("change_password.success"));
       closeModal();
-      setFormData(initialFormData);
     } catch (e) {
       console.error(e);
       if (e instanceof Error)
@@ -335,10 +335,11 @@ function Settings() {
                     type="password"
                     label={t("change_password.current_password.label")}
                     required
+                    value={formData.currentPassword}
                     onChange={(e) => {
                       setFormData({
                         ...formData,
-                        currentPassword: e.target.value.trim(),
+                        currentPassword: e.target.value,
                       });
                     }}
                   />

--- a/src/app/screens/Settings/index.tsx
+++ b/src/app/screens/Settings/index.tsx
@@ -4,6 +4,7 @@ import LocaleSwitcher from "@components/LocaleSwitcher/LocaleSwitcher";
 import PasswordForm from "@components/PasswordForm";
 import Setting from "@components/Setting";
 import Input from "@components/form/Input";
+import TextField from "@components/form/TextField";
 import Select from "@components/form/Select";
 import Toggle from "@components/form/Toggle";
 import { Html5Qrcode } from "html5-qrcode";
@@ -17,6 +18,7 @@ import { CURRENCIES } from "~/common/constants";
 import msg from "~/common/lib/msg";
 
 const initialFormData = {
+  currentPassword: "",
   password: "",
   passwordConfirmation: "",
 };
@@ -35,18 +37,20 @@ function Settings() {
     setModalIsOpen(false);
   }
 
-  async function updateAccountPassword(password: string) {
+  async function updateAccountPassword() {
     try {
       await msg.request("changePassword", {
+        currentPassword: formData.currentPassword,
         password: formData.password,
       });
 
       toast.success(t("change_password.success"));
       closeModal();
+      setFormData(initialFormData);
     } catch (e) {
       console.error(e);
       if (e instanceof Error)
-        toast.error(`An unexpected error occurred: ${e.message}`);
+        toast.error(e.message);
     }
   }
 
@@ -322,9 +326,24 @@ function Settings() {
               <form
                 onSubmit={(e: FormEvent) => {
                   e.preventDefault();
-                  updateAccountPassword(formData.password);
+                  updateAccountPassword();
                 }}
               >
+                <div className="w-full mt-8">
+                  <TextField
+                    id="currentPassword"
+                    type="password"
+                    label={t("change_password.current_password.label")}
+                    required
+                    onChange={(e) => {
+                      setFormData({
+                        ...formData,
+                        currentPassword: e.target.value.trim(),
+                      });
+                    }}
+                  />
+                </div>
+
                 <PasswordForm
                   i18nKeyPrefix="settings.change_password"
                   formData={formData}
@@ -337,6 +356,7 @@ function Settings() {
                     type="submit"
                     primary
                     disabled={
+                      !formData.currentPassword ||
                       !formData.password ||
                       formData.password !== formData.passwordConfirmation
                     }

--- a/src/extension/background-script/actions/settings/changePassword.ts
+++ b/src/extension/background-script/actions/settings/changePassword.ts
@@ -28,7 +28,8 @@ const changePassword = async (message: MessageChangePassword) => {
 
   const tmpAccounts = { ...accounts };
 
-  for (const accountId in tmpAccounts) {
+  for (const accountId in accounts) {
+    tmpAccounts[accountId] = { ...accounts[accountId] };
     const accountConfig = decryptData(
       accounts[accountId].config as string,
       currentPassword

--- a/src/extension/background-script/actions/settings/changePassword.ts
+++ b/src/extension/background-script/actions/settings/changePassword.ts
@@ -1,19 +1,37 @@
 import { decryptData, encryptData } from "~/common/lib/crypto";
-import type { Message } from "~/types";
+import type { MessageChangePassword } from "~/types";
 
 import state from "../../state";
 
-const changePassword = async (message: Message) => {
+const changePassword = async (message: MessageChangePassword) => {
+  const { currentPassword, password: newPassword } = message.args;
+
+  if (typeof currentPassword !== "string" || currentPassword === "") {
+    return { error: "Current password is missing" };
+  }
+
+  if (typeof newPassword !== "string" || newPassword === "") {
+    return { error: "New password is missing" };
+  }
+
   const accounts = state.getState().accounts;
-  const password = await state.getState().password();
-  if (!password) return { error: "Password is missing" };
-  const newPassword = message.args.password as string;
+  const accountIds = Object.keys(accounts);
+
+  if (accountIds.length > 0) {
+    // Verify current password by attempting to decrypt an account config
+    try {
+      decryptData(accounts[accountIds[0]].config as string, currentPassword);
+    } catch (e) {
+      return { error: "Invalid current password" };
+    }
+  }
+
   const tmpAccounts = { ...accounts };
 
   for (const accountId in tmpAccounts) {
     const accountConfig = decryptData(
       accounts[accountId].config as string,
-      password
+      currentPassword
     );
     tmpAccounts[accountId].config = encryptData(accountConfig, newPassword);
 
@@ -21,7 +39,7 @@ const changePassword = async (message: Message) => {
     if (accounts[accountId].nostrPrivateKey) {
       const accountNostrKey = decryptData(
         accounts[accountId].nostrPrivateKey as string,
-        password
+        currentPassword
       );
       tmpAccounts[accountId].nostrPrivateKey = encryptData(
         accountNostrKey,
@@ -33,7 +51,7 @@ const changePassword = async (message: Message) => {
     if (accounts[accountId].mnemonic) {
       const accountMnemonic = decryptData(
         accounts[accountId].mnemonic as string,
-        password
+        currentPassword
       );
       tmpAccounts[accountId].mnemonic = encryptData(
         accountMnemonic,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -654,6 +654,9 @@
         "title": "Change Unlock Passcode",
         "subtitle": "",
         "screen_reader": "Change Unlock Passcode",
+        "current_password": {
+          "label": "Current unlock passcode:"
+        },
         "choose_password": {
           "label": "Enter a new unlock passcode:"
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -441,6 +441,14 @@ export interface MessageSetPassword extends MessageDefault {
   action: "setPassword";
 }
 
+export interface MessageChangePassword extends MessageDefault {
+  args: {
+    currentPassword: string;
+    password: string;
+  };
+  action: "changePassword";
+}
+
 export interface MessageAccountValidate extends MessageDefault {
   args: {
     connector: ConnectorType;


### PR DESCRIPTION
### Describe the changes you have made in this PR

Require the user to enter their current password before allowing a password change. Previously, anyone with access to an unlocked extension could change the password without re-authentication.

The fix decrypts the stored account config with the provided current password (same pattern used in `unlock.ts`) before accepting the new password.

### Link this PR to an issue

Fixes #2865

### Type of change

- `fix`: Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

- `yarn tsc:compile` — 0 errors
- `yarn lint:js` — 0 errors, 0 warnings
- `yarn test:unit` — all 75 suites / 168 tests pass
- Manual testing: verified the password change flow works end-to-end with correct current password, and rejects incorrect current passwords

### Checklist

- [x] Self-review of changed code
- [x] Manual testing
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides
- For UI-related changes
- [x] Darkmode
- [x] Responsive layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “current password” field to the change-password flow.
  * Password updates now require both your current password and the new password.
* **Bug Fixes**
  * Improved validation and clearer error messaging when the current password is incorrect or required fields are missing.
  * The submit button is disabled until the current password is provided.
  * After a successful password change, the modal resets automatically.
* **Documentation**
  * Added a new localized label for the current password field in Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->