### PR TITLE
fix: scope webln.request permissions and account for the requests that move funds

### DIFF
--- a/src/app/screens/ConfirmRequestPermission/index.tsx
+++ b/src/app/screens/ConfirmRequestPermission/index.tsx
@@ -1,3 +1,4 @@
+import Alert from "@components/Alert";
 import ConfirmOrCancel from "@components/ConfirmOrCancel";
 import Container from "@components/Container";
 import PublisherCard from "@components/PublisherCard";
@@ -5,6 +6,7 @@ import Checkbox from "@components/form/Checkbox";
 import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ScreenHeader from "~/app/components/ScreenHeader";
+import { useSettings } from "~/app/context/SettingsContext";
 import { useNavigationState } from "~/app/hooks/useNavigationState";
 import { USER_REJECTED_ERROR } from "~/common/constants";
 import msg from "~/common/lib/msg";
@@ -18,11 +20,15 @@ const ConfirmRequestPermission: FC = () => {
   });
   const { t: tCommon } = useTranslation("common");
   const { t: tPermissions } = useTranslation("permissions");
+  const { getFormattedSats } = useSettings();
 
   const navState = useNavigationState();
   const origin = navState.origin as OriginData;
   const requestMethod = navState.args?.requestPermission?.method;
   const description = navState.args?.requestPermission?.description;
+  const isFundMoving = navState.args?.requestPermission?.isFundMoving;
+  const amount = navState.args?.requestPermission?.amount;
+  const destination = navState.args?.requestPermission?.destination;
 
   const enable = () => {
     msg.reply({
@@ -64,24 +70,41 @@ const ConfirmRequestPermission: FC = () => {
                     )}
                   </p>
                 )}
+                {amount !== undefined && (
+                  <p className="mt-2 text-sm text-gray-700 dark:text-neutral-400">
+                    {t("amount", { amount: getFormattedSats(amount) })}
+                  </p>
+                )}
+                {destination && (
+                  <p className="text-sm break-all text-gray-700 dark:text-neutral-400">
+                    {t("destination", { destination })}
+                  </p>
+                )}
               </div>
+              {isFundMoving && (
+                <Alert type="warn">
+                  <p className="text-sm">{t("fund_moving_warning")}</p>
+                </Alert>
+              )}
             </div>
           </div>
           <div className="text-center flex flex-col">
-            <div className="flex items-center mb-4">
-              <Checkbox
-                id="always_allow"
-                name="always_allow"
-                checked={alwaysAllow}
-                onChange={() => setAlwaysAllow((prev) => !prev)}
-              />
-              <label
-                htmlFor="always_allow"
-                className="cursor-pointer pl-2 block text-sm text-gray-900 font-medium dark:text-white"
-              >
-                {t("always_allow")}
-              </label>
-            </div>
+            {!isFundMoving && (
+              <div className="flex items-center mb-4">
+                <Checkbox
+                  id="always_allow"
+                  name="always_allow"
+                  checked={alwaysAllow}
+                  onChange={() => setAlwaysAllow((prev) => !prev)}
+                />
+                <label
+                  htmlFor="always_allow"
+                  className="cursor-pointer pl-2 block text-sm text-gray-900 font-medium dark:text-white"
+                >
+                  {t("always_allow")}
+                </label>
+              </div>
+            )}
             <ConfirmOrCancel
               label={tCommon("actions.confirm")}
               onCancel={reject}

--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -1,12 +1,14 @@
 import utils from "~/common/lib/utils";
 import type Connector from "~/extension/background-script/connectors/connector.interface";
 import db from "~/extension/background-script/db";
+import * as events from "~/extension/background-script/events";
 import type { MessageGenericRequest, OriginData } from "~/types";
 
 import request from "../request";
 
 // suppress console logs when running tests
 console.error = jest.fn();
