### PR TITLE
fix(i18n): use informal address in German onboarding strings

### DIFF
--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -867,13 +867,13 @@
       "alby": {
         "title": "Alby-Konto",
         "description": "Ideal, wenn du die Anwendungen nutzen und gleichzeitig die Kontrolle über deine Bitcoin behalten möchtest.",
-        "connect": "Schließe es an",
+        "connect": "Verbinden",
         "prompt": "Hast du schon ein Alby-Konto?"
       },
       "title": "Alby Extension mit einer Wallet verbinden",
       "other": {
         "title": "Hast du schon eine Wallet?",
-        "description": "Verbinden Sie Ihren Alby Hub oder eine beliebige andere Lightning-Wallet.",
+        "description": "Verbinde deinen Alby Hub oder eine beliebige andere Lightning-Wallet.",
         "connect": "Verbinden"
       },
       "albyhub": {


### PR DESCRIPTION
## Summary

Follow-up to the Weblate sync #3579. Two of the new German onboarding strings under `welcome.choose_path` broke with the informal "du" address used everywhere else in the German catalog (also flagged by CodeRabbit on #3579):

- `alby.connect`: "Schließe es an" → "Verbinden" ("Schließe es an" reads like plugging in a device)
- `other.description`: "Verbinden Sie Ihren Alby Hub …" → "Verbinde deinen Alby Hub …"

Fixed here on master rather than on the Weblate fork branch so Weblate picks the change up on its next sync instead of rebasing over it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- JSON parses, prettier clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated German wording for the Alby account connection button.
  * Revised the German description for connecting an Alby Hub wallet to use informal language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->