### PR TITLE
chore: update wext-manifest-webpack-plugin to fix webpack deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,6 @@
     "webpack-dev-server": "^5.2.6",
     "webpack-sources": "^3.2.3",
     "wext-manifest-loader": "^3.0.0",
-    "wext-manifest-webpack-plugin": "^1.2.1"
+    "wext-manifest-webpack-plugin": "^1.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,11 +4931,6 @@ emittery@^0.13.1:
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
-emoji-log@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/emoji-log/-/emoji-log-1.0.2.tgz"
-  integrity sha512-3r9WI8xWU3gaeuPSrHEO9cbTybzlud82v98qeJlwyeGhUhKMleKdvDLegn/CPd1UZiFfTgl5VmJ9OW7I0y7CVA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -11728,12 +11723,10 @@ wext-manifest-loader@^3.0.0:
     loader-utils "^3.2.0"
     schema-utils "^4.0.0"
 
-wext-manifest-webpack-plugin@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/wext-manifest-webpack-plugin/-/wext-manifest-webpack-plugin-1.2.1.tgz"
-  integrity sha512-NvyNpyhCxMa5aHzJyWcH2RBKIBEoZkb+CFvIk2Pg4QPSvTIUXpPXsiYrtUf5ghJh/DUorPoijwzNFi6agSl4bg==
-  dependencies:
-    emoji-log "^1.0.2"
+wext-manifest-webpack-plugin@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/wext-manifest-webpack-plugin/-/wext-manifest-webpack-plugin-1.4.1.tgz#86ebd6cfc0d6e5bfeb5d4600a9b6efda29f0eb8f"
+  integrity sha512-vmoM7qzQiQKGr+wJ9Jkc9lsN3QOoXyP2W/GbMmT/d7nbD7NVnxGcn8UgMdCB8edJkucn4XSV6RS9mi9w1LqTdA==
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Bumps `wext-manifest-webpack-plugin` from 1.2.1 to 1.4.1.

Every webpack build currently prints:

```
[DEP_WEBPACK_CHUNK_HAS_ENTRY_MODULE] DeprecationWarning: Chunk.hasEntryModule: Use new ChunkGraph API
[DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
[DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
```

All three come from `wext-manifest-webpack-plugin@1.2.1`, which still calls `chunk.hasEntryModule()`, `chunk.entryModule`, and `chunk.files.filter(...)`. Version 1.4.1 uses `compilation.chunkGraph` and `chunk.files.delete(...)` instead, and also drops its `emoji-log` dependency.

## Verification

- `yarn build:chrome` and `yarn build:firefox` compile with no deprecation warnings.
- The plugin still removes the `js/manifest.bundle.js` chunk and `manifest.json` is emitted as before.

https://claude.ai/code/session_014jXYiakjcKGtWiqq8xVwq5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling used during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->