+console.info = jest.fn();
 
 jest.mock("~/common/lib/utils", () => ({
   openPrompt: jest.fn(() => Promise.resolve({ data: {} })),
@@ -22,11 +24,13 @@ jest.mock("~/extension/background-script/state", () => ({
   getState: () => ({
     getConnector: jest.fn(() => Promise.resolve(new ConnectorClass())),
     currentAccountId: "8b7f1dc6-ab87-4c6c-bca5-19fa8632731e",
+    settings: { browserNotifications: false },
   }),
 }));
 
 const allowanceInDB = {
   enabled: true,
+  enabledFor: ["webln"],
   host: "getalby.com",
   id: 1,
   imageURL: "https://getalby.com/favicon.ico",
@@ -73,6 +77,45 @@ const fullConnector = {
   ],
 } as unknown as Connector;
 
+// the response of the node for a "sendtoroute" call
+const sendToRouteResponse = {
+  data: {
+    payment_preimage: "preimage",
+    payment_hash: "hash",
+    payment_route: { total_amt: "120", total_fees: "20" },
+  },
+};
+
+const sendToRouteConnector = {
+  // hacky fix because Jest doesn't return constructor name
+  constructor: {
+    name: "lnd",
+  },
+  requestMethod: jest.fn(() => Promise.resolve(sendToRouteResponse)),
+  supportedMethods: ["request.sendtoroute"],
+} as unknown as Connector;
+
+const sendToRouteMessage: MessageGenericRequest = {
+  action: "request",
+  origin: { host: allowanceInDB.host } as OriginData,
+  args: {
+    method: "sendtoroute",
+    params: {
+      payment_hash: "hash",
+      route: {
+        total_amt: "120",
+        total_fees: "20",
+        hops: [{ pub_key: "first-hop" }, { pub_key: "destination" }],
+      },
+    },
+  },
+};
+
+const sendToRoutePermissionInDB = {
+  ...permissionInDB,
+  method: "webln/lnd/sendtoroute",
+};
+
 // prepare DB with allowance
 db.allowances.bulkAdd([allowanceInDB]);
 
@@ -81,6 +124,10 @@ afterEach(async () => {
   jest.clearAllMocks();
   // ensure a clear permission table in DB
   await db.permissions.clear();
+  // restore the allowance, tests may have changed or debited it
+  await db.allowances.clear();
+  await db.allowances.add({ ...allowanceInDB });
+  await db.payments.clear();
   // set a default connector if overwritten in a previous test
   connector = fullConnector;
 });
@@ -360,6 +407,124 @@ describe("ln request", () => {
       ).toBeUndefined();
 
       expect(result).toStrictEqual(requestResponse);
+    });
+  });
+
+  describe("requires the host to be enabled for WebLN", () => {
+    test("throws if the allowance is disabled", async () => {
+      await db.allowances.update(allowanceInDB.id, { enabled: false });
+
+      const result = await request(message);
+
+      expect(connector.requestMethod).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        error: "WebLN is not enabled for this host",
+      });
+    });
+
+    test("throws if the allowance is only enabled for another provider", async () => {
+      await db.allowances.update(allowanceInDB.id, { enabledFor: ["nostr"] });
+
+      const result = await request(message);
+
+      expect(connector.requestMethod).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        error: "WebLN is not enabled for this host",
+      });
+    });
+  });
+
+  describe("on a request that moves funds", () => {
+    beforeEach(() => {
+      connector = sendToRouteConnector;
+    });
+
+    test("prompts the user even if a permission exists", async () => {
+      await db.permissions.bulkAdd([sendToRoutePermissionInDB]);
+
+      const result = await request(sendToRouteMessage);
+
+      expect(utils.openPrompt).toHaveBeenCalledWith({
+        args: {
+          requestPermission: {
+            method: "sendtoroute",
+            description: "lnd.sendtoroute",
+            isFundMoving: true,
+            amount: 120,
+            destination: "destination",
+          },
+        },
+        origin: sendToRouteMessage.origin,
+        action: "public/confirmRequestPermission",
+      });
+      expect(result).toStrictEqual(sendToRouteResponse);
+    });
+
+    test("does not save the permission if enabled 'true'", async () => {
+      (utils.openPrompt as jest.Mock).mockResolvedValueOnce({
+        data: { enabled: true, blocked: false },
+      });
+
+      await request(sendToRouteMessage);
+
+      expect(await db.permissions.toArray()).toHaveLength(0);
+    });
+
+    test("throws before calling requestMethod if the budget is not sufficient", async () => {
+      await db.allowances.update(allowanceInDB.id, { remainingBudget: 100 });
+
+      const result = await request(sendToRouteMessage);
+
+      expect(connector.requestMethod).not.toHaveBeenCalled();
+      expect(utils.openPrompt).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        error: "The budget of this website is not sufficient",
+      });
+    });
+
+    test("throws before calling requestMethod if the amount can not be read", async () => {
+      const messageWithoutAmount = {
+        ...sendToRouteMessage,
+        args: {
+          ...sendToRouteMessage.args,
+          params: { route: { hops: [] } },
+        },
+      };
+
+      const result = await request(messageWithoutAmount);
+
+      expect(connector.requestMethod).not.toHaveBeenCalled();
+      expect(utils.openPrompt).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        error: "Could not determine the amount of this request",
+      });
+    });
+
+    test("debits the budget and persists the payment", async () => {
+      events.subscribe();
+
+      const result = await request(sendToRouteMessage);
+      // the payment is published, give the subscribers time to run
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(result).toStrictEqual(sendToRouteResponse);
+
+      const allowance = await db.allowances.get(allowanceInDB.id);
+      // 120 sats sent, 20 of which are routing fees
+      expect(allowance?.remainingBudget).toBe(400);
+
+      const payments = await db.payments.toArray();
+      expect(payments).toHaveLength(1);
+      expect(payments[0]).toEqual(
+        expect.objectContaining({
+          host: allowanceInDB.host,
+          totalAmount: 100,
+          totalFees: 20,
+          preimage: "preimage",
+          paymentHash: "hash",
+          destination: "destination",
+        })
+      );
     });
   });
 });

