### PR TITLE
chore: bump package.json version to 3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-browser-extension",
-  "version": "3.14.5",
+  "version": "3.15.0",
   "description": "Lightning browser extension",
   "private": true,
   "repository": "https://github.com/bumi/lightning-browser-extension.git",


### PR DESCRIPTION
## Describe the changes you have made in this PR

Bumps the version to 3.15.0 for the next release. Minor bump because `webln.request` was removed (#3610) and several security fixes change behaviour (#3597, #3592, #3611, #3613, #3615).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 3.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->