### PR TITLE
fix: probe Blink/Galoy route fee before payment to avoid max fee reserve

### DIFF
--- a/src/extension/background-script/connectors/galoy.test.ts
+++ b/src/extension/background-script/connectors/galoy.test.ts
@@ -1,0 +1,156 @@
+import { Account } from "~/types";
+
+// getCurrencyRate pulls in background-script state, which re-imports the
+// connectors index and creates an import cycle when galoy.ts is the entry
+// module of the test. It is only used by getTransactions/getBalance (not the
+// send path under test), so mock it to break the cycle.
+jest.mock(
+  "~/extension/background-script/actions/cache/getCurrencyRate",
+  () => ({
+    getCurrencyRateWithCache: jest.fn().mockResolvedValue(1),
+  })
+);
+
+import Galoy from "./galoy";
+
+const BLINK_URL = "https://api.blink.sv/graphql";
+
+// A real amount-carrying mainnet invoice (1 sat) used only for decoding.
+const AMOUNT_INVOICE_1SAT =
+  "lnbc10n1pjn9nmzpp5a7znt4tv9gy5v6342xrgnntltkljffp255dph40vaf6964j27pvqhp59ly2g7flsy97vqahh9yue8qz7u6tvlpjfh9r0m9nzfezhm6fgmqscqzzsxqzursp55l9zht4zya3jyjdr9khr22z6afvjqdcw06l7vyd6tksdtsc8ezqs9qyyssqwswp9dnz9txv8t8zjrrts9rv4agu40ufqc04434f6lszdwvlhjk45m3pdcpqzghswkrcvgeaztcr6h82xp35suu64hnk4ms929pcahgpfg7sza";
+
+// A zero-amount mainnet invoice (BOLT11 spec donation vector — no amount encoded).
+const ZERO_AMOUNT_INVOICE =
+  "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
+
+function makeGaloy(currency: "BTC" | "USD") {
+  const account = {} as Account;
+  return new Galoy(account, {
+    walletId: "wallet-123",
+    url: BLINK_URL,
+    currency,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-API-KEY": "blink_test",
+    },
+    apiCompatibilityMode: false,
+  });
+}
+
+/**
+ * Spies on the connector's GraphQL transport (`request`) and records the
+ * sequence of GraphQL operations it receives, returning canned responses for
+ * the fee probe and the payment send so `sendPayment` can complete. This avoids
+ * depending on the axios "fetch" adapter, which is not available under jsdom.
+ */
+function interceptBlink(
+  galoy: Galoy,
+  options?: { probeReturnsError?: boolean }
+) {
+  const operations: string[] = [];
+
+  jest
+    .spyOn(
+      galoy as unknown as {
+        request: (q: { query: string }) => Promise<unknown>;
+      },
+      "request"
+    )
+    .mockImplementation(async (q: { query: string }) => {
+      const query = q.query || "";
+
+      if (query.includes("lnInvoiceFeeProbe")) {
+        operations.push("lnInvoiceFeeProbe");
+        return {
+          data: {
+            lnInvoiceFeeProbe: {
+              amount: options?.probeReturnsError ? null : 1,
+              errors: options?.probeReturnsError
+                ? [{ message: "Invoice must be a zero-amount invoice" }]
+                : [],
+            },
+          },
+        };
+      }
+
+      if (query.includes("lnUsdInvoiceFeeProbe")) {
+        operations.push("lnUsdInvoiceFeeProbe");
+        return {
+          data: {
+            lnUsdInvoiceFeeProbe: {
+              amount: options?.probeReturnsError ? null : 1,
+              errors: options?.probeReturnsError
+                ? [{ message: "Invoice must be a zero-amount invoice" }]
+                : [],
+            },
+          },
+        };
+      }
+
+      if (query.includes("lnInvoicePaymentSend")) {
+        operations.push("lnInvoicePaymentSend");
+        return {
+          data: {
+            lnInvoicePaymentSend: {
+              status: "SUCCESS",
+              errors: [],
+              transaction: {
+                settlementVia: { preImage: "a".repeat(64) },
+              },
+            },
+          },
+        };
+      }
+
+      operations.push("UNKNOWN");
+      return { data: {} };
+    });
+
+  return operations;
+}
+
+describe("Galoy/Blink fee probe", () => {
+  test("probes with lnInvoiceFeeProbe before payment for a BTC amount invoice", async () => {
+    const galoy = makeGaloy("BTC");
+    const operations = interceptBlink(galoy);
+
+    await galoy.sendPayment({ paymentRequest: AMOUNT_INVOICE_1SAT });
+
+    expect(operations).toEqual(["lnInvoiceFeeProbe", "lnInvoicePaymentSend"]);
+  });
+
+  test("probes with lnUsdInvoiceFeeProbe before payment for a USD amount invoice", async () => {
+    const galoy = makeGaloy("USD");
+    const operations = interceptBlink(galoy);
+
+    await galoy.sendPayment({ paymentRequest: AMOUNT_INVOICE_1SAT });
+
+    expect(operations).toEqual([
+      "lnUsdInvoiceFeeProbe",
+      "lnInvoicePaymentSend",
+    ]);
+  });
+
+  test("does not probe a zero-amount invoice", async () => {
+    const galoy = makeGaloy("BTC");
+    const operations = interceptBlink(galoy);
+
+    await galoy.sendPayment({ paymentRequest: ZERO_AMOUNT_INVOICE });
+
+    expect(operations).toEqual(["lnInvoicePaymentSend"]);
+  });
+
+  test("still pays when the fee probe returns an error (never reject)", async () => {
+    const galoy = makeGaloy("BTC");
+    const operations = interceptBlink(galoy, { probeReturnsError: true });
+
+    const result = await galoy.sendPayment({
+      paymentRequest: AMOUNT_INVOICE_1SAT,
+    });
+
+    // Probe was attempted, then the payment still went through.
+    expect(operations).toEqual(["lnInvoiceFeeProbe", "lnInvoicePaymentSend"]);
+    expect(result.data.preimage).toBe("a".repeat(64));
+  });
+});

