### PR TITLE
chore: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -8,9 +8,9 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
       - run: npm install axios
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "yarn"
@@ -35,13 +35,13 @@ jobs:
         run: yarn build:chrome
 
       - name: Archive firefox production zip file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: firefox.xpi
           path: dist/production/firefox.xpi
 
       - name: Archive chrome production zip file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: chrome.zip
           path: dist/production/chrome.zip

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "yarn"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,9 +12,9 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v5
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
         with:
@@ -33,7 +33,7 @@ jobs:
           args: npx playwright test
 
       - name: Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-artifcats

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2 # Fetch the base commit as well
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v5
 
       - name: Check source translation file for changes
         run: |

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "yarn"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "yarn"


### PR DESCRIPTION
Fixes the runner warning:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable.

All workflows were pinned to action majors that run on Node 20 (or older). Bumped to the current majors, which run on Node 24:

- `actions/checkout` v3 → v5
- `actions/setup-node` v2/v3 → v5
- `actions/upload-artifact` v4 → v5
- `actions/github-script` v6 → v8

No workflow inputs changed; these majors are drop-in for the options used here.