### PR TITLE
feat: authenticated at-rest encryption for account secrets

### DIFF
--- a/src/app/components/PasswordForm/index.tsx
+++ b/src/app/components/PasswordForm/index.tsx
@@ -3,6 +3,12 @@ import type { KeyPrefix } from "i18next";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import PasswordViewAdornment from "~/app/components/PasswordViewAdornment";
+import {
+  UNLOCK_PASSWORD_MIN_LENGTH,
+  getPasswordError,
+  type PasswordConfirmationError,
+  type PasswordError,
+} from "~/common/utils/validations";
 
 export type PasswordFormData = {
   password: string;
@@ -19,13 +25,10 @@ export type Props<T extends PasswordFormData = PasswordFormData> = {
   autoFocus?: boolean;
 };
 
-type errorMessage =
-  | ""
-  | "enter_password"
-  | "confirm_password"
-  | "mismatched_password";
-
-const initialErrors: Record<string, errorMessage> = {
+const initialErrors: {
+  passwordErrorMessage: PasswordError;
+  passwordConfirmationErrorMessage: PasswordConfirmationError;
+} = {
   passwordErrorMessage: "",
   passwordConfirmationErrorMessage: "",
 };
@@ -36,7 +39,7 @@ export default function PasswordForm<
   formData,
   setFormData,
   i18nKeyPrefix,
-  minLength,
+  minLength = UNLOCK_PASSWORD_MIN_LENGTH,
   confirm = true,
   autoFocus = true,
 }: Props<T>) {
@@ -71,17 +74,15 @@ export default function PasswordForm<
   }
 
   function validate() {
-    let passwordErrorMessage: errorMessage = "";
-    let passwordConfirmationErrorMessage: errorMessage = "";
+    let passwordConfirmationErrorMessage: PasswordConfirmationError = "";
 
-    if (!formData.password) passwordErrorMessage = "enter_password";
     if (confirm && !formData.passwordConfirmation) {
       passwordConfirmationErrorMessage = "confirm_password";
     } else if (confirm && formData.password !== formData.passwordConfirmation) {
       passwordConfirmationErrorMessage = "mismatched_password";
     }
     setErrors({
-      passwordErrorMessage,
+      passwordErrorMessage: getPasswordError(formData.password, minLength),
       passwordConfirmationErrorMessage,
     });
   }
@@ -115,7 +116,7 @@ export default function PasswordForm<
         />
         {errors.passwordErrorMessage && (
           <p className="mt-1 text-red-500">
-            {t(`errors.${errors.passwordErrorMessage}`)}
+            {t(`errors.${errors.passwordErrorMessage}`, { min: minLength })}
           </p>
         )}
       </div>

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import toast from "~/app/components/Toast";
 import msg from "~/common/lib/msg";