--- a/src/extension/background-script/connectors/galoy.ts
+++ b/src/extension/background-script/connectors/galoy.ts
@@ -338,6 +338,58 @@ class Galoy implements Connector {
     });
   }
 
+  /**
+   * Probe the route for the fee of an amount-carrying lightning invoice.
+   *
+   * Blink caches the probed route on its backend so that the subsequent
+   * `lnInvoicePaymentSend` settles with the exact fee instead of Blink's max
+   * fee reserve (which otherwise overcharges e.g. 10 sats on a small payment).
+   *
+   * This is best-effort: any failure (GraphQL error or network) is logged and
+   * swallowed so the payment still proceeds. Only amount-carrying invoices are
+   * probed; zero-amount invoices carry no amount to probe with here.
+   */
+  async feeProbe(paymentRequest: string): Promise<void> {
+    const isUSD = this.config.currency === "USD";
+    const mutationName = isUSD ? "lnUsdInvoiceFeeProbe" : "lnInvoiceFeeProbe";
+    const inputTypeName = isUSD
+      ? "LnUsdInvoiceFeeProbeInput"
+      : "LnInvoiceFeeProbeInput";
+
+    const query = {
+      query: `
+        mutation ${mutationName}($input: ${inputTypeName}!) {
+          ${mutationName}(input: $input) {
+            amount
+            errors {
+              message
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          walletId: this.config.walletId,
+          paymentRequest,
+        },
+      },
+    };
+
+    try {
+      const { data, errors } = await this.request(query);
+      const errs = errors || data?.[mutationName]?.errors;
+      if (errs && errs.length) {
+        console.warn(
+          `Galoy/Blink fee probe failed ('${
+            errs[0].message || JSON.stringify(errs)
+          }'), paying without probe.`
+        );
+      }
+    } catch (e) {
+      console.warn("Galoy/Blink fee probe errored, paying without probe.", e);
+    }
+  }
+
   async sendPayment(args: SendPaymentArgs): Promise<SendPaymentResponse> {
     const query = {
       query: `
@@ -380,6 +432,13 @@ class Galoy implements Connector {
     const paymentRequestDetails = lightningPayReq.decode(args.paymentRequest);
     const amountInSats = paymentRequestDetails.satoshis || 0;
     const paymentHash = paymentRequestDetails.tagsObject.payment_hash || "";
+
+    // Probe amount invoices first so Blink caches the route and settles at the
+    // exact fee instead of its max fee reserve. Zero-amount invoices carry no
+    // amount to probe with here, so they are paid as-is (best-effort, no reject).
+    if (amountInSats > 0) {
+      await this.feeProbe(args.paymentRequest);
+    }
 
     return this.request(query).then(({ data, errors }) => {
       const errs = errors || data.lnInvoicePaymentSend.errors;


### PR DESCRIPTION
## Problem

When paying a Lightning invoice through a **Blink** account (which uses the **Galoy** connector), the extension always overpaid the routing fee — Blink applied its **max fee reserve** (e.g. **10 sats** on a small payment) instead of the exact fee (~1 sat).

Root cause: `Galoy.sendPayment` sends `lnInvoicePaymentSend` with **no fee probe** beforehand. Without a probe, Blink cannot cache a route and falls back to its max fee reserve. (The Blink mobile app probes first, which is why it settles at ~1 sat for the same payment.)

This is the same class of issue recently fixed in LNbits and the BTCPayServer Blink plugin.

## Fix

Add a fee probe before the payment in `galoy.ts`, for amount-carrying invoices, so Blink caches the route and the subsequent `lnInvoicePaymentSend` settles at the **exact fee**.

- **BTC** wallets probe via `lnInvoiceFeeProbe`; **USD** wallets via `lnUsdInvoiceFeeProbe` (both return `SatAmountPayload { amount, errors }`).
- **Zero-amount invoices** are paid as-is — `sendPayment` receives no explicit amount, so there is nothing to probe with.
- **Best-effort / never rejects:** a probe error (GraphQL or network) is logged and the payment still proceeds, preserving the connector's existing always-pays behavior. No fee-limit enforcement is added (the connector interface carries no fee limit).
- No change to the `sendPayment` response shape (`total_fees` stays as-is).

## Tests

New `galoy.test.ts` covers:
- amount invoice + BTC → `lnInvoiceFeeProbe` issued **before** `lnInvoicePaymentSend`
- amount invoice + USD → `lnUsdInvoiceFeeProbe` issued before send
- zero-amount invoice → no probe
- probe returning an error → payment still proceeds

## Validation

- `yarn test:unit` — full suite green (incl. the 4 new tests); `yarn lint` clean.
- **Live probe** against `api.blink.sv` for BTC and USD wallets → both returned a **1‑sat** probed fee, no errors.
- **Live end‑to‑end payments** through the real connector code path:
  - BTC: paid a 50‑sat invoice → settled `settlementFee` = **1 sat**
  - USD: paid a 55‑sat invoice → settled `settlementFee` = **1 sat**
  
  (Previously these would settle at the ~10‑sat max fee reserve.)

## Scope

Only `src/extension/background-script/connectors/galoy.ts` (+ colocated test). Affects Blink / Bitcoin Jungle / other Galoy‑based accounts that pay via this connector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fee checks before sending non-zero Lightning payments.
  * Supports fee checks for both BTC- and USD-denominated invoices.
  * Payments continue normally if a fee check fails.
  * Zero-amount invoices skip the fee check for faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->