### PR TITLE
chore: drop the webpack bundle analyzer report

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:firefox": "NODE_ENV=production ALBY_API_URL=https://api.getalby.com TARGET_BROWSER=firefox webpack",
     "build:opera": "NODE_ENV=production ALBY_API_URL=https://api.getalby.com TARGET_BROWSER=opera webpack",
     "build": "yarn build:chrome && yarn build:firefox && yarn build:opera",
+    "analyze": "yarn build:chrome --json=dist/stats.json --stats detailed && webpack-bundle-analyzer dist/stats.json dist/production/chrome -m static -r dist/bundle-report.html -O",
     "package": "./create-packages.sh",
     "lint": "yarn lint:js && yarn tsc:compile && yarn format:fix",
     "lint:js": "eslint src --max-warnings 0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,8 +10,6 @@ const WextManifestWebpackPlugin = require("wext-manifest-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const ProviderInjectionPlugin = require("./build-utils/ProviderInjectionPlugin");
-const BundleAnalyzerPlugin =
-  require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 
 if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = "development";
@@ -251,13 +249,6 @@ var options = {
     // copy static assets
     new CopyWebpackPlugin({
       patterns: [{ from: "static/assets", to: "assets" }],
-    }),
-    new BundleAnalyzerPlugin({
-      generateStatsFile: nodeEnv !== "development" ? true : false,
-      analyzerMode: nodeEnv !== "development" ? "static" : "disabled",
-      reportFilename: "../bundle-report.html",
-      statsFilename: "../bundle-stats.json",
-      openAnalyzer: nodeEnv !== "development",
     }),
   ],
 };


### PR DESCRIPTION
Every production build wrote `bundle-report.html` and `bundle-stats.json`, and opened the report in a browser window. Nothing in the repo reads either file — no CI job, no script, no docs — so the plugin is removed.

Production builds are ~13% faster as a result (73.5s → 63.9s locally) and no longer pop a browser window.

The report is still available on demand:

```bash
yarn analyze
```

That builds with stats and writes `dist/bundle-report.html` (plus `dist/stats.json`), without opening anything. Both land in `dist/`, which is already gitignored. Drop `-O` from the script if you would rather it open in a browser.

`webpack-bundle-analyzer` stays in devDependencies, since the script still uses it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an analysis command that generates detailed production build statistics and a static bundle report for troubleshooting and performance review.

- **Chores**
  - Removed the automatic bundle analyzer configuration from standard builds, keeping regular production builds focused and streamlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->