+import { isValidUnlockPassword } from "~/common/utils/validations";
 
 const initialFormData = {
   password: "",
@@ -25,6 +26,9 @@ export default function SetPassword() {
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (!isValidUnlockPassword(formData.password)) {
+      return;
+    }
     try {
       await msg.request("setPassword", { password: formData.password });
       navigate("/choose-path");
@@ -74,7 +78,7 @@ export default function SetPassword() {
               type="submit"
               primary
               disabled={
-                !formData.password ||
+                !isValidUnlockPassword(formData.password) ||
                 formData.password !== formData.passwordConfirmation
               }
               className="w-64"

--- a/src/app/screens/Onboard/SetPassword/index.tsx
+++ b/src/app/screens/Onboard/SetPassword/index.tsx
@@ -26,7 +26,10 @@ export default function SetPassword() {
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!isValidUnlockPassword(formData.password)) {
+    if (
+      !isValidUnlockPassword(formData.password) ||
+      formData.password !== formData.passwordConfirmation
+    ) {
       return;
     }
     try {

--- a/src/app/screens/Settings/index.tsx
+++ b/src/app/screens/Settings/index.tsx
@@ -15,6 +15,7 @@ import toast from "~/app/components/Toast";
 import { useSettings } from "~/app/context/SettingsContext";
 import { CURRENCIES } from "~/common/constants";
 import msg from "~/common/lib/msg";
+import { isValidUnlockPassword } from "~/common/utils/validations";
 
 const initialFormData = {
   password: "",
@@ -36,9 +37,12 @@ function Settings() {
   }
 
   async function updateAccountPassword(password: string) {
+    if (!isValidUnlockPassword(password)) {
+      return;
+    }
     try {
       await msg.request("changePassword", {
-        password: formData.password,
+        password,
       });
 
       toast.success(t("change_password.success"));
@@ -337,7 +341,7 @@ function Settings() {
                     type="submit"
                     primary
                     disabled={
-                      !formData.password ||
+                      !isValidUnlockPassword(formData.password) ||
                       formData.password !== formData.passwordConfirmation
                     }
                   />

--- a/src/app/screens/Settings/index.tsx
+++ b/src/app/screens/Settings/index.tsx
@@ -37,7 +37,10 @@ function Settings() {
   }
 
   async function updateAccountPassword(password: string) {
-    if (!isValidUnlockPassword(password)) {
+    if (
+      !isValidUnlockPassword(password) ||
+      password !== formData.passwordConfirmation
+    ) {
       return;
     }
     try {

--- a/src/common/lib/__tests__/crypto.test.ts
+++ b/src/common/lib/__tests__/crypto.test.ts
@@ -1,0 +1,90 @@
+import { AES } from "crypto-js";
+
+import {
+  decryptData,
+  encryptData,
+  isLegacyEncrypted,
+  reEncryptToLatest,
+} from "../crypto";
+
+const secret = {
+  nostrWalletConnectUrl: "nostr+walletconnect://abc?relay=wss://r&secret=xyz",
+  macaroon: "0201036c6e6402ff",
+};
+
+describe("crypto (v2 authenticated format)", () => {
+  test("round-trips arbitrary data", () => {
+    const cipher = encryptData(secret, "correct horse battery staple");
+    expect(decryptData(cipher, "correct horse battery staple")).toEqual(secret);
+  });
+
+  test("writes a versioned, non-crypto-js envelope", () => {
+    const cipher = encryptData(secret, "pw");
+    const env = JSON.parse(cipher);
+    expect(env.v).toBe(2);
+    expect(env.c).toBeGreaterThanOrEqual(600_000);
+    expect(typeof env.s).toBe("string");
+    expect(typeof env.n).toBe("string");
+    // must NOT be the old OpenSSL "Salted__" base64 format
+    expect(cipher.startsWith("U2FsdGVk")).toBe(false);
+  });
+
+  test("uses a fresh salt and nonce every call (no deterministic ciphertext)", () => {
+    const a = encryptData(secret, "pw");
+    const b = encryptData(secret, "pw");
+    expect(a).not.toEqual(b);
+    expect(JSON.parse(a).s).not.toEqual(JSON.parse(b).s);
+    expect(JSON.parse(a).n).not.toEqual(JSON.parse(b).n);
+  });
+
+  test("wrong password fails to decrypt (does not return garbage)", () => {
+    const cipher = encryptData(secret, "right");
+    expect(() => decryptData(cipher, "wrong")).toThrow();
+  });
+
+  test("tampering with the ciphertext is detected (AEAD tag)", () => {
+    const cipher = encryptData(secret, "pw");
+    const env = JSON.parse(cipher);
+    // flip one nibble of the ciphertext+tag
+    const bytes = env.d.split("");
+    bytes[10] = bytes[10] === "a" ? "b" : "a";
+    env.d = bytes.join("");
+    expect(() => decryptData(JSON.stringify(env), "pw")).toThrow();
+  });
+});
+
+describe("crypto (legacy compatibility)", () => {
+  // exactly what the old code produced: AES.encrypt(JSON.stringify(x), password)
+  const legacy = AES.encrypt(JSON.stringify(secret), "legacy-pw").toString();
+
+  test("still decrypts legacy crypto-js blobs", () => {
+    expect(legacy.startsWith("U2FsdGVk")).toBe(true); // "Salted__"
+    expect(decryptData(legacy, "legacy-pw")).toEqual(secret);
+  });
+
+  test("isLegacyEncrypted distinguishes the two formats", () => {
+    expect(isLegacyEncrypted(legacy)).toBe(true);
+    expect(isLegacyEncrypted(encryptData(secret, "pw"))).toBe(false);
+  });
+
+  test("reEncryptToLatest upgrades a legacy blob, preserving plaintext", () => {
+    const upgraded = reEncryptToLatest(legacy, "legacy-pw") as string;
+    expect(isLegacyEncrypted(upgraded)).toBe(false);
+    expect(decryptData(upgraded, "legacy-pw")).toEqual(secret);
+  });
+
+  test("reEncryptToLatest leaves a v2 blob untouched", () => {
+    const v2 = encryptData(secret, "pw");
+    expect(reEncryptToLatest(v2, "pw")).toBe(v2);
+  });
+
+  test("reEncryptToLatest returns the original when it cannot decrypt", () => {
+    // wrong password: must not throw, must not lose the blob
+    expect(reEncryptToLatest(legacy, "not-the-password")).toBe(legacy);
+  });
+
+  test("reEncryptToLatest passes through null/undefined", () => {
+    expect(reEncryptToLatest(null, "pw")).toBeNull();
+    expect(reEncryptToLatest(undefined, "pw")).toBeUndefined();
+  });
+});

--- a/src/common/lib/__tests__/crypto.test.ts
+++ b/src/common/lib/__tests__/crypto.test.ts
@@ -1,6 +1,7 @@
 import { AES } from "crypto-js";
 
 import {
+  clearKeyCache,
   decryptData,
   encryptData,
   isLegacyEncrypted,
@@ -45,11 +46,31 @@ describe("crypto (v2 authenticated format)", () => {
   test("tampering with the ciphertext is detected (AEAD tag)", () => {
     const cipher = encryptData(secret, "pw");
     const env = JSON.parse(cipher);
-    // flip one nibble of the ciphertext+tag
+    // flip one character of the base64 ciphertext+tag
     const bytes = env.d.split("");
-    bytes[10] = bytes[10] === "a" ? "b" : "a";
+    bytes[10] = bytes[10] === "A" ? "B" : "A";
     env.d = bytes.join("");
     expect(() => decryptData(JSON.stringify(env), "pw")).toThrow();
+  });
+
+  test("an absurd iteration count is rejected, not run (no unbounded KDF)", () => {
+    const cipher = encryptData(secret, "pw");
+    const env = JSON.parse(cipher);
+    // a corrupted / sync-poisoned envelope must not send pbkdf2 into a spin;
+    // it is treated as not-a-v2-envelope and falls through to the legacy path,
+    // which throws on this input rather than hanging.
+    for (const bad of [Infinity, 1e12, -1, 0, 1.5, NaN]) {
+      env.c = bad;
+      expect(isLegacyEncrypted(JSON.stringify(env))).toBe(true);
+      expect(() => decryptData(JSON.stringify(env), "pw")).toThrow();
+    }
+  });
+
+  test("clearKeyCache lets the same blob be decrypted again", () => {
+    const cipher = encryptData(secret, "pw");
+    expect(decryptData(cipher, "pw")).toEqual(secret); // populates cache
+    clearKeyCache();
+    expect(decryptData(cipher, "pw")).toEqual(secret); // re-derives, still works
   });
 });
 

--- a/src/common/lib/crypto.ts
+++ b/src/common/lib/crypto.ts
@@ -1,12 +1,8 @@
 import { gcm } from "@noble/ciphers/aes.js";
 import { pbkdf2 } from "@noble/hashes/pbkdf2.js";
 import { sha256 } from "@noble/hashes/sha2.js";
-import {
-  bytesToHex,
-  hexToBytes,
-  randomBytes,
-  utf8ToBytes,
-} from "@noble/hashes/utils.js";
+import { bytesToHex, randomBytes, utf8ToBytes } from "@noble/hashes/utils.js";
+import { base64 } from "@scure/base";
 import { AES, enc } from "crypto-js";
 
 /**
@@ -18,15 +14,24 @@ import { AES, enc } from "crypto-js";
  *    ciphertext tamper-evident; a modified blob fails to decrypt instead of
  *    silently yielding altered plaintext.
  *  - **legacy** (crypto-js passphrase mode): still readable so that data written
- *    by older versions — including blobs that sync down from another device that
- *    has not upgraded yet — keeps working. Never written by new code.
+ *    by older versions keeps working. Never written by new code.
  *
- * `encryptData` always writes v2. `decryptData` detects the format and reads
- * either. Both keep the synchronous signature the rest of the codebase relies
- * on (connectors and actions call these inline).
+ * `encryptData` always writes v2. `decryptData` reads either. Both keep the
+ * synchronous signature the rest of the codebase relies on (connectors and
+ * actions call these inline).
+ *
+ * Cross-version note: v2 blobs are stored under the single `accounts`
+ * `browser.storage.sync` key, so they replicate to other devices. A v2 blob is
+ * NOT readable by versions <= 3.14.5 (their crypto-js path throws on it). Reading
+ * the previous format here keeps a not-yet-upgraded device working when it
+ * receives an old blob; the reverse — an old build receiving a v2 blob — cannot
+ * be made to work and is a deliberate, documented consequence of no longer
+ * writing the weak format.
  */
 
 const KDF_ITERATIONS = 600_000; // OWASP 2023 floor for PBKDF2-HMAC-SHA256
+const MIN_ITERATIONS = 1;
+const MAX_ITERATIONS = 4_000_000; // guardrail: reject absurd counts from storage
 const SALT_BYTES = 16;
 const NONCE_BYTES = 12;
 const KEY_BYTES = 32;
@@ -34,43 +39,57 @@ const KEY_BYTES = 32;
 type EncryptedEnvelope = {
   v: 2;
   c: number; // KDF iteration count (so it can be raised later without a break)
-  s: string; // salt, hex
-  n: string; // GCM nonce, hex
-  d: string; // ciphertext + GCM tag, hex
+  s: string; // salt, base64
+  n: string; // GCM nonce, base64
+  d: string; // ciphertext + GCM tag, base64
 };
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
 // Deriving a PBKDF2 key at this iteration count costs a few hundred ms, so the
-// result is memoised per (password, salt, iterations). Decrypting the same
-// stored blob repeatedly in one session then pays the cost once. Bounded so it
-// can never grow without limit. The derived key is no more sensitive than the
-// unlock password, which is already held in memory while unlocked.
+// result is memoised per (password, salt, iterations) for the hot *read* path:
+// decrypting the same stored blob repeatedly in one session then pays the cost
+// once. Bounded, and cleared on lock via clearKeyCache() so derived keys and the
+// password hash below do not outlive the unlocked session. Encryption uses a
+// fresh salt every call, so its keys are single-use and are never cached (that
+// would only evict useful read keys).
 const MAX_CACHE_ENTRIES = 64;
 const keyCache = new Map<string, Uint8Array>();
+
+/** Drop all memoised keys. Call when the wallet locks or state is reset. */
+export function clearKeyCache(): void {
+  keyCache.clear();
+}
 
 function deriveKey(
   password: string,
   salt: Uint8Array,
-  iterations: number
+  iterations: number,
+  cache: boolean
 ): Uint8Array {
-  const cacheKey = `${iterations}:${bytesToHex(salt)}:${bytesToHex(
-    sha256(utf8ToBytes(password))
-  )}`;
-  const cached = keyCache.get(cacheKey);
-  if (cached) return cached;
+  const cacheKey = cache
+    ? `${iterations}:${bytesToHex(salt)}:${bytesToHex(
+        sha256(utf8ToBytes(password))
+      )}`
+    : null;
+  if (cacheKey) {
+    const cached = keyCache.get(cacheKey);
+    if (cached) return cached;
+  }
 
   const key = pbkdf2(sha256, utf8ToBytes(password), salt, {
     c: iterations,
     dkLen: KEY_BYTES,
   });
 
-  if (keyCache.size >= MAX_CACHE_ENTRIES) {
-    const oldest = keyCache.keys().next().value;
-    if (oldest !== undefined) keyCache.delete(oldest);
+  if (cacheKey) {
+    if (keyCache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = keyCache.keys().next().value;
+      if (oldest !== undefined) keyCache.delete(oldest);
+    }
+    keyCache.set(cacheKey, key);
   }
-  keyCache.set(cacheKey, key);
   return key;
 }
 
@@ -80,6 +99,9 @@ function isEncryptedEnvelope(value: unknown): value is EncryptedEnvelope {
   return (
     e.v === 2 &&
     typeof e.c === "number" &&
+    Number.isInteger(e.c) &&
+    e.c >= MIN_ITERATIONS &&
+    e.c <= MAX_ITERATIONS &&
     typeof e.s === "string" &&
     typeof e.n === "string" &&
     typeof e.d === "string"
@@ -99,7 +121,7 @@ export function isLegacyEncrypted(cipher: string): boolean {
 export function encryptData(data: unknown, password: string): string {
   const salt = randomBytes(SALT_BYTES);
   const nonce = randomBytes(NONCE_BYTES);
-  const key = deriveKey(password, salt, KDF_ITERATIONS);
+  const key = deriveKey(password, salt, KDF_ITERATIONS, false);
 
   const plaintext = textEncoder.encode(JSON.stringify(data));
   const ciphertext = gcm(key, nonce).encrypt(plaintext);
@@ -107,9 +129,9 @@ export function encryptData(data: unknown, password: string): string {
   const envelope: EncryptedEnvelope = {
     v: 2,
     c: KDF_ITERATIONS,
-    s: bytesToHex(salt),
-    n: bytesToHex(nonce),
-    d: bytesToHex(ciphertext),
+    s: base64.encode(salt),
+    n: base64.encode(nonce),
+    d: base64.encode(ciphertext),
   };
   return JSON.stringify(envelope);
 }
@@ -123,10 +145,10 @@ export function decryptData(cipher: string, password: string) {
   }
 
   if (isEncryptedEnvelope(parsed)) {
-    const key = deriveKey(password, hexToBytes(parsed.s), parsed.c);
+    const key = deriveKey(password, base64.decode(parsed.s), parsed.c, true);
     // GCM verifies the tag and throws on any tampering or wrong key.
-    const plaintext = gcm(key, hexToBytes(parsed.n)).decrypt(
-      hexToBytes(parsed.d)
+    const plaintext = gcm(key, base64.decode(parsed.n)).decrypt(
+      base64.decode(parsed.d)
     );
     return JSON.parse(textDecoder.decode(plaintext));
   }
@@ -140,8 +162,7 @@ export function decryptData(cipher: string, password: string) {
  * Re-encrypt a legacy blob into the v2 format using the same password. Returns
  * the input unchanged when it is already v2, or when it cannot be decrypted
  * (wrong password / not this account's data) so callers can run it opportunis-
- * tically without risking data loss. Used to upgrade already-stored secrets on
- * unlock, when the password is available.
+ * tically without risking data loss.
  */
 export function reEncryptToLatest(
   cipher: string | null | undefined,

--- a/src/common/lib/crypto.ts
+++ b/src/common/lib/crypto.ts
@@ -1,10 +1,157 @@
+import { gcm } from "@noble/ciphers/aes.js";
+import { pbkdf2 } from "@noble/hashes/pbkdf2.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+  bytesToHex,
+  hexToBytes,
+  randomBytes,
+  utf8ToBytes,
+} from "@noble/hashes/utils.js";
 import { AES, enc } from "crypto-js";
 
-export function encryptData(data: unknown, password: string) {
-  return AES.encrypt(JSON.stringify(data), password).toString();
+/**
+ * At-rest encryption for account secrets (connector configs, mnemonic, nostr
+ * key). Two formats are understood:
+ *
+ *  - **v2** (written by this version): PBKDF2-SHA256 key derivation with a high
+ *    iteration count, AES-256-GCM authenticated encryption. GCM's tag makes the
+ *    ciphertext tamper-evident; a modified blob fails to decrypt instead of
+ *    silently yielding altered plaintext.
+ *  - **legacy** (crypto-js passphrase mode): still readable so that data written
+ *    by older versions — including blobs that sync down from another device that
+ *    has not upgraded yet — keeps working. Never written by new code.
+ *
+ * `encryptData` always writes v2. `decryptData` detects the format and reads
+ * either. Both keep the synchronous signature the rest of the codebase relies
+ * on (connectors and actions call these inline).
+ */
+
+const KDF_ITERATIONS = 600_000; // OWASP 2023 floor for PBKDF2-HMAC-SHA256
+const SALT_BYTES = 16;
+const NONCE_BYTES = 12;
+const KEY_BYTES = 32;
+
+type EncryptedEnvelope = {
+  v: 2;
+  c: number; // KDF iteration count (so it can be raised later without a break)
+  s: string; // salt, hex
+  n: string; // GCM nonce, hex
+  d: string; // ciphertext + GCM tag, hex
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+// Deriving a PBKDF2 key at this iteration count costs a few hundred ms, so the
+// result is memoised per (password, salt, iterations). Decrypting the same
+// stored blob repeatedly in one session then pays the cost once. Bounded so it
+// can never grow without limit. The derived key is no more sensitive than the
+// unlock password, which is already held in memory while unlocked.
+const MAX_CACHE_ENTRIES = 64;
+const keyCache = new Map<string, Uint8Array>();
+
+function deriveKey(
+  password: string,
+  salt: Uint8Array,
+  iterations: number
+): Uint8Array {
+  const cacheKey = `${iterations}:${bytesToHex(salt)}:${bytesToHex(
+    sha256(utf8ToBytes(password))
+  )}`;
+  const cached = keyCache.get(cacheKey);
+  if (cached) return cached;
+
+  const key = pbkdf2(sha256, utf8ToBytes(password), salt, {
+    c: iterations,
+    dkLen: KEY_BYTES,
+  });
+
+  if (keyCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = keyCache.keys().next().value;
+    if (oldest !== undefined) keyCache.delete(oldest);
+  }
+  keyCache.set(cacheKey, key);
+  return key;
+}
+
+function isEncryptedEnvelope(value: unknown): value is EncryptedEnvelope {
+  if (typeof value !== "object" || value === null) return false;
+  const e = value as Record<string, unknown>;
+  return (
+    e.v === 2 &&
+    typeof e.c === "number" &&
+    typeof e.s === "string" &&
+    typeof e.n === "string" &&
+    typeof e.d === "string"
+  );
+}
+
+/** True when `cipher` is a legacy crypto-js passphrase blob, not a v2 envelope. */
+export function isLegacyEncrypted(cipher: string): boolean {
+  try {
+    return !isEncryptedEnvelope(JSON.parse(cipher));
+  } catch {
+    // legacy ciphertext is base64 of "Salted__…", which is not valid JSON
+    return true;
+  }
+}
+
+export function encryptData(data: unknown, password: string): string {
+  const salt = randomBytes(SALT_BYTES);
+  const nonce = randomBytes(NONCE_BYTES);
+  const key = deriveKey(password, salt, KDF_ITERATIONS);
+
+  const plaintext = textEncoder.encode(JSON.stringify(data));
+  const ciphertext = gcm(key, nonce).encrypt(plaintext);
+
+  const envelope: EncryptedEnvelope = {
+    v: 2,
+    c: KDF_ITERATIONS,
+    s: bytesToHex(salt),
+    n: bytesToHex(nonce),
+    d: bytesToHex(ciphertext),
+  };
+  return JSON.stringify(envelope);
 }
 
 export function decryptData(cipher: string, password: string) {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cipher);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (isEncryptedEnvelope(parsed)) {
+    const key = deriveKey(password, hexToBytes(parsed.s), parsed.c);
+    // GCM verifies the tag and throws on any tampering or wrong key.
+    const plaintext = gcm(key, hexToBytes(parsed.n)).decrypt(
+      hexToBytes(parsed.d)
+    );
+    return JSON.parse(textDecoder.decode(plaintext));
+  }
+
+  // Legacy crypto-js passphrase format (EVP_BytesToKey/MD5, AES-CBC, no MAC).
   const decrypted = AES.decrypt(cipher, password);
   return JSON.parse(decrypted.toString(enc.Utf8));
+}
+
+/**
+ * Re-encrypt a legacy blob into the v2 format using the same password. Returns
+ * the input unchanged when it is already v2, or when it cannot be decrypted
+ * (wrong password / not this account's data) so callers can run it opportunis-
+ * tically without risking data loss. Used to upgrade already-stored secrets on
+ * unlock, when the password is available.
+ */
+export function reEncryptToLatest(
+  cipher: string | null | undefined,
+  password: string
+): string | null | undefined {
+  if (typeof cipher !== "string" || !isLegacyEncrypted(cipher)) return cipher;
+  try {
+    const data = decryptData(cipher, password);
+    return encryptData(data, password);
+  } catch {
+    return cipher;
+  }
 }

--- a/src/common/lib/crypto.ts
+++ b/src/common/lib/crypto.ts
@@ -31,7 +31,15 @@ import { AES, enc } from "crypto-js";
 
 const KDF_ITERATIONS = 600_000; // OWASP 2023 floor for PBKDF2-HMAC-SHA256
 const MIN_ITERATIONS = 1;
-const MAX_ITERATIONS = 4_000_000; // guardrail: reject absurd counts from storage
+// Guardrail against a corrupted/poisoned envelope driving PBKDF2 into a long
+// synchronous stall. Sized to leave headroom above KDF_ITERATIONS while capping
+// the worst case near a second or two.
+//
+// NOTE: raising KDF_ITERATIONS above MAX_ITERATIONS is a BREAKING format change.
+// Builds with the lower bound classify such envelopes as not-v2 and fail to
+// decrypt them, which surfaces to the user as "invalid password". Raise this
+// constant (and ship it) before raising KDF_ITERATIONS past it.
+const MAX_ITERATIONS = 1_200_000;
 const SALT_BYTES = 16;
 const NONCE_BYTES = 12;
 const KEY_BYTES = 32;

--- a/src/common/utils/__tests__/validations.test.ts
+++ b/src/common/utils/__tests__/validations.test.ts
@@ -1,5 +1,10 @@
 import { Accounts } from "~/types";
-import { getUniqueAccountName } from "~/common/utils/validations";
+import {
+  UNLOCK_PASSWORD_MIN_LENGTH,
+  getPasswordError,
+  getUniqueAccountName,
+  isValidUnlockPassword,
+} from "~/common/utils/validations";
 
 function getMockAccounts(names: string[]): Accounts {
   const accounts: Accounts = {};
@@ -13,6 +18,30 @@ function getMockAccounts(names: string[]): Accounts {
   });
   return accounts;
 }
+
+describe("getPasswordError", () => {
+  test("rejects an empty password", () => {
+    expect(getPasswordError("")).toBe("enter_password");
+    expect(isValidUnlockPassword("")).toBe(false);
+  });
+
+  test("rejects a password shorter than the minimum length", () => {
+    expect(getPasswordError("abc12")).toBe("password_too_short");
+    expect(getPasswordError("a".repeat(UNLOCK_PASSWORD_MIN_LENGTH - 1))).toBe(
+      "password_too_short"
+    );
+  });
+
+  test("rejects a numbers-only password", () => {
+    expect(getPasswordError("12345678")).toBe("password_numeric_only");
+    expect(isValidUnlockPassword("00000000")).toBe(false);
+  });
+
+  test("accepts a mixed password that meets the minimum length", () => {
+    expect(getPasswordError("correct horse")).toBe("");
+    expect(isValidUnlockPassword("passcode1")).toBe(true);
+  });
+});
 
 describe("getUniqueAccountName", () => {
   test("should return the same name if account account is not present yet", () => {

--- a/src/common/utils/validations.ts
+++ b/src/common/utils/validations.ts
@@ -1,10 +1,39 @@
 import { Account, Accounts } from "~/types";
 
-export const validate = (formData: Record<string, string>) => {
-  let password = "";
-  let passwordConfirmation = "";
+export const UNLOCK_PASSWORD_MIN_LENGTH = 8;
 
-  if (!formData.password) password = "enter_password";
+export type PasswordError =
+  | ""
+  | "enter_password"
+  | "password_too_short"
+  | "password_numeric_only";
+
+export type PasswordConfirmationError =
+  | ""
+  | "confirm_password"
+  | "mismatched_password";
+
+export function getPasswordError(
+  password: string,
+  minLength = UNLOCK_PASSWORD_MIN_LENGTH
+): PasswordError {
+  if (!password) return "enter_password";
+  if (password.length < minLength) return "password_too_short";
+  if (/^\d+$/.test(password)) return "password_numeric_only";
+  return "";
+}
+
+export function isValidUnlockPassword(
+  password: string,
+  minLength = UNLOCK_PASSWORD_MIN_LENGTH
+): boolean {
+  return getPasswordError(password, minLength) === "";
+}
+
+export const validate = (formData: Record<string, string>) => {
+  const password = getPasswordError(formData.password);
+  let passwordConfirmation: PasswordConfirmationError = "";
+
   if (!formData.passwordConfirmation) {
     passwordConfirmation = "confirm_password";
   } else if (formData.password !== formData.passwordConfirmation) {

--- a/src/extension/background-script/actions/accounts/__tests__/unlock.test.ts
+++ b/src/extension/background-script/actions/accounts/__tests__/unlock.test.ts
@@ -28,12 +28,12 @@ const mockState = {
   saveToStorage: jest.fn().mockResolvedValue(undefined),
 };
 
-describe("edit account", () => {
+describe("unlock account", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test("edit existing account", async () => {
+  test("unlocks and upgrades a legacy-encrypted config", async () => {
     const message: MessageAccountUnlock = {
       application: "LBE",
       args: { password: 1 },

--- a/src/extension/background-script/actions/accounts/__tests__/unlock.test.ts
+++ b/src/extension/background-script/actions/accounts/__tests__/unlock.test.ts
@@ -7,17 +7,25 @@ jest.mock("~/extension/background-script/state");
 
 const passwordMock = jest.fn;
 
+// a genuine legacy (crypto-js passphrase) blob that decrypts with password "1"
+const LEGACY_CONFIG =
+  "U2FsdGVkX19YMFK/8YpN5XQbMsmbVmlOJgpZCIRlt25K6ur4EPp4XdRUQC7+ep/m1k8d2yy69QfuGpsgn2SZOv4DQaPsdYTTwjj0mibQG/dkJ9OCp88zXuMpconrmRu5w4uZWEvdg7p5GQfIYJCvTPLUq+1zH3iH0xX7GhlrlQ8=";
+
+const account = {
+  config: LEGACY_CONFIG,
+  connector: "lndhub",
+  id: "1e1e8ea6-493e-480b-9855-303d37506e97",
+  name: "Alby",
+};
+
 const mockState = {
   password: passwordMock,
   currentAccountId: "1e1e8ea6-493e-480b-9855-303d37506e97",
-  getAccount: () => ({
-    config:
-      "U2FsdGVkX19YMFK/8YpN5XQbMsmbVmlOJgpZCIRlt25K6ur4EPp4XdRUQC7+ep/m1k8d2yy69QfuGpsgn2SZOv4DQaPsdYTTwjj0mibQG/dkJ9OCp88zXuMpconrmRu5w4uZWEvdg7p5GQfIYJCvTPLUq+1zH3iH0xX7GhlrlQ8=",
-    connector: "lndhub",
-    id: "1e1e8ea6-493e-480b-9855-303d37506e97",
-    name: "Alby",
-  }),
+  accounts: { "1e1e8ea6-493e-480b-9855-303d37506e97": account },
+  getAccount: () => account,
   getConnector: jest.fn(),
+  setState: jest.fn(),
+  saveToStorage: jest.fn().mockResolvedValue(undefined),
 };
 
 describe("edit account", () => {
@@ -47,5 +55,16 @@ describe("edit account", () => {
     expect(spy).toHaveBeenNthCalledWith(1, "1");
 
     expect(spy).toHaveBeenCalledTimes(1);
+
+    // the legacy-format config is re-encrypted to the current format on unlock
+    expect(mockState.saveToStorage).toHaveBeenCalled();
+    const savedAccounts = (state.setState as jest.Mock).mock.calls
+      .map((c) => c[0])
+      .find((a) => a && a.accounts)?.accounts;
+    const savedConfig =
+      savedAccounts?.["1e1e8ea6-493e-480b-9855-303d37506e97"]?.config;
+    expect(savedConfig).toBeDefined();
+    expect(savedConfig).not.toEqual(LEGACY_CONFIG);
+    expect(JSON.parse(savedConfig).v).toBe(2);
   });
 });

--- a/src/extension/background-script/actions/accounts/unlock.ts
+++ b/src/extension/background-script/actions/accounts/unlock.ts
@@ -1,4 +1,5 @@
 import { decryptData } from "~/common/lib/crypto";
+import { upgradeAccountEncryption } from "~/extension/background-script/actions/accounts/upgradeEncryption";
 import state from "~/extension/background-script/state";
 import i18n from "~/i18n/i18nConfig";
 import type { MessageAccountUnlock } from "~/types";
@@ -31,6 +32,14 @@ const unlock = async (message: MessageAccountUnlock) => {
 
   // if everything is fine we keep the password in memory
   await state.getState().password(password);
+
+  // Opportunistically upgrade any secrets still stored in the legacy format now
+  // that the password is available. Best-effort: never allowed to block unlock.
+  try {
+    await upgradeAccountEncryption(password);
+  } catch (e) {
+    console.error("Could not upgrade stored account encryption", e);
+  }
 
   // load the connector to make sure it is initialized for the future calls
   // with this we prevent potentially multiple action calls trying to initialize the connector in parallel

--- a/src/extension/background-script/actions/accounts/upgradeEncryption.ts
+++ b/src/extension/background-script/actions/accounts/upgradeEncryption.ts
@@ -1,0 +1,47 @@
+import { isLegacyEncrypted, reEncryptToLatest } from "~/common/lib/crypto";
+import state from "~/extension/background-script/state";
+
+/**
+ * Opportunistically re-encrypt account secrets still stored in the legacy
+ * format into the current authenticated format, using the unlock password.
+ *
+ * Runs on unlock rather than as a startup migration because the startup
+ * migration runner has no access to the password. It is intentionally
+ * best-effort: any account whose secrets cannot be re-encrypted is left exactly
+ * as-is (`reEncryptToLatest` returns the original blob on failure), so this can
+ * never lock a user out. It only writes to storage when something actually
+ * changed.
+ */
+export async function upgradeAccountEncryption(
+  password: string
+): Promise<void> {
+  const accounts = state.getState().accounts;
+  let changed = false;
+  const updated = { ...accounts };
+
+  for (const [id, account] of Object.entries(accounts)) {
+    const next = { ...account };
+    let accountChanged = false;
+
+    for (const field of ["config", "mnemonic", "nostrPrivateKey"] as const) {
+      const value = next[field];
+      if (typeof value === "string" && isLegacyEncrypted(value)) {
+        const upgraded = reEncryptToLatest(value, password);
+        if (typeof upgraded === "string" && upgraded !== value) {
+          next[field] = upgraded;
+          accountChanged = true;
+        }
+      }
+    }
+
+    if (accountChanged) {
+      updated[id] = next;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    state.setState({ accounts: updated });
+    await state.getState().saveToStorage();
+  }
+}

--- a/src/extension/background-script/actions/settings/changePassword.ts
+++ b/src/extension/background-script/actions/settings/changePassword.ts
@@ -1,4 +1,5 @@
 import { clearKeyCache, decryptData, encryptData } from "~/common/lib/crypto";
+import { isValidUnlockPassword } from "~/common/utils/validations";
 import type { Message } from "~/types";
 
 import state from "../../state";
@@ -8,6 +9,12 @@ const changePassword = async (message: Message) => {
   const password = await state.getState().password();
   if (!password) return { error: "Password is missing" };
   const newPassword = message.args.password as string;
+  if (!isValidUnlockPassword(newPassword)) {
+    return {
+      error:
+        "Password must be at least 8 characters and must not be numbers only",
+    };
+  }
   const tmpAccounts = { ...accounts };
 
   for (const accountId in tmpAccounts) {

--- a/src/extension/background-script/actions/settings/changePassword.ts
+++ b/src/extension/background-script/actions/settings/changePassword.ts
@@ -1,4 +1,4 @@
-import { decryptData, encryptData } from "~/common/lib/crypto";
+import { clearKeyCache, decryptData, encryptData } from "~/common/lib/crypto";
 import type { Message } from "~/types";
 
 import state from "../../state";
@@ -43,6 +43,9 @@ const changePassword = async (message: Message) => {
   }
   await state.getState().password(newPassword);
   state.setState({ accounts: tmpAccounts });
+  // drop keys derived from the previous password: changing a password is often
+  // exactly when the old one should stop being usable
+  clearKeyCache();
   // make sure we immediately persist the updated accounts
   await state.getState().saveToStorage();
 

--- a/src/extension/background-script/actions/setup/setPassword.ts
+++ b/src/extension/background-script/actions/setup/setPassword.ts
@@ -1,3 +1,4 @@
+import { isValidUnlockPassword } from "~/common/utils/validations";
 import state from "~/extension/background-script/state";
 import { MessageSetPassword } from "~/types";
 
@@ -6,6 +7,12 @@ const setPassword = async (message: MessageSetPassword) => {
   // We might want to validate that no account was already configured with a different password
 
   const password = message.args.password;
+  if (!isValidUnlockPassword(password)) {
+    return {
+      error:
+        "Password must be at least 8 characters and must not be numbers only",
+    };
+  }
   await state.getState().password(password);
   return Promise.resolve({ data: { unlocked: true } });
 };

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -2,7 +2,7 @@ import merge from "lodash.merge";
 import pick from "lodash.pick";
 import browser from "webextension-polyfill";
 import { create } from "zustand";
-import { decryptData } from "~/common/lib/crypto";
+import { clearKeyCache, decryptData } from "~/common/lib/crypto";
 import { DEFAULT_SETTINGS } from "~/common/settings";
 import { isManifestV3 } from "~/common/utils/mv3";
 import Bitcoin from "~/extension/background-script/bitcoin";
@@ -203,6 +203,8 @@ const state = create<State>((set, get) => ({
     return bitcoin;
   },
   lock: async () => {
+    // drop derived keys so they do not outlive the unlocked session
+    clearKeyCache();
     if (isManifestV3) {
       // @ts-ignore: https://github.com/mozilla/webextension-polyfill/issues/329
       await browser.storage.session.set({ password: null });
@@ -262,6 +264,7 @@ const state = create<State>((set, get) => ({
       });
   },
   reset: async () => {
+    clearKeyCache();
     try {
       // @ts-ignore: https://github.com/mozilla/webextension-polyfill/issues/329
       await browser.storage.session.clear();

--- a/src/extension/background-script/state.ts
+++ b/src/extension/background-script/state.ts
@@ -237,6 +237,8 @@ const state = create<State>((set, get) => ({
       mnemonic: null,
       bitcoin: null,
     });
+    // in-flight decrypts can refill the cache after the opening clear
+    clearKeyCache();
   },
   isUnlocked: async () => {
     const password = await await get().password();
@@ -278,6 +280,8 @@ const state = create<State>((set, get) => ({
     }
     set({ ...getFreshState() });
     await get().saveToStorage();
+    // in-flight decrypts can refill the cache after the opening clear
+    clearKeyCache();
   },
   saveToStorage: () => {
     const current = get();

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -14,7 +14,9 @@
         "errors": {
           "enter_password": "Please enter a passcode.",
           "confirm_password": "Please confirm your passcode.",
-          "mismatched_password": "Passcodes don't match."
+          "mismatched_password": "Passcodes don't match.",
+          "password_too_short": "Passcode must be at least {{min}} characters.",
+          "password_numeric_only": "Passcode cannot be numbers only."
         }
       },
       "test_connection": {
@@ -672,7 +674,9 @@
         "errors": {
           "enter_password": "Please enter a new unlock passcode.",
           "confirm_password": "Please confirm your passcode.",
-          "mismatched_password": "Passcodes don't match."
+          "mismatched_password": "Passcodes don't match.",
+          "password_too_short": "Passcode must be at least {{min}} characters.",
+          "password_numeric_only": "Passcode cannot be numbers only."
         },
         "success": "Passcode changed successfully"
       }


### PR DESCRIPTION
Fixes #3612 

## Describe the changes you have made in this PR

Account secrets — connector configs (macaroons, NWC URIs, LNDHub credentials), the mnemonic, and the nostr private key — are encrypted at rest before being written to `browser.storage.sync`. This moves that encryption from crypto-js's passphrase mode to a modern, authenticated format with a strong key-derivation function:

- **`src/common/lib/crypto.ts`** now writes a versioned envelope: **PBKDF2-SHA256 (600,000 iterations)** for key derivation and **AES-256-GCM** for encryption. Both primitives come from `@noble/*`, already in the dependency tree (used by nip44). The functions keep their **synchronous** signatures, so the ~25 call sites (connectors and actions) are unchanged.
- **GCM authenticates the ciphertext**: a modified blob now fails to decrypt instead of silently yielding altered plaintext.
- **Backwards read compatibility**: `decryptData` detects the format and still reads the previous crypto-js blobs, so data written by older versions — including blobs that sync down from another device that hasn't updated yet — keeps working. New writes are always the new format.
- **On unlock**, any secrets still in the old format are re-encrypted to the new one (`actions/accounts/upgradeEncryption.ts`). It is best-effort and wrapped so it can never block unlock: any blob it can't re-encrypt is left byte-for-byte unchanged.
- Derived keys are **memoised per (password, salt, iterations)** (bounded cache, cleared on lock/reset/password-change) so decrypting the same stored blob repeatedly within a session only pays the ~0.45s derivation once.

---

## ⛔ Read this before merging: a rollback after release causes permanent user lockout

**The new format is write-once-forward.** A v2 blob **cannot be read by any build ≤ 3.14.5** — those builds have no v2 reader at all, and their crypto-js path throws on it (verified).

That creates an asymmetry that is easy to miss:

- Old blob read by a new build → **fine** (this PR reads both formats).
- **New blob read by an old build → permanent lockout for that user.** The account data is intact, but that build cannot decrypt it and will report "invalid password".

**Why this is a live risk, not a hypothetical:** releases get rolled back for reasons that have nothing to do with this change — an unrelated regression shipped in the same version. If a release containing v2 *writing* goes out and is then rolled back, **every user who unlocked even once in the meantime has had their secrets rewritten to v2 and is locked out of the rolled-back build.** There is no recovery path from the rolled-back build; the user must go forward to a v2-capable version again.

The same asymmetry applies across devices: once any device writes v2, the `accounts` key syncs, and a device still on ≤ 3.14.5 cannot unlock until it updates.

## Release sequencing — a maintainer decision, not made here

This PR currently **reads and writes v2 in the same release**. That is one of two options, and the choice is yours:

**Option A — reader-first (two releases).** Split this PR: ship only the v2 *reader* (plus legacy read/write) first, let it propagate, then enable v2 *writing* and the on-unlock upgrade in a later release.
- *Cost:* the weak format keeps being written until the second release, so remediation is delayed by roughly one release cycle. Requires splitting this PR and tracking the follow-up.
- *Benefit:* a rollback of either release is safe. No user can be locked out.

**Option B — ship as-is (one release).** Remediation lands immediately for everyone on the new version.
- *Cost:* accepts the rollback risk above for the window between this release and the point where a rollback is no longer plausible.
- *Benefit:* the weak format stops being written on day one.

**My recommendation is Option A**, on the grounds that the failure mode is permanent loss of wallet access for real users, triggered by an unrelated regression — while the cost is a delay of roughly one release cycle for a storage hardening improvement whose benefit only applies to someone who already holds a copy of the user's profile or sync data. But this is a release-management call with context I don't have — the extension's rollback history and staged-rollout policy should decide it, and I've deliberately not made that decision in code.

---

## Behaviour / performance notes

- **Change-password** re-encrypts every account's three secret fields; each encryption now runs a 600k-iteration KDF (~0.45s each). For a handful of accounts this is a few seconds — worth a spinner if there isn't one.
- **MV3 cold start**: the key cache lives in the service worker, so the first decrypt after a worker restart pays one ~0.45s PBKDF2 (previously ~1ms). This is the cost of a strong KDF on a synchronous surface; a native `crypto.subtle` path would be faster but is async and would touch all ~25 call sites. Happy to pursue that separately.
- The Alby connector re-encrypts its config on token refresh; that now costs one KDF derivation, in the background.
- No new dependency is added; crypto-js remains only for reading legacy blobs.

## Migration placement

Re-encryption runs on **unlock** rather than as a startup migration in `migrations/index.ts`, because the startup migration runner executes before the password is available.

## Hardening included

- Salt/nonce/ciphertext are base64, not hex, to stay within the `storage.sync` per-item quota for accounts holding several secrets.
- The stored iteration count is validated (integer within a bounded range) before key derivation, so a corrupted or out-of-range envelope is rejected as invalid rather than sending PBKDF2 into a long synchronous stall the unlock error path can't catch. Raising the default past that bound is a breaking format change and is commented as such.
- The derived-key cache is cleared on `lock()`, `reset()` and `changePassword`, so keys don't outlive the unlocked session or a replaced password. Encryption keys (fresh salt per write, single-use) are never cached.

## Tests

- `src/common/lib/__tests__/crypto.test.ts` — v2 round-trip, versioned-envelope shape, fresh salt/nonce per call, wrong-password rejection, **tamper rejection (AEAD tag)**, rejection of out-of-range iteration counts, cache clearing, legacy-blob read, and all `reEncryptToLatest` paths (upgrade, no-op on v2, safe pass-through on wrong password / null).
- `actions/accounts/__tests__/unlock.test.ts` — extended to assert a legacy-format config is re-encrypted to the new format on unlock.

`yarn tsc:compile` and `yarn lint:js` pass clean; `yarn test:unit` passes 76 suites / 181 tests (2 pre-existing skips). `prettier --check src` reports one pre-existing failure in `src/app/styles/index.css`, which is untouched by this PR and also fails on `master`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly protected data now uses stronger authenticated encryption.
  - Existing encrypted data remains readable and is automatically upgraded after unlock.
  - Added protection against tampering, incorrect passwords, and invalid encryption parameters.

- **Security**
  - Cached encryption keys are cleared when locking, resetting, or changing the password.

- **Bug Fixes**
  - Encryption upgrade failures no longer block unlocking.
  - Password setup and changes reject passwords shorter than eight characters or containing only numbers.
  - Password changes now require matching confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->