--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -23,6 +23,7 @@ const ConnectorClass = jest.fn().mockImplementation(() => {
 jest.mock("~/extension/background-script/state", () => ({
   getState: () => ({
     getConnector: jest.fn(() => Promise.resolve(new ConnectorClass())),
+    getAccount: jest.fn(() => ({ connector: "lnd" })),
     currentAccountId: "8b7f1dc6-ab87-4c6c-bca5-19fa8632731e",
     settings: { browserNotifications: false },
   }),
@@ -526,5 +527,23 @@ describe("ln request", () => {
         })
       );
     });
+  });
+
+  test("calls requestMethod on the connector", async () => {
+    // the connectors implement requestMethod as a class method that calls other
+    // methods on themselves, so it has to keep its receiver
+    class TestConnector {
+      supportedMethods = ["request.listchannels"];
+      private channels = { channels: [] };
+
+      requestMethod() {
+        return Promise.resolve({ data: this.channels });
+      }
+    }
+    connector = new TestConnector() as unknown as Connector;
+
+    const result = await request(message);
+
+    expect(result).toStrictEqual({ data: { channels: [] } });
   });
 });

--- a/src/extension/background-script/actions/ln/__tests__/request.test.ts
+++ b/src/extension/background-script/actions/ln/__tests__/request.test.ts
@@ -11,6 +11,7 @@ console.error = jest.fn();
 console.info = jest.fn();
 
 jest.mock("~/common/lib/utils", () => ({
+  ...jest.requireActual("~/common/lib/utils").default,
   openPrompt: jest.fn(() => Promise.resolve({ data: {} })),
 }));
 
@@ -79,10 +80,11 @@ const fullConnector = {
 } as unknown as Connector;
 
 // the response of the node for a "sendtoroute" call
+// the node returns the preimage and the hash as base64 encoded bytes
 const sendToRouteResponse = {
   data: {
-    payment_preimage: "preimage",
-    payment_hash: "hash",
+    payment_preimage: "jxzysJs=",
+    payment_hash: "jxzysA==",
     payment_route: { total_amt: "120", total_fees: "20" },
   },
 };
@@ -471,25 +473,64 @@ describe("ln request", () => {
       expect(await db.permissions.toArray()).toHaveLength(0);
     });
 
-    test("throws before calling requestMethod if the budget is not sufficient", async () => {
-      await db.allowances.update(allowanceInDB.id, { remainingBudget: 100 });
-
-      const result = await request(sendToRouteMessage);
-
-      expect(connector.requestMethod).not.toHaveBeenCalled();
-      expect(utils.openPrompt).not.toHaveBeenCalled();
-      expect(result).toStrictEqual({
-        error: "The budget of this website is not sufficient",
-      });
-    });
-
-    test("throws before calling requestMethod if the amount can not be read", async () => {
-      const messageWithoutAmount = {
+    test("confirms the amount the node reads, not the deprecated one", async () => {
+      // the node takes the amount from the millisatoshi field and ignores
+      // total_amt when both are set
+      const messageWithMsatAmount = {
         ...sendToRouteMessage,
         args: {
           ...sendToRouteMessage.args,
-          params: { route: { hops: [] } },
+          params: {
+            route: { total_amt: "0", total_amt_msat: "500000", hops: [] },
+          },
         },
+      };
+
+      await request(messageWithMsatAmount);
+
+      expect(utils.openPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: {
+            requestPermission: expect.objectContaining({ amount: 500 }),
+          },
+        })
+      );
+    });
+
+    test("confirms the size of a channel it is asked to open", async () => {
+      connector = {
+        ...sendToRouteConnector,
+        supportedMethods: ["request.openchannel"],
+      } as unknown as Connector;
+
+      await request({
+        ...sendToRouteMessage,
+        args: {
+          method: "openchannel",
+          params: { local_funding_amount: "250000", node_pubkey: "abc" },
+        },
+      } as MessageGenericRequest);
+
+      expect(utils.openPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: {
+            requestPermission: expect.objectContaining({
+              isFundMoving: true,
+              amount: 250000,
+            }),
+          },
+        })
+      );
+    });
+
+    test.each([
+      ["no amount at all", { route: { hops: [] } }],
+      ["an amount of zero", { route: { total_amt: "0", hops: [] } }],
+      ["an empty amount", { route: { total_amt: "", hops: [] } }],
+    ])("throws before calling requestMethod with %s", async (_name, params) => {
+      const messageWithoutAmount = {
+        ...sendToRouteMessage,
+        args: { ...sendToRouteMessage.args, params },
       };
 
       const result = await request(messageWithoutAmount);
@@ -521,8 +562,8 @@ describe("ln request", () => {
           host: allowanceInDB.host,
           totalAmount: 100,
           totalFees: 20,
-          preimage: "preimage",
-          paymentHash: "hash",
+          preimage: "8f1cf2b09b",
+          paymentHash: "8f1cf2b0",
           destination: "destination",
         })
       );

--- a/src/extension/background-script/actions/ln/request.ts
+++ b/src/extension/background-script/actions/ln/request.ts
@@ -1,4 +1,6 @@
+import pubsub from "~/common/lib/pubsub";
 import utils from "~/common/lib/utils";
+import { isFundMovingRequestMethod } from "~/extension/background-script/connectors/connector.interface";
 import {
   addPermissionFor,
   hasPermissionFor,
@@ -9,6 +11,109 @@ import db from "../../db";
 import state from "../../state";
 
 const WEBLN_PREFIX = "webln/";
+
+// the request method that sends a payment and therefore has to be accounted
+// for in the allowance budget of the host
+const SEND_TO_ROUTE = "sendtoroute";
+
+// LND returns int64 values as strings, LNC returns them as numbers. Both the
+// REST and the LNC API are called with the parameters the website provides, so
+// the keys can be in snake_case or in camelCase.
+const readAmount = (
+  values: Record<string, unknown>,
+  keys: string[],
+  divisor = 1
+): number | undefined => {
+  for (const key of keys) {
+    const value = values[key];
+    if (typeof value !== "string" && typeof value !== "number") {
+      continue;
+    }
+    const amount = Number(value);
+    if (Number.isFinite(amount) && amount >= 0) {
+      return Math.ceil(amount / divisor);
+    }
+  }
+};
+
+// the amount that leaves the wallet is the total amount of the route the
+// website asks the node to send along. It includes the routing fees.
+const getSendToRouteAmount = (params: Record<string, unknown>): number => {
+  const route = params?.route;
+  if (!route || typeof route !== "object") {
+    throw new Error("Could not determine the amount of this request");
+  }
+
+  const routeValues = route as Record<string, unknown>;
+  const amount =
+    readAmount(routeValues, ["total_amt", "totalAmt"]) ??
+    readAmount(routeValues, ["total_amt_msat", "totalAmtMsat"], 1000);
+
+  if (amount === undefined) {
+    throw new Error("Could not determine the amount of this request");
+  }
+  return amount;
+};
+
+const getSendToRouteDestination = (
+  params: Record<string, unknown>
+): string | undefined => {
+  const hops = (params?.route as Record<string, unknown> | undefined)?.hops;
+  if (!Array.isArray(hops) || !hops.length) {
+    return;
+  }
+  const lastHop = hops[hops.length - 1] as Record<string, unknown>;
+  const destination = lastHop?.pub_key ?? lastHop?.pubKey;
+  return typeof destination === "string" ? destination : undefined;
+};
+
+// the response of the node for a sendtoroute call. LNC converts its response to
+// snake_case, so both connectors return the same keys here.
+type SendToRouteResponse = {
+  payment_error?: string;
+  payment_preimage?: string;
+  payment_hash?: string;
+  payment_route?: { total_amt?: number | string; total_fees?: number | string };
+};
+
+// publish the payment so that the existing subscribers debit the budget of the
+// allowance and persist the payment
+const publishSendToRoutePayment = (
+  message: MessageGenericRequest,
+  accountId: string,
+  response: { data: unknown },
+  amount: number,
+  destination?: string
+) => {
+  const data = (response.data ?? {}) as SendToRouteResponse;
+
+  if (data.payment_error) {
+    pubsub.publishPaymentNotification("sendPayment", message, {
+      accountId,
+      response: { error: data.payment_error },
+      details: {},
+    });
+    return;
+  }
+
+  const route = (data.payment_route ?? {}) as Record<string, unknown>;
+  const totalFees = readAmount(route, ["total_fees"]) ?? 0;
+  // like the connector `sendPayment` implementations, the published route
+  // amount is the amount without the routing fees
+  const totalAmount = (readAmount(route, ["total_amt"]) ?? amount) - totalFees;
+
+  pubsub.publishPaymentNotification("sendPayment", message, {
+    accountId,
+    response: {
+      data: {
+        preimage: data.payment_preimage ?? "",
+        paymentHash: data.payment_hash ?? "",
+        route: { total_amt: Math.max(totalAmount, 0), total_fees: totalFees },
+      },
+    },
+    details: { destination },
+  });
+};
 
 const request = async (
   message: MessageGenericRequest
@@ -49,24 +154,61 @@ const request = async (
       throw new Error("Could not find an allowance for this host");
     }
 
+    // the allowance can exist because the host was enabled for another provider
+    // (e.g. nostr), requests are only allowed if WebLN is enabled for the host
+    if (!allowance.enabled || !allowance.enabledFor?.includes("webln")) {
+      throw new Error("WebLN is not enabled for this host");
+    }
+
     if (!accountId) {
       // type guard
       throw new Error("Could not find a selected account");
+    }
+
+    const isFundMoving = isFundMovingRequestMethod(methodInLowerCase);
+    const isSendToRoute = methodInLowerCase === SEND_TO_ROUTE;
+
+    // throws if the amount can not be read, we never send an unknown amount
+    const amount = isSendToRoute
+      ? getSendToRouteAmount(args.params)
+      : undefined;
+    const destination = isSendToRoute
+      ? getSendToRouteDestination(args.params)
+      : undefined;
+
+    if (amount !== undefined && !(allowance.remainingBudget > amount)) {
+      throw new Error("The budget of this website is not sufficient");
     }
 
     const connectorName = connector.constructor.name.toLowerCase();
     // prefix method with webln to prevent potential naming conflicts (e.g. with nostr calls that also use the permissions)
     const weblnMethod = `${WEBLN_PREFIX}${connectorName}/${methodInLowerCase}`;
 
-    const hasPermission = await hasPermissionFor(weblnMethod, origin.host);
+    // methods that can move funds are confirmed on every call, a stored
+    // permission never skips the prompt for them
+    const hasPermission =
+      !isFundMoving && (await hasPermissionFor(weblnMethod, origin.host));
+
+    const requestMethod = connector.requestMethod;
+    const callRequestMethod = async () => {
+      const response = await requestMethod(methodInLowerCase, args.params);
+
+      if (amount !== undefined) {
+        publishSendToRoutePayment(
+          message,
+          accountId,
+          response,
+          amount,
+          destination
+        );
+      }
+
+      return response;
+    };
 
     // request method is allowed to be called
     if (hasPermission) {
-      const response = await connector.requestMethod(
-        methodInLowerCase,
-        args.params
-      );
-      return response;
+      return await callRequestMethod();
     } else {
       // throws an error if the user rejects
       const promptResponse = await utils.openPrompt<{
@@ -77,19 +219,18 @@ const request = async (
           requestPermission: {
             method: methodInLowerCase,
             description: `${connectorName}.${methodInLowerCase}`,
+            ...(isFundMoving && { isFundMoving, amount, destination }),
           },
         },
         origin,
         action: "public/confirmRequestPermission",
       });
 
-      const response = await connector.requestMethod(
-        methodInLowerCase,
-        args.params
-      );
+      const response = await callRequestMethod();
 
-      // add permission to db only if user decided to always allow this request
-      if (promptResponse.data.enabled) {
+      // add permission to db only if user decided to always allow this request.
+      // methods that can move funds are never remembered.
+      if (!isFundMoving && promptResponse.data.enabled) {
         await addPermissionFor(
           weblnMethod,
           origin.host,

--- a/src/extension/background-script/actions/ln/request.ts
+++ b/src/extension/background-script/actions/ln/request.ts
@@ -180,7 +180,15 @@ const request = async (
       throw new Error("The budget of this website is not sufficient");
     }
 
-    const connectorName = connector.constructor.name.toLowerCase();
+    // the connector type of the account, not the name of the connector class:
+    // the class name is mangled by the production build, so a permission keyed
+    // on it depends on the output of the minifier and the description does not
+    // resolve to a translation
+    const connectorName = state.getState().getAccount()?.connector;
+    if (!connectorName) {
+      throw new Error("Could not find a selected account");
+    }
+
     // prefix method with webln to prevent potential naming conflicts (e.g. with nostr calls that also use the permissions)
     const weblnMethod = `${WEBLN_PREFIX}${connectorName}/${methodInLowerCase}`;
 
@@ -189,7 +197,9 @@ const request = async (
     const hasPermission =
       !isFundMoving && (await hasPermissionFor(weblnMethod, origin.host));
 
-    const requestMethod = connector.requestMethod;
+    // bound to the connector: the implementations call other methods on
+    // themselves, a detached reference loses the receiver
+    const requestMethod = connector.requestMethod.bind(connector);
     const callRequestMethod = async () => {
       const response = await requestMethod(methodInLowerCase, args.params);
 

--- a/src/extension/background-script/actions/ln/request.ts
+++ b/src/extension/background-script/actions/ln/request.ts
@@ -15,6 +15,7 @@ const WEBLN_PREFIX = "webln/";
 // the request method that sends a payment and therefore has to be accounted
 // for in the allowance budget of the host
 const SEND_TO_ROUTE = "sendtoroute";
+const OPEN_CHANNEL = "openchannel";
 
 // LND returns int64 values as strings, LNC returns them as numbers. Both the
 // REST and the LNC API are called with the parameters the website provides, so
@@ -29,8 +30,13 @@ const readAmount = (
     if (typeof value !== "string" && typeof value !== "number") {
       continue;
     }
+    if (typeof value === "string" && !value.trim()) {
+      continue;
+    }
     const amount = Number(value);
-    if (Number.isFinite(amount) && amount >= 0) {
+    // an amount of zero is not an amount we can show or account for, it is
+    // treated like a missing value
+    if (Number.isFinite(amount) && amount > 0) {
       return Math.ceil(amount / divisor);
     }
   }
@@ -45,14 +51,37 @@ const getSendToRouteAmount = (params: Record<string, unknown>): number => {
   }
 
   const routeValues = route as Record<string, unknown>;
-  const amount =
-    readAmount(routeValues, ["total_amt", "totalAmt"]) ??
-    readAmount(routeValues, ["total_amt_msat", "totalAmtMsat"], 1000);
+  // the node takes the amount from the millisatoshi fields and ignores the
+  // deprecated satoshi fields when both are given, so the amount that can leave
+  // the wallet is the larger of the two readings, never the first one found
+  const amounts = [
+    readAmount(routeValues, ["total_amt", "totalAmt"]),
+    readAmount(routeValues, ["total_amt_msat", "totalAmtMsat"], 1000),
+  ].filter((amount): amount is number => amount !== undefined);
 
-  if (amount === undefined) {
+  if (!amounts.length) {
     throw new Error("Could not determine the amount of this request");
   }
-  return amount;
+  return Math.max(...amounts);
+};
+
+// the funds a channel is opened with. Not a lightning payment, so it is not
+// checked against or debited from the budget, but the confirmation has to state
+// the size of the channel it asks for
+const getOpenChannelAmount = (
+  params: Record<string, unknown>
+): number | undefined => {
+  const values = (params ?? {}) as Record<string, unknown>;
+  const amounts = [
+    readAmount(values, ["local_funding_amount", "localFundingAmount"]),
+    readAmount(
+      values,
+      ["local_funding_amount_msat", "localFundingAmountMsat"],
+      1000
+    ),
+  ].filter((amount): amount is number => amount !== undefined);
+
+  return amounts.length ? Math.max(...amounts) : undefined;
 };
 
 const getSendToRouteDestination = (
@@ -106,8 +135,14 @@ const publishSendToRoutePayment = (
     accountId,
     response: {
       data: {
-        preimage: data.payment_preimage ?? "",
-        paymentHash: data.payment_hash ?? "",
+        // both are base64 encoded bytes on the wire, the payment history
+        // stores them as hex, like the connectors do for `sendPayment`
+        preimage: data.payment_preimage
+          ? utils.base64ToHex(data.payment_preimage)
+          : "",
+        paymentHash: data.payment_hash
+          ? utils.base64ToHex(data.payment_hash)
+          : "",
         route: { total_amt: Math.max(totalAmount, 0), total_fees: totalFees },
       },
     },
@@ -176,9 +211,13 @@ const request = async (
       ? getSendToRouteDestination(args.params)
       : undefined;
 
-    if (amount !== undefined && !(allowance.remainingBudget > amount)) {
-      throw new Error("The budget of this website is not sufficient");
-    }
+    // the amount to put in front of the user. Requests that move funds are
+    // confirmed on every call, so the confirmation is what guards the amount,
+    // the budget is what the payment is debited from afterwards
+    const confirmedAmount =
+      methodInLowerCase === OPEN_CHANNEL
+        ? getOpenChannelAmount(args.params)
+        : amount;
 
     // the connector type of the account, not the name of the connector class:
     // the class name is mangled by the production build, so a permission keyed
@@ -229,7 +268,11 @@ const request = async (
           requestPermission: {
             method: methodInLowerCase,
             description: `${connectorName}.${methodInLowerCase}`,
-            ...(isFundMoving && { isFundMoving, amount, destination }),
+            ...(isFundMoving && {
+              isFundMoving,
+              amount: confirmedAmount,
+              destination,
+            }),
           },
         },
         origin,

--- a/src/extension/background-script/connectors/connector.interface.ts
+++ b/src/extension/background-script/connectors/connector.interface.ts
@@ -158,3 +158,20 @@ export default interface Connector {
 export function flattenRequestMethods(methods: string[]) {
   return methods.map((method) => `request.${method}`);
 }
+
+// Request methods that move funds or change the state of the node.
+// These are confirmed on every call, are never remembered as a permission and,
+// where the amount is known, are checked against and debited from the
+// allowance budget of the host.
+export const FUND_MOVING_REQUEST_METHODS = [
+  "sendtoroute",
+  "openchannel",
+  "settleinvoice",
+  "addholdinvoice",
+  "connectpeer",
+  "disconnectpeer",
+];
+
+export function isFundMovingRequestMethod(method: string) {
+  return FUND_MOVING_REQUEST_METHODS.includes(method);
+}

--- a/src/extension/background-script/migrations/__tests__/migrations.test.ts
+++ b/src/extension/background-script/migrations/__tests__/migrations.test.ts
@@ -1,0 +1,49 @@
+import db from "~/extension/background-script/db";
+import type { DbPermission } from "~/types";
+
+import migrate from "../index";
+
+// suppress console logs when running tests
+console.info = jest.fn();
+
+jest.mock("~/extension/background-script/state", () => ({
+  getState: () => ({
+    migrations: [],
+    saveToStorage: jest.fn(() => Promise.resolve()),
+  }),
+  setState: jest.fn(),
+}));
+
+const permission = {
+  accountId: "8b7f1dc6-ab87-4c6c-bca5-19fa8632731e",
+  allowanceId: 1,
+  createdAt: "1487076708000",
+  host: "getalby.com",
+  blocked: false,
+  enabled: true,
+};
+
+const permissionsInDB: DbPermission[] = [
+  { ...permission, id: 1, method: "webln/lnd/sendtoroute" },
+  { ...permission, id: 2, method: "webln/lnc/openchannel" },
+  { ...permission, id: 3, method: "webln/lnd/settleinvoice" },
+  { ...permission, id: 4, method: "webln/lnd/listchannels" },
+  { ...permission, id: 5, method: "nostr/getpublickey" },
+];
+
+beforeEach(async () => {
+  await db.permissions.clear();
+  await db.permissions.bulkAdd(permissionsInDB);
+});
+
+describe("migrateFundMovingRequestPermissions", () => {
+  test("removes the stored permissions of request methods that move funds", async () => {
+    await migrate();
+
+    const methods = (await db.permissions.toArray()).map(
+      (permission) => permission.method
+    );
+
+    expect(methods).toEqual(["webln/lnd/listchannels", "nostr/getpublickey"]);
+  });
+});

--- a/src/extension/background-script/migrations/__tests__/migrations.test.ts
+++ b/src/extension/background-script/migrations/__tests__/migrations.test.ts
@@ -28,7 +28,10 @@ const permissionsInDB: DbPermission[] = [
   { ...permission, id: 2, method: "webln/lnc/openchannel" },
   { ...permission, id: 3, method: "webln/lnd/settleinvoice" },
   { ...permission, id: 4, method: "webln/lnd/listchannels" },
-  { ...permission, id: 5, method: "nostr/getpublickey" },
+  // written by a build that mangled the name of the connector class
+  { ...permission, id: 5, method: "webln/e/listchannels" },
+  { ...permission, id: 6, method: "webln/getbalance" },
+  { ...permission, id: 7, method: "nostr/getpublickey" },
 ];
 
 beforeEach(async () => {
@@ -36,14 +39,14 @@ beforeEach(async () => {
   await db.permissions.bulkAdd(permissionsInDB);
 });
 
-describe("migrateFundMovingRequestPermissions", () => {
-  test("removes the stored permissions of request methods that move funds", async () => {
+describe("migrateRequestMethodPermissions", () => {
+  test("removes the stored permissions of request methods", async () => {
     await migrate();
 
     const methods = (await db.permissions.toArray()).map(
       (permission) => permission.method
     );
 
-    expect(methods).toEqual(["webln/lnd/listchannels", "nostr/getpublickey"]);
+    expect(methods).toEqual(["webln/getbalance", "nostr/getpublickey"]);
   });
 });

--- a/src/extension/background-script/migrations/index.ts
+++ b/src/extension/background-script/migrations/index.ts
@@ -1,4 +1,3 @@
-import { FUND_MOVING_REQUEST_METHODS } from "../connectors/connector.interface";
 import db from "../db";
 import state from "../state";
 
@@ -94,24 +93,26 @@ const migrations = {
     console.info("Migration migrateDecryptPermission complete.");
   },
 
-  migrateFundMovingRequestPermissions: async () => {
+  migrateRequestMethodPermissions: async () => {
     const permissions = await db.permissions.toArray();
 
     for (const permission of permissions) {
-      // stored as webln/<connector>/<method>
-      const method = permission.method.split("/").pop() || "";
-
-      if (
-        permission.method.startsWith("webln/") &&
-        FUND_MOVING_REQUEST_METHODS.includes(method)
-      ) {
-        permission.id && (await db.permissions.delete(permission.id));
+      // request method permissions are stored as webln/<connector>/<method>,
+      // every other webln permission has no connector segment
+      const segments = permission.method.split("/");
+      if (segments[0] !== "webln" || segments.length !== 3) {
+        continue;
       }
+
+      // methods that can move funds are no longer remembered at all, and the
+      // remaining rows are keyed on the connector class name, which the
+      // production build mangles, so they can never match again
+      permission.id && (await db.permissions.delete(permission.id));
     }
 
     await db.saveToStorage();
 
-    console.info("Migration migrateFundMovingRequestPermissions complete.");
+    console.info("Migration migrateRequestMethodPermissions complete.");
   },
 };
 
@@ -137,10 +138,10 @@ const migrate = async () => {
     await setMigrated("migrateDecryptPermission");
   }
 
-  if (shouldMigrate("migrateFundMovingRequestPermissions")) {
-    console.info("Running migration for: migrateFundMovingRequestPermissions");
-    await migrations["migrateFundMovingRequestPermissions"]();
-    await setMigrated("migrateFundMovingRequestPermissions");
+  if (shouldMigrate("migrateRequestMethodPermissions")) {
+    console.info("Running migration for: migrateRequestMethodPermissions");
+    await migrations["migrateRequestMethodPermissions"]();
+    await setMigrated("migrateRequestMethodPermissions");
   }
 };
 

--- a/src/extension/background-script/migrations/index.ts
+++ b/src/extension/background-script/migrations/index.ts
@@ -1,3 +1,4 @@
+import { FUND_MOVING_REQUEST_METHODS } from "../connectors/connector.interface";
 import db from "../db";
 import state from "../state";
 
@@ -92,6 +93,26 @@ const migrations = {
 
     console.info("Migration migrateDecryptPermission complete.");
   },
+
+  migrateFundMovingRequestPermissions: async () => {
+    const permissions = await db.permissions.toArray();
+
+    for (const permission of permissions) {
+      // stored as webln/<connector>/<method>
+      const method = permission.method.split("/").pop() || "";
+
+      if (
+        permission.method.startsWith("webln/") &&
+        FUND_MOVING_REQUEST_METHODS.includes(method)
+      ) {
+        permission.id && (await db.permissions.delete(permission.id));
+      }
+    }
+
+    await db.saveToStorage();
+
+    console.info("Migration migrateFundMovingRequestPermissions complete.");
+  },
 };
 
 const migrate = async () => {
@@ -114,6 +135,12 @@ const migrate = async () => {
     console.info("Running migration for: migrateDecryptPermission");
     await migrations["migrateDecryptPermission"]();
     await setMigrated("migrateDecryptPermission");
+  }
+
+  if (shouldMigrate("migrateFundMovingRequestPermissions")) {
+    console.info("Running migration for: migrateFundMovingRequestPermissions");
+    await migrations["migrateFundMovingRequestPermissions"]();
+    await setMigrated("migrateFundMovingRequestPermissions");
   }
 };
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -878,7 +878,10 @@
     "confirm_request_permission": {
       "title": "Approve Request",
       "allow": "Allow this website to execute:",
-      "always_allow": "Remember my choice and don't ask again"
+      "always_allow": "Remember my choice and don't ask again",
+      "amount": "Amount: {{amount}}",
+      "destination": "To: {{destination}}",
+      "fund_moving_warning": "This request can move funds or change the state of your node. It has to be confirmed every time and can not be remembered."
     },
     "confirm_add_account": {
       "title": "Add wallet",

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,9 @@ export type NavigationState = {
     requestPermission: {
       method: string;
       description: string;
+      isFundMoving?: boolean;
+      amount?: number;
+      destination?: string;
     };
     // liquid
     pset?: string;


### PR DESCRIPTION
## Describe the changes you have made in this PR

`window.webln.request(method, params)` forwards a whitelisted RPC to the active connector. The LND and LNC connectors whitelist methods that move funds or change the state of the node — `sendtoroute`, `openchannel`, `settleinvoice`, `addholdinvoice`, `connectpeer`, `disconnectpeer` — and those were treated like every other request method: approved once, remembered forever, never accounted for in the budget of the host and never recorded in the payment history.

**Requests that can move funds**

- are confirmed on every call; the "remember my choice" option is not offered for them and a stored permission no longer skips the prompt
- show a warning and, where they are known, the amount and the destination of the request
- `sendtoroute` reads the amount from the route it is asked to send along and publishes the payment afterwards, so the budget is debited and the payment shows up in the history like any other payment. A request whose amount cannot be read — missing, empty or zero — is rejected

The amount is read from the millisatoshi field as well as the deprecated satoshi field and the larger of the two is used: the node takes the amount from the millisatoshi field and ignores `total_amt` when both are set, so reading the satoshi field first confirmed and accounted for a request as `0` while the node sent the full amount. `openchannel` is the largest fund mover in the allowlist and showed no amount at all; it now shows `local_funding_amount`. It commits on-chain funds rather than making a lightning payment, so it is not debited from the budget.

**All requests** now additionally require the allowance of the host to be `enabled` and to include `webln` in `enabledFor`. An allowance that exists only because the host was enabled for another provider (e.g. nostr) no longer grants access to `webln.request`.

**Permission keys** were derived from `connector.constructor.name`. The production build mangles class names, so a release keyed the permission on whatever identifier the minifier produced and looked up a translation that does not exist — the prompt showed the raw key (`e.sendtoroute`) instead of the description of the method. Both now come from the connector type of the account, which is stable across builds. `requestMethod` is also bound to the connector before it is called; the implementations call other methods on themselves and a detached reference loses its receiver.

The preimage and the payment hash are base64-encoded bytes on the wire and are now stored as hex, matching what the connectors do for `sendPayment`.

A migration removes stored request-method permissions: the fund-moving ones are no longer remembered at all, and the rest were keyed the old way and can never match again.

## Behaviour changes worth noting

Sites that were granted a request-method permission are prompted once more. `connectpeer` / `disconnectpeer` do not move funds themselves but do change node state, so they are grouped with the fund-moving methods and prompt every time — happy to split them out if that is too strict.

An insufficient budget does not reject the request. The allowance an `enable()` creates has a budget of `0`, so rejecting would break every existing `sendtoroute` integration. The confirmation is what guards these calls — it is shown every time and states the amount — and the budget is what the payment is debited from afterwards, in the same spirit as `sendPayment` falling back to the prompt when the budget does not cover it.

A host whose allowance exists only because it was enabled for another provider, and which was then enabled for WebLN without "remember", now gets an error from `webln.request` instead of being served. There is no session-level enable state to consult, so closing the "any allowance row will do" gap costs that case.

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/a2166422-2b74-4798-8e96-79931fab6bb9) | ![after](https://github.com/user-attachments/assets/bcb67647-9d93-4d74-91e3-45be1dd3bff2) |

## Tests

- `src/extension/background-script/actions/ln/__tests__/request.test.ts` — permission vs. prompt, the WebLN-enabled requirement, and for fund-moving methods: prompting despite a stored permission, not storing the permission, confirming the amount the node actually reads, the channel size for `openchannel`, rejecting a missing / empty / zero amount, and debiting the budget plus persisting the payment. Also covers that `requestMethod` keeps its receiver.
- `src/extension/background-script/migrations/__tests__/migrations.test.ts` — the migration removes request-method permissions and leaves everything else alone.

`yarn lint`, `yarn tsc:compile` and `yarn test:unit` pass (76 suites, 180 passed, 2 pre-existing skips). Also exercised end to end against an LND-backed account in a production Chrome